### PR TITLE
fix(browser): fix browser preview mode bugs and improve mock coverage

### DIFF
--- a/src/adapters/mock/backend.ts
+++ b/src/adapters/mock/backend.ts
@@ -28,8 +28,29 @@ export class MockBackendService implements IBackendService {
     this._connected = false
   }
 
-  async executeCommand(_command: ProjectCommand): Promise<CommandResult> {
-    // Simulate command execution - command parameter available for override in tests
+  async executeCommand(command: ProjectCommand): Promise<CommandResult> {
+    if (command.type === "OpenProject") {
+      const path = command.params.path
+      const mockFiles = typeof window !== "undefined"
+        ? ((window as any).__TAURI_MOCK_FILES__ as Record<string, File> | undefined)
+        : undefined
+      const fileName = path.split("/").pop() ?? path
+      const file = mockFiles?.[path] ?? mockFiles?.[fileName]
+      if (file) {
+        try {
+          const text = await file.text()
+          const data = JSON.parse(text) as ProjectState
+          this.setState(data)
+          this.emitEvent({
+            type: "ProjectOpened",
+            payload: { project_id: data.project?.id ?? crypto.randomUUID(), path },
+          })
+          return { success: true, data, error: null }
+        } catch {
+          // Файл не является валидным ProjectState — игнорируем
+        }
+      }
+    }
     return {
       success: true,
       data: null,

--- a/src/domains/project-management/machines/user-settings-machine.ts
+++ b/src/domains/project-management/machines/user-settings-machine.ts
@@ -271,6 +271,11 @@ interface UpdateLayoutModeEvent {
   layoutMode: LayoutMode // Новый макет интерфейса
 }
 
+interface UpdateThemeModeEvent {
+  type: "UPDATE_THEME_MODE"
+  themeMode: string
+}
+
 /**
  * Интерфейс события обновления пути для скриншотов
  * @interface UpdateScreenshotsPathEvent
@@ -614,6 +619,8 @@ export type UserSettingsEvent =
   | UpdatePreferredLanguageEvent
   | UpdateDateFormatEvent
   | UpdateTimeFormatEvent
+  // Тема
+  | UpdateThemeModeEvent
 
 /**
  * Машина состояний для управления пользовательскими настройками
@@ -672,6 +679,10 @@ export const userSettingsMachine = createMachine(
           // Обновление макета интерфейса (альтернативное имя события, используется orchestrator)
           UPDATE_LAYOUT_MODE: {
             actions: ["updateLayout"],
+          },
+
+          UPDATE_THEME_MODE: {
+            actions: ["updateThemeMode"],
           },
 
           // Обновление пути для скриншотов
@@ -921,6 +932,14 @@ export const userSettingsMachine = createMachine(
         return {
           ...context,
           layoutMode: typedEvent.layoutMode, // Новый макет интерфейса
+        }
+      }),
+
+      updateThemeMode: assign(({ context, event }) => {
+        const typedEvent = event as UpdateThemeModeEvent
+        return {
+          ...context,
+          themeMode: typedEvent.themeMode as any,
         }
       }),
 

--- a/src/domains/project-management/services/project-management-orchestrator.ts
+++ b/src/domains/project-management/services/project-management-orchestrator.ts
@@ -352,6 +352,7 @@ export class ProjectManagementOrchestrator {
    */
   private getSettingsEventType(key: string): string | null {
     const eventMap: Record<string, string> = {
+      themeMode: "UPDATE_THEME_MODE",
       layoutMode: "UPDATE_LAYOUT_MODE",
       activeTab: "UPDATE_ACTIVE_TAB",
       openAiApiKey: "UPDATE_OPENAI_API_KEY",

--- a/src/domains/system-integration/services/updates/update-service.ts
+++ b/src/domains/system-integration/services/updates/update-service.ts
@@ -48,6 +48,9 @@ export class UpdateService {
    * Настроить слушатели событий обновления
    */
   private async setupEventListeners(): Promise<void> {
+    if (typeof window === "undefined" || !(window as any).__TAURI_INTERNALS__?.transformCallback) {
+      return
+    }
     try {
       // Слушаем события прогресса загрузки (если они будут добавлены в backend)
       await listen("update-progress", (event: any) => {

--- a/src/features/ai-director/services/analysis-notification-service.ts
+++ b/src/features/ai-director/services/analysis-notification-service.ts
@@ -30,6 +30,7 @@ class AnalysisNotificationService {
    * Проверяет разрешение на системные нотификации
    */
   private async init() {
+    if (typeof window === "undefined" || !(window as any).__TAURI_INTERNALS__) return
     try {
       this.permissionGranted = await isPermissionGranted()
 

--- a/src/features/color-scheme/components/color-scheme-provider.tsx
+++ b/src/features/color-scheme/components/color-scheme-provider.tsx
@@ -25,14 +25,15 @@ export function ColorSchemeProvider({ children }: { children: ReactNode }) {
     applyColorScheme(activeScheme)
   }, [activeScheme])
 
-  // После загрузки настроек из стора — приводим next-themes к settings.themeMode.
-  // Проверка равенства внутри гарантирует отсутствие цикла при изменении theme.
+  // После загрузки/изменения themeMode из стора — приводим next-themes к нему.
+  // Намеренно не включаем `theme` в deps — нас интересует только изменение
+  // themeMode в сторе (начальная загрузка, изменение из настроек).
+  // Включение `theme` создаёт петлю: toggle → setTheme → effect → setTheme.
   useEffect(() => {
-    if (!isLoaded) return
-    if (themeMode && theme !== themeMode) {
-      setTheme(themeMode)
-    }
-  }, [isLoaded, themeMode, theme, setTheme])
+    if (!isLoaded || !themeMode) return
+    setTheme(themeMode)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoaded, themeMode])
 
   return <>{children}</>
 }

--- a/src/features/fairlight-audio/components/meters/level-meter.tsx
+++ b/src/features/fairlight-audio/components/meters/level-meter.tsx
@@ -82,7 +82,11 @@ export function LevelMeter({
         cancelAnimationFrame(animationRef.current)
       }
       if (analyserRef.current && source) {
-        source.disconnect(analyserRef.current)
+        try {
+          source.disconnect(analyserRef.current)
+        } catch {
+          // Node may have already been disconnected
+        }
       }
     }
   }, [audioContext, source, channels])

--- a/src/features/fairlight-audio/services/meters/level-meter.ts
+++ b/src/features/fairlight-audio/services/meters/level-meter.ts
@@ -380,7 +380,11 @@ export class LevelMeter extends EventEmitter {
     this.stop()
 
     if (this.processor) {
-      this.processor.disconnect()
+      try {
+        this.processor.disconnect()
+      } catch {
+        // Node may not be connected
+      }
       this.processor = null
     }
 

--- a/src/features/fairlight-audio/services/midi/midi-engine.ts
+++ b/src/features/fairlight-audio/services/midi/midi-engine.ts
@@ -110,7 +110,8 @@ export class MidiEngine extends EventEmitter {
       this.isInitialized = true
       this.emit("initialized")
     } catch (error) {
-      logger.error("Failed to initialize MIDI:", { error })
+      // Expected in browser without MIDI hardware or when permission is denied
+      logger.warn("Failed to initialize MIDI (expected in browser mode):", { error })
       // Don't throw, just log the error and emit initialized
       this.emit("initialized")
     }

--- a/src/features/media-studio/components/top-bar/theme/theme-toggle.tsx
+++ b/src/features/media-studio/components/top-bar/theme/theme-toggle.tsx
@@ -1,26 +1,37 @@
 "use client"
 
 import { Moon, Sun } from "lucide-react"
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import { useTheme } from "@/config/providers"
+import { useUserSettings } from "@/domains/project-management/hooks"
 import { TOP_BAR_BUTTON_CLASS } from "../top-bar"
 
 export function ThemeToggle() {
   const [mounted, setMounted] = useState(false)
-  const { theme, setTheme } = useTheme()
+  const { resolvedTheme, setTheme } = useTheme()
+  const { updateSettings } = useUserSettings()
 
   useEffect(() => {
     setMounted(true)
   }, [])
 
+  const handleToggle = useCallback(() => {
+    if (!mounted) return
+    const newTheme = resolvedTheme === "dark" ? "light" : "dark"
+    setTheme(newTheme)
+    updateSettings({ themeMode: newTheme })
+  }, [mounted, resolvedTheme, setTheme, updateSettings])
+
   return (
     <Button
       variant="ghost"
       size="icon"
-      onClick={() => mounted && setTheme(theme === "dark" ? "light" : "dark")}
+      onClick={handleToggle}
       className={TOP_BAR_BUTTON_CLASS}
+      title={mounted ? (resolvedTheme === "dark" ? "Светлая тема" : "Тёмная тема") : "Переключить тему"}
+      data-testid="theme-toggle-button"
       data-oid="6zco41g"
     >
       <Sun className="h-5 w-5 scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" data-oid="jqf.czz" />

--- a/src/features/project-settings/components/project-settings-modal.tsx
+++ b/src/features/project-settings/components/project-settings-modal.tsx
@@ -64,8 +64,27 @@ export function ProjectSettingsModal() {
     // Обновляем значения пользовательской ширины и высоты
     // ТОЛЬКО если пользователь НЕ редактирует поля в данный момент
     if (!isEditing) {
-      setCustomWidth(settings.aspectRatio.value.width)
-      setCustomHeight(settings.aspectRatio.value.height)
+      if (settings.aspectRatio.label === "custom") {
+        // Для custom соотношения value.width/height хранит реальные пиксели
+        setCustomWidth(settings.aspectRatio.value.width)
+        setCustomHeight(settings.aspectRatio.value.height)
+      } else if (settings.resolution && settings.resolution !== "custom") {
+        // Для стандартных соотношений берём размеры из строки разрешения (e.g. "1920x1080")
+        const parts = settings.resolution.split("x")
+        if (parts.length === 2) {
+          const w = parseInt(parts[0], 10)
+          const h = parseInt(parts[1], 10)
+          if (!isNaN(w) && !isNaN(h)) {
+            setCustomWidth(w)
+            setCustomHeight(h)
+          }
+        }
+      } else {
+        // Fallback: берём рекомендованное разрешение для данного соотношения
+        const defaultRes = getDefaultResolutionForAspectRatio(settings.aspectRatio.label)
+        setCustomWidth(defaultRes.width)
+        setCustomHeight(defaultRes.height)
+      }
     }
 
     logger.info("[ProjectSettingsDialog] Доступные разрешения обновлены:", {

--- a/src/test/providers/tauri-mock-provider.tsx
+++ b/src/test/providers/tauri-mock-provider.tsx
@@ -11,11 +11,32 @@ const isTauri = () => {
   return (window as any).__TAURI_INTERNALS__ !== undefined && (window as any).__TAURI_INTERNALS__ !== null
 }
 
+// Синхронная инициализация stub-а до того как любой сервис (UpdateService, etc.)
+// попытается вызвать listen() из @tauri-apps/api/event — она требует transformCallback.
+if (typeof window !== "undefined" && !(window as any).__TAURI_INTERNALS__) {
+  const stubCallbacks = new Map<number, (data: any) => void>()
+  ;(window as any).__TAURI_INTERNALS__ = {
+    transformCallback: (cb: any) => {
+      const id = Math.floor(Math.random() * 0xffffffff)
+      stubCallbacks.set(id, cb)
+      return id
+    },
+    unregisterCallback: (id: number) => stubCallbacks.delete(id),
+    callbacks: stubCallbacks,
+    // Временный invoke — переопределяется в useEffect после монтажа компонента
+    invoke: async (cmd: string) => {
+      logger.warn(`[TauriMock stub] Command before full init: ${cmd}`)
+      return null
+    },
+  }
+}
+
 export function TauriMockProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
-    // Only mock in browser environment when Tauri is not available
-    // This includes development server and E2E tests
-    if (typeof window !== "undefined" && !isTauri()) {
+    // Always (re-)initialize mock in browser environment.
+    // We update __TAURI_INTERNALS__ even when isTauri() is true so that
+    // hot-module reloads pick up the latest invoke handler.
+    if (typeof window !== "undefined") {
       // Mock navigator.mediaDevices API for Tauri environment
       if (!navigator.mediaDevices) {
         Object.defineProperty(navigator, "mediaDevices", {
@@ -195,6 +216,8 @@ export function TauriMockProvider({ children }: { children: React.ReactNode }) {
             case "check_hardware_acceleration_support":
               return true
             case "set_hardware_acceleration":
+              return null
+            case "restore_preview_cache":
               return null
             case "get_prerender_cache_info":
               return {
@@ -431,6 +454,40 @@ export function TauriMockProvider({ children }: { children: React.ReactNode }) {
                 cloud_project_dir: "/Users/test/Movies/Timeline Studio/CloudProjects",
                 upload_dir: "/Users/test/Movies/Timeline Studio/Upload",
               }
+            case "plugin:dialog|open": {
+              // Используем нативный File System Access API браузера.
+              // Используем .catch() вместо try/await чтобы избежать false-positive
+              // "unhandledRejection" от Next.js при SecurityError (нет user gesture).
+              const opts = (args as any)?.options || args || {}
+              if (opts.directory) {
+                if (!("showDirectoryPicker" in window)) return null
+                return (window as any)
+                  .showDirectoryPicker()
+                  .then((h: any) => h?.name ?? null)
+                  .catch(() => null)
+              }
+              if (!("showOpenFilePicker" in window)) return null
+              return (window as any)
+                .showOpenFilePicker({ multiple: opts.multiple ?? false })
+                .then(async (handles: FileSystemFileHandle[]) => {
+                  if (!handles || handles.length === 0) return null
+                  const files: File[] = await Promise.all(handles.map((h) => h.getFile()))
+                  ;(window as any).__TAURI_MOCK_FILES__ = (window as any).__TAURI_MOCK_FILES__ || {}
+                  files.forEach((f) => { ;(window as any).__TAURI_MOCK_FILES__[f.name] = f })
+                  const paths = files.map((f) => f.name)
+                  return opts.multiple !== false ? paths : paths[0] ?? null
+                })
+                .catch((e: Error) => {
+                  if (e.name === "AbortError" || e.name === "SecurityError") return null
+                  throw e
+                })
+            }
+            case "plugin:dialog|save":
+              // В браузере сохранение на диск недоступно — имитируем отмену
+              return null
+            case "plugin:path|home_dir":
+            case "plugin:path|resolve_directory":
+              return "/Users/mock"
             case "plugin:dialog|open_file":
               // Для тестов возвращаем пустой массив, если не переопределено
               return { paths: [] }
@@ -455,12 +512,40 @@ export function TauriMockProvider({ children }: { children: React.ReactNode }) {
             case "delete_api_key":
               // Возвращаем успешный результат
               return { success: true }
+            case "execute_command": {
+              // Все ProjectCommand-ы — возвращаем успех; TauriBackendAdapter использует это
+              const command = (args as any)?.command
+              if (command?.type === "CreateProject") {
+                const projectId = crypto.randomUUID()
+                return {
+                  success: true,
+                  data: { project_id: projectId, name: command.params?.name || "Untitled Project" },
+                  error: null,
+                }
+              }
+              return { success: true, data: null, error: null }
+            }
+            case "get_project_state":
+              // Возвращаем null — проект не загружен в browser режиме
+              return null
+            case "mcp_initialize":
+              return false
+            case "plugin:notification|is_permission_granted":
+              return false
+            case "plugin:notification|request_permission":
+              return "denied"
+            case "get_current_version":
+              return "3.46.1"
+            case "is_updater_available":
+              return false
+            case "check_for_update":
+              return null
             case "ai_get_supported_providers":
-              // Возвращаем список AI провайдеров (пустой в browser режиме)
-              return { status: "ok", data: [], error: null }
+              // Возвращаем [] напрямую — сгенерированный биндинг уже оборачивает в { status, data }
+              return []
             case "ai_get_provider_models":
-              // Возвращаем пустой список моделей (в browser режиме без backend)
-              return { status: "ok", data: [], error: null }
+              // Возвращаем [] напрямую — сгенерированный биндинг уже оборачивает в { status, data }
+              return []
             case "ai_send_secure_request":
               // Mock AI request response
               return {


### PR DESCRIPTION
## Summary

- **ThemeToggle**: use `resolvedTheme` + persist `themeMode` to user settings store; added `UPDATE_THEME_MODE` event to `user-settings-machine` and orchestrator mapping to break `setTheme` feedback loop in `ColorSchemeProvider`
- **LevelMeter**: wrap `disconnect()` calls in try/catch to prevent `DOMException` on cleanup
- **AnalysisNotificationService**: guard `isPermissionGranted()` behind `__TAURI_INTERNALS__` check to prevent SSR/browser errors
- **UpdateService**: skip `setupEventListeners()` when `transformCallback` is absent (browser mode)
- **ProjectSettingsModal**: read pixel dimensions from `settings.resolution` string for standard aspect ratios — `value.width/height` stores ratio coefficients (16, 9), not pixel dimensions (1920, 1080)
- **MidiEngine**: downgrade `requestMIDIAccess` failure from `error` to `warn` — `SecurityError` is expected in browser without MIDI hardware
- **TauriMockProvider**: add module-level `__TAURI_INTERNALS__` stub for synchronous pre-mount init; add mocks for `plugin:dialog|open` (File System Access API), `plugin:path`, `execute_command`, `get_project_state`, notification, updater, and `OpenProject` command; fix `ai_get_supported_providers` / `ai_get_provider_models` to return arrays directly

## Test plan

- [ ] Open browser preview at `localhost:3001`
- [ ] Toggle theme — light/dark switches and persists across reload
- [ ] Open Project Settings → Custom Size shows `1920 x 1080` (not `16 x 9`)
- [ ] Check console — no red MIDI errors, no SSR errors from notification service
- [ ] Check console — no `transformCallback` errors from UpdateService
- [ ] Audio mixer level meters mount and unmount without `DOMException`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)