### PR TITLE
fix(settings): apply settings keys without a dedicated event

### DIFF
--- a/src/domains/project-management/services/project-management-orchestrator.ts
+++ b/src/domains/project-management/services/project-management-orchestrator.ts
@@ -285,9 +285,17 @@ export class ProjectManagementOrchestrator {
   updateUserSettings(settings: Partial<UserSettingsContextType>) {
     logger.info("[Project Management Orchestrator] Updating user settings")
 
+    // Ключи без специального события собираем и применяем одним UPDATE_ALL,
+    // чтобы они не терялись (например, themeMode/colorScheme и др.)
+    const bulkSettings: Record<string, unknown> = {}
+
     // Отправляем события для каждой настройки
     Object.entries(settings).forEach(([key, value]) => {
       const eventType = this.getSettingsEventType(key)
+      if (!eventType) {
+        bulkSettings[key] = value
+        return
+      }
       if (eventType) {
         // TOGGLE события не принимают параметров - они просто инвертируют значение
         if (eventType.startsWith("TOGGLE_")) {
@@ -345,6 +353,14 @@ export class ProjectManagementOrchestrator {
         }
       }
     })
+
+    // Применяем настройки без выделенного события одним массовым обновлением
+    if (Object.keys(bulkSettings).length > 0) {
+      this.userSettingsActor.send({
+        type: "UPDATE_ALL",
+        settings: bulkSettings,
+      } as any)
+    }
   }
 
   /**


### PR DESCRIPTION
updateUserSettings dropped any key not present in getSettingsEventType (e.g. colorScheme, themeMode), so color schemes never switched. Route such keys through a single UPDATE_ALL so they merge into machine state and persist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user settings handling to ensure all configuration changes are properly persisted instead of being silently discarded.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chatman-media/timeline-studio/pull/88?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->