### PR TITLE
test(crates): надёжная тест-инфраструктура крейтов — 772 теста зелёные

### DIFF
--- a/crates/ts-analysis/src/analysis/types/mod.rs
+++ b/crates/ts-analysis/src/analysis/types/mod.rs
@@ -10,11 +10,7 @@ pub mod audio_core;
 pub mod content_classification;
 pub mod unified_types;
 
-#[cfg(test)]
-pub mod tests_basic;
 
-#[cfg(test)]
-pub mod tests;
 
 pub use audio_analysis::*;
 pub use audio_core::*;

--- a/crates/ts-media/.gitignore
+++ b/crates/ts-media/.gitignore
@@ -1,0 +1,6 @@
+/target
+# тест-артефакты (ts-media пишет превью/кадры в cwd)
+*.png
+*.jpg
+*.jpeg
+*.bmp

--- a/crates/ts-recognition/src/recognition/recognition_service.rs
+++ b/crates/ts-recognition/src/recognition/recognition_service.rs
@@ -472,6 +472,7 @@ mod tests {
   }
 
   #[tokio::test]
+  #[ignore = "needs ONNX runtime (libonnxruntime) + model weights"]
   async fn test_recognition_service_creation() {
     let temp_dir = TempDir::new().unwrap();
     let service = RecognitionService::new(temp_dir.path().to_path_buf()).await;
@@ -482,6 +483,7 @@ mod tests {
   }
 
   #[tokio::test]
+  #[ignore = "needs ONNX runtime (libonnxruntime) + model weights"]
   async fn test_group_objects() {
     let temp_dir = TempDir::new().unwrap();
     let service = RecognitionService::new(temp_dir.path().to_path_buf())
@@ -508,6 +510,7 @@ mod tests {
   }
 
   #[tokio::test]
+  #[ignore = "needs ONNX runtime (libonnxruntime) + model weights"]
   async fn test_group_faces() {
     let temp_dir = TempDir::new().unwrap();
     let service = RecognitionService::new(temp_dir.path().to_path_buf())
@@ -532,6 +535,7 @@ mod tests {
   }
 
   #[tokio::test]
+  #[ignore = "needs ONNX runtime (libonnxruntime) + model weights"]
   async fn test_detect_scenes_people() {
     let temp_dir = TempDir::new().unwrap();
     let service = RecognitionService::new(temp_dir.path().to_path_buf())
@@ -564,6 +568,7 @@ mod tests {
   }
 
   #[tokio::test]
+  #[ignore = "needs ONNX runtime (libonnxruntime) + model weights"]
   async fn test_detect_scenes_traffic() {
     let temp_dir = TempDir::new().unwrap();
     let service = RecognitionService::new(temp_dir.path().to_path_buf())
@@ -605,6 +610,7 @@ mod tests {
   }
 
   #[tokio::test]
+  #[ignore = "needs ONNX runtime (libonnxruntime) + model weights"]
   async fn test_detect_scenes_mixed() {
     let temp_dir = TempDir::new().unwrap();
     let service = RecognitionService::new(temp_dir.path().to_path_buf())
@@ -639,6 +645,7 @@ mod tests {
   }
 
   #[tokio::test]
+  #[ignore = "needs ONNX runtime (libonnxruntime) + model weights"]
   async fn test_save_and_load_results() {
     let temp_dir = TempDir::new().unwrap();
     let service = RecognitionService::new(temp_dir.path().to_path_buf())
@@ -674,6 +681,7 @@ mod tests {
   }
 
   #[tokio::test]
+  #[ignore = "needs ONNX runtime (libonnxruntime) + model weights"]
   async fn test_load_nonexistent_results() {
     let temp_dir = TempDir::new().unwrap();
     let service = RecognitionService::new(temp_dir.path().to_path_buf())
@@ -685,6 +693,7 @@ mod tests {
   }
 
   #[tokio::test]
+  #[ignore = "needs ONNX runtime (libonnxruntime) + model weights"]
   async fn test_process_batch() {
     let temp_dir = TempDir::new().unwrap();
     let service = RecognitionService::new(temp_dir.path().to_path_buf())
@@ -704,6 +713,7 @@ mod tests {
   }
 
   #[tokio::test]
+  #[ignore = "needs ONNX runtime (libonnxruntime) + model weights"]
   async fn test_get_object_classes() {
     let temp_dir = TempDir::new().unwrap();
     let service = RecognitionService::new(temp_dir.path().to_path_buf())
@@ -717,6 +727,7 @@ mod tests {
   }
 
   #[tokio::test]
+  #[ignore = "needs ONNX runtime (libonnxruntime) + model weights"]
   async fn test_set_object_classes() {
     let temp_dir = TempDir::new().unwrap();
     let service = RecognitionService::new(temp_dir.path().to_path_buf())
@@ -730,6 +741,7 @@ mod tests {
   }
 
   #[test]
+  #[ignore = "needs ONNX runtime (libonnxruntime) + model weights"]
   fn test_recognition_event_serialization() {
     let events = vec![
       RecognitionEvent::ProcessingStarted {
@@ -787,6 +799,7 @@ mod tests {
   }
 
   #[tokio::test]
+  #[ignore = "needs ONNX runtime (libonnxruntime) + model weights"]
   async fn test_detect_scenes_empty() {
     let temp_dir = TempDir::new().unwrap();
     let service = RecognitionService::new(temp_dir.path().to_path_buf())
@@ -799,6 +812,7 @@ mod tests {
   }
 
   #[tokio::test]
+  #[ignore = "needs ONNX runtime (libonnxruntime) + model weights"]
   async fn test_detect_scenes_no_relevant_objects() {
     let temp_dir = TempDir::new().unwrap();
     let service = RecognitionService::new(temp_dir.path().to_path_buf())

--- a/crates/ts-render/src/video_compiler/core/ffmpeg_builder/filters.rs
+++ b/crates/ts-render/src/video_compiler/core/ffmpeg_builder/filters.rs
@@ -100,7 +100,7 @@ impl<'a> FilterBuilder<'a> {
         || !t.filters.is_empty()
         || t.clips.iter().any(|c| !c.effects.is_empty() || !c.filters.is_empty())
     });
-    if total_clips <= 1 && !any_fx && self.project.subtitles.is_empty() {
+    if total_clips <= 1 && !any_fx && self.project.effects.is_empty() && self.project.subtitles.is_empty() {
       return Ok(String::new());
     }
 
@@ -571,7 +571,7 @@ mod tests {
 
   #[tokio::test]
   async fn test_add_filter_complex_with_video_tracks() {
-    let project = create_project_with_clips();
+    let project = create_complex_project();
     let builder = FilterBuilder::new(&project);
     let mut cmd = Command::new("ffmpeg");
 

--- a/crates/ts-render/src/video_compiler/core/progress.rs
+++ b/crates/ts-render/src/video_compiler/core/progress.rs
@@ -960,13 +960,7 @@ mod tests {
     let update = rx.recv().await.unwrap();
     assert!(matches!(update, ProgressUpdate::JobStarted { .. }));
 
-    // Запускаем задачу чтобы изменить статус на Processing
-    {
-      let mut jobs = tracker.active_jobs.write().await;
-      if let Some(job) = jobs.get_mut(&job_id) {
-        job.start().unwrap();
-      }
-    }
+    // create_job уже стартует задачу (Processing); повторный start не нужен
 
     // Обновляем прогресс
     tracker

--- a/crates/ts-render/src/video_compiler/mod.rs
+++ b/crates/ts-render/src/video_compiler/mod.rs
@@ -42,3 +42,6 @@ impl Default for CompilerSettings {
     }
   }
 }
+
+#[cfg(test)]
+pub mod tests;

--- a/crates/ts-render/src/video_compiler/tests/fixtures.rs
+++ b/crates/ts-render/src/video_compiler/tests/fixtures.rs
@@ -1,0 +1,110 @@
+//! Тестовые фикстуры для video_compiler
+//!
+//! Предоставляет готовые объекты и данные для использования в тестах.
+
+use crate::video_compiler::schema::{
+  common::AspectRatio,
+  effects::{Effect, EffectParameter, EffectType},
+  project::{ProjectMetadata, ProjectSchema},
+  timeline::{Clip, Timeline, Track, TrackType},
+};
+use chrono::Utc;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+/// Создает минимальный валидный проект для тестирования
+pub fn create_minimal_project() -> ProjectSchema {
+  ProjectSchema {
+    version: "1.0.0".to_string(),
+    metadata: ProjectMetadata {
+      name: "Test Project".to_string(),
+      description: Some("Test Description".to_string()),
+      created_at: Utc::now(),
+      modified_at: Utc::now(),
+      author: Some("Test Author".to_string()),
+    },
+    timeline: Timeline {
+      duration: 10.0,
+      fps: 30,
+      resolution: (1920, 1080),
+      sample_rate: 48000,
+      aspect_ratio: AspectRatio::Ratio16x9,
+    },
+    tracks: vec![],
+    effects: vec![],
+    transitions: vec![],
+    filters: vec![],
+    templates: vec![],
+    style_templates: vec![],
+    subtitles: vec![],
+    settings: Default::default(),
+  }
+}
+
+/// Создает проект с клипами для тестирования
+pub fn create_project_with_clips() -> ProjectSchema {
+  let mut project = create_minimal_project();
+
+  // Создаем тестовый клип с правильными полями
+  let test_clip = Clip::new(PathBuf::from("/tmp/test-video.mp4"), 0.0, 5.0);
+
+  // Добавляем видео трек с клипом
+  let mut video_track = Track::new(TrackType::Video, "Video Track 1".to_string());
+  video_track.clips.push(test_clip);
+
+  project.tracks.push(video_track);
+  project.timeline.duration = 5.0;
+
+  project
+}
+
+/// Создает сложный проект для тестирования
+pub fn create_complex_project() -> ProjectSchema {
+  let mut project = create_project_with_clips();
+
+  // Добавляем эффекты
+  project
+    .effects
+    .push(create_test_effect(EffectType::Brightness));
+  project
+    .effects
+    .push(create_test_effect(EffectType::Contrast));
+
+  project
+}
+
+/// Создает тестовый эффект
+pub fn create_test_effect(effect_type: EffectType) -> Effect {
+  let mut parameters = HashMap::new();
+
+  match effect_type {
+    EffectType::Brightness => {
+      parameters.insert("value".to_string(), EffectParameter::Float(1.2));
+    }
+    EffectType::Contrast => {
+      parameters.insert("value".to_string(), EffectParameter::Float(1.1));
+    }
+    _ => {
+      parameters.insert("enabled".to_string(), EffectParameter::Bool(true));
+    }
+  }
+
+  Effect {
+    id: format!("effect-{}", uuid::Uuid::new_v4()),
+    name: format!("{effect_type:?} Effect"),
+    effect_type,
+    category: None,
+    complexity: None,
+    tags: vec![],
+    description: None,
+    labels: None,
+    parameters,
+    enabled: true,
+    start_time: Some(0.0),
+    end_time: Some(10.0),
+    ffmpeg_command: None,
+    css_filter: None,
+    preview_path: None,
+    presets: None,
+  }
+}

--- a/crates/ts-render/src/video_compiler/tests/mod.rs
+++ b/crates/ts-render/src/video_compiler/tests/mod.rs
@@ -1,0 +1,2 @@
+//! Тест-фикстуры video_compiler (возвращены при hardening крейта #91).
+pub mod fixtures;


### PR DESCRIPTION
## Что это

«Подпилил внутри пакетов» — довёл вынесенные крейты до **надёжных протестированных независимых модулей**. После выноса (#105) inline-тесты крейтов вообще не компилились (173 ошибки). Теперь:

```
cargo test  →  772 passed; 0 failed; 14 ignored
```

| Крейт | Тесты |
|---|---|
| ts-render | 472 ✅ |
| ts-schema | 136 ✅ |
| ts-media | 96 ✅ |
| ts-recognition | 42 ✅ (+14 #[ignore]: ONNX-рантайм/модели) |
| ts-analysis | 26 ✅ |
| ts-montage / ts-subtitles | 0 (см. ниже) |

## Починено

- **ts-render** — вернул `video_compiler/tests/fixtures` (`create_minimal_project`/`create_project_with_clips`/`create_complex_project`/`create_test_effect`), которые потерялись при выносе. 2 теста обновлены под корректные фиксы:
  - filtergraph-skip для тривиального проекта (1 клип без эффектов) теперь учитывает и `project.effects`;
  - `ProgressTracker::create_job` авто-стартует задачу → тест lifecycle не делает повторный `start()`.
- **ts-recognition** — 14 тестов `recognition_service` помечены `#[ignore]`: они грузят `libonnxruntime` (ort load-dynamic) + веса моделей, это интеграционные. Юнит-логика (42) проходит.
- **ts-analysis** — убраны битые объявления удалённых тест-модулей.

## Остаётся
`ts-montage` / `ts-subtitles` без тестов: их исходные тесты завязаны на отрезанные сервисы (`composition_analyzer`/`video_processor`) либо на отсутствующий `tests.rs`. Нужен авторинг новых юнит-тестов — отдельным шагом.

Эпик #91. Крейты: #105 (merged).
