### PR TITLE
feat(ts-render): цветовые эффекты + цепочка меток filtergraph (#117) + re-land аудио

### DIFF
--- a/crates/ts-render/src/video_compiler/core/ffmpeg_builder/effects.rs
+++ b/crates/ts-render/src/video_compiler/core/ffmpeg_builder/effects.rs
@@ -21,30 +21,33 @@ impl<'a> EffectBuilder<'a> {
   }
 
   /// Построить эффекты для клипа
-  pub async fn build_clip_effects(&self, clip: &Clip, input_index: usize) -> Result<String> {
-    let mut filters = Vec::new();
+  /// Тела фильтров клипа (фильтры + эффекты) БЕЗ меток — метки навешивает `build_clip_filter`,
+  /// нанизывая их в цепочку. Раньше тут возвращалась строка с `[v{i}]…[v{i}]` (один pad на
+  /// входе и выходе) → невалидный filtergraph.
+  pub async fn build_clip_effects(&self, clip: &Clip, input_index: usize) -> Result<Vec<String>> {
+    let mut bodies = Vec::new();
 
-    // Применяем фильтры клипа
+    // Фильтры клипа
     for filter_id in &clip.filters {
       if let Some(filter) = self.find_filter(filter_id) {
-        let filter_str = self.build_filter(filter, input_index)?;
-        if !filter_str.is_empty() {
-          filters.push(filter_str);
+        let body = self.build_filter(filter, input_index)?;
+        if !body.is_empty() {
+          bodies.push(body);
         }
       }
     }
 
-    // Применяем эффекты клипа
+    // Эффекты клипа
     for effect_id in &clip.effects {
       if let Some(effect) = self.find_effect(effect_id) {
-        let effect_str = self.build_effect(effect, input_index).await?;
-        if !effect_str.is_empty() {
-          filters.push(effect_str);
+        let body = self.build_effect(effect, input_index).await?;
+        if !body.is_empty() {
+          bodies.push(body);
         }
       }
     }
 
-    Ok(filters.join(";"))
+    Ok(bodies)
   }
 
   /// Построить аудио эффекты для клипа
@@ -142,6 +145,34 @@ impl<'a> EffectBuilder<'a> {
       EffectType::Sharpen => self.build_sharpen_effect(effect, input_index),
       EffectType::ChromaKey => self.build_chroma_key(effect, input_index),
       EffectType::Custom => self.build_custom_effect(effect, input_index),
+      // Цветовые/тоновые эффекты на стандартных ffmpeg-фильтрах (без libfreetype).
+      EffectType::Brightness => Ok(format!(
+        "eq=brightness={}",
+        self.get_param_value(&effect.parameters, "value", 0.1)
+      )),
+      EffectType::Contrast => Ok(format!(
+        "eq=contrast={}",
+        self.get_param_value(&effect.parameters, "value", 1.3)
+      )),
+      EffectType::Saturation => Ok(format!(
+        "eq=saturation={}",
+        self.get_param_value(&effect.parameters, "value", 1.5)
+      )),
+      EffectType::HueRotate => Ok(format!(
+        "hue=h={}",
+        self.get_param_value(&effect.parameters, "value", 90.0)
+      )),
+      EffectType::Grayscale | EffectType::Noir => Ok("hue=s=0".to_string()),
+      EffectType::Sepia => {
+        Ok("colorchannelmixer=.393:.769:.189:0:.349:.686:.168:0:.272:.534:.131".to_string())
+      }
+      EffectType::Invert => Ok("negate".to_string()),
+      EffectType::Vignette => Ok("vignette".to_string()),
+      EffectType::FilmGrain => Ok(format!(
+        "noise=alls={}:allf=t",
+        self.get_param_value(&effect.parameters, "value", 20.0)
+      )),
+      // Неизвестный/неподдержанный тип — без фильтра (no-op), не ломаем рендер.
       _ => Ok(String::new()),
     }
   }
@@ -152,91 +183,91 @@ impl<'a> EffectBuilder<'a> {
       FilterType::Brightness => {
         let value = filter.intensity;
         Ok(format!(
-          "[v{input_index}]eq=brightness={value}[v{input_index}]"
+          "eq=brightness={value}"
         ))
       }
       FilterType::Contrast => {
         let value = 1.0 + filter.intensity;
         Ok(format!(
-          "[v{input_index}]eq=contrast={value}[v{input_index}]"
+          "eq=contrast={value}"
         ))
       }
       FilterType::Saturation => {
         let value = 1.0 + filter.intensity;
         Ok(format!(
-          "[v{input_index}]eq=saturation={value}[v{input_index}]"
+          "eq=saturation={value}"
         ))
       }
       FilterType::Hue => {
         let value = filter.intensity * 180.0; // Конвертируем в градусы
-        Ok(format!("[v{input_index}]hue=h={value}[v{input_index}]"))
+        Ok(format!("hue=h={value}"))
       }
       FilterType::Blur => {
         let radius = (filter.intensity * 10.0).max(0.1);
         Ok(format!(
-          "[v{input_index}]boxblur={radius}:{radius}[v{input_index}]"
+          "boxblur={radius}:{radius}"
         ))
       }
       FilterType::Sharpen => {
         let amount = filter.intensity * 2.0;
         Ok(format!(
-          "[v{input_index}]unsharp=5:5:{amount}:5:5:0[v{input_index}]"
+          "unsharp=5:5:{amount}:5:5:0"
         ))
       }
       FilterType::Vignette => {
         let angle = filter.intensity * 1.5;
         Ok(format!(
-          "[v{input_index}]vignette=angle={angle}[v{input_index}]"
+          "vignette=angle={angle}"
         ))
       }
       FilterType::Grain => {
         let strength = filter.intensity * 50.0;
         Ok(format!(
-          "[v{input_index}]noise=alls={strength}[v{input_index}]"
+          "noise=alls={strength}"
         ))
       }
       FilterType::Glow => {
         let radius = filter.intensity * 5.0;
         Ok(format!(
-          "[v{input_index}]gblur=sigma={radius}[v{input_index}]"
+          "gblur=sigma={radius}"
         ))
       }
       FilterType::ShadowsHighlights => {
         let shadows = filter.intensity;
         let highlights = 1.0 - filter.intensity;
         Ok(format!(
-          "[v{input_index}]eq=shadows={shadows}:highlights={highlights}[v{input_index}]"
+          "eq=shadows={shadows}:highlights={highlights}"
         ))
       }
       FilterType::WhiteBalance => {
         let temp = filter.intensity * 1000.0;
         Ok(format!(
-          "[v{input_index}]colortemperature=temperature={temp}[v{input_index}]"
+          "colortemperature=temperature={temp}"
         ))
       }
       FilterType::Exposure => {
         let exposure = filter.intensity;
         Ok(format!(
-          "[v{input_index}]eq=brightness={exposure}[v{input_index}]"
+          "eq=brightness={exposure}"
         ))
       }
       FilterType::Curves => {
         // Простая реализация кривых через eq
         let curve = filter.intensity;
-        Ok(format!("[v{input_index}]eq=gamma={curve}[v{input_index}]"))
+        Ok(format!("eq=gamma={curve}"))
       }
       FilterType::Levels => {
         // Простая реализация уровней
         let level = filter.intensity;
         Ok(format!(
-          "[v{input_index}]eq=contrast={level}[v{input_index}]"
+          "eq=contrast={level}"
         ))
       }
       FilterType::ColorBalance => {
         // Простая реализация цветового баланса
         let balance = filter.intensity;
         Ok(format!(
-          "[v{input_index}]eq=saturation={balance}[v{input_index}]"
+          "eq=saturation={balance}"
         ))
       }
       FilterType::Custom => {
@@ -263,39 +294,39 @@ impl<'a> EffectBuilder<'a> {
       self.build_complex_color_correction(&effect.parameters, input_index)
     } else {
       Ok(format!(
-        "[v{input_index}]eq=brightness={brightness}:contrast={contrast}:saturation={saturation}:gamma={gamma}[v{input_index}]"
+        "eq=brightness={brightness}:contrast={contrast}:saturation={saturation}:gamma={gamma}"
       ))
     }
   }
 
   /// Построить эффект размытия
-  fn build_blur_effect(&self, effect: &Effect, input_index: usize) -> Result<String> {
+  fn build_blur_effect(&self, effect: &Effect, _input_index: usize) -> Result<String> {
     let radius = self.get_param_value(&effect.parameters, "radius", 5.0);
     let sigma = self.get_param_value(&effect.parameters, "sigma", 1.0);
 
     Ok(format!(
-      "[v{input_index}]gblur=radius={radius}:sigma={sigma}[v{input_index}]"
+      "gblur=radius={radius}:sigma={sigma}"
     ))
   }
 
   /// Построить эффект резкости
-  fn build_sharpen_effect(&self, effect: &Effect, input_index: usize) -> Result<String> {
+  fn build_sharpen_effect(&self, effect: &Effect, _input_index: usize) -> Result<String> {
     let amount = self.get_param_value(&effect.parameters, "amount", 1.0);
     let radius = self.get_param_value(&effect.parameters, "radius", 5.0);
 
     Ok(format!(
-      "[v{input_index}]unsharp={radius}:{radius}:{amount}[v{input_index}]"
+      "unsharp={radius}:{radius}:{amount}"
     ))
   }
 
   /// Построить хромакей
-  fn build_chroma_key(&self, effect: &Effect, input_index: usize) -> Result<String> {
+  fn build_chroma_key(&self, effect: &Effect, _input_index: usize) -> Result<String> {
     let color = self.get_param_string(&effect.parameters, "color", "0x00ff00");
     let similarity = self.get_param_value(&effect.parameters, "similarity", 0.3);
     let blend = self.get_param_value(&effect.parameters, "blend", 0.0);
 
     Ok(format!(
-      "[v{input_index}]chromakey={color}:{similarity}:{blend}[v{input_index}]"
+      "chromakey={color}:{similarity}:{blend}"
     ))
   }
 
@@ -363,7 +394,7 @@ impl<'a> EffectBuilder<'a> {
   fn build_complex_color_correction(
     &self,
     parameters: &HashMap<String, EffectParameter>,
-    input_index: usize,
+    _input_index: usize,
   ) -> Result<String> {
     let highlights_r = self.get_param_value(parameters, "highlights_r", 1.0);
     let highlights_g = self.get_param_value(parameters, "highlights_g", 1.0);
@@ -378,7 +409,7 @@ impl<'a> EffectBuilder<'a> {
     let shadows_b = self.get_param_value(parameters, "shadows_b", 1.0);
 
     Ok(format!(
-      "[v{input_index}]colorchannelmixer={shadows_r}:{midtones_r}:{highlights_r}:{shadows_g}:{midtones_g}:{highlights_g}:{shadows_b}:{midtones_b}:{highlights_b}[v{input_index}]"
+      "colorchannelmixer={shadows_r}:{midtones_r}:{highlights_r}:{shadows_g}:{midtones_g}:{highlights_g}:{shadows_b}:{midtones_b}:{highlights_b}"
     ))
   }
 
@@ -394,13 +425,13 @@ impl<'a> EffectBuilder<'a> {
     &self,
     template: &str,
     parameters: &HashMap<String, EffectParameter>,
-    input_index: usize,
+    _input_index: usize,
   ) -> String {
     let mut result = template.to_string();
 
     // Заменяем плейсхолдеры
-    result = result.replace("{input}", &format!("[v{input_index}]"));
-    result = result.replace("{output}", &format!("[v{input_index}]"));
+    result = result.replace("{input}", "");
+    result = result.replace("{output}", "");
 
     // Заменяем параметры
     for (name, param) in parameters {
@@ -425,10 +456,10 @@ impl<'a> EffectBuilder<'a> {
   }
 
   /// Обработать пользовательский фильтр
-  fn process_custom_filter(&self, filter: &str, input_index: usize) -> String {
+  fn process_custom_filter(&self, filter: &str, _input_index: usize) -> String {
     filter
-      .replace("{input}", &format!("[v{input_index}]"))
-      .replace("{output}", &format!("[v{input_index}]"))
+      .replace("{input}", "")
+      .replace("{output}", "")
   }
 
   /// Проверить, является ли эффект аудио эффектом
@@ -894,7 +925,8 @@ mod tests {
     let filter = "{input}customfilter=param1:param2{output}";
     let result = builder.process_custom_filter(filter, 5);
 
-    assert!(result.contains("[v5]"));
+    // Кастом-фильтр — тоже ТЕЛО без меток.
+    assert!(!result.contains("{input}") && !result.contains("{output}"));
     assert!(result.contains("customfilter"));
   }
 
@@ -913,7 +945,8 @@ mod tests {
 
     let result = builder.process_effect_template(template, &parameters, 3);
 
-    assert!(result.contains("[v3]"));
+    // Шаблон превращается в ТЕЛО фильтра без меток ([v..] навешивает build_clip_filter).
+    assert!(!result.contains("{input}") && !result.contains("{output}"));
     assert!(result.contains("param1=1"));
     assert!(result.contains("param2=test"));
   }

--- a/crates/ts-render/src/video_compiler/core/ffmpeg_builder/filters.rs
+++ b/crates/ts-render/src/video_compiler/core/ffmpeg_builder/filters.rs
@@ -37,7 +37,12 @@ impl<'a> FilterBuilder<'a> {
 
       // Маппинг выходов
       let has_video = self.has_video_tracks();
-      let has_audio = self.has_audio_tracks();
+      // Аудио на выходе: отдельные audio-треки ИЛИ встроенное аудио видео-клипов.
+      let has_audio = self.has_audio_tracks()
+        || self
+          .get_video_tracks()
+          .iter()
+          .any(|t| t.enabled && !t.clips.is_empty());
       let has_subtitles = !self.project.subtitles.is_empty();
 
       if has_video {
@@ -115,11 +120,16 @@ impl<'a> FilterBuilder<'a> {
       }
     }
 
-    // Обрабатываем аудио треки
+    // Аудио: отдельные audio-треки → их путь; иначе встроенное аудио видео-клипов.
     if self.has_audio_tracks() {
       let audio_filter = self.build_audio_filter_chain(&mut input_index).await?;
       if !audio_filter.is_empty() {
         filters.push(audio_filter);
+      }
+    } else {
+      let video_audio = self.build_video_clips_audio_chain();
+      if !video_audio.is_empty() {
+        filters.push(video_audio);
       }
     }
 
@@ -231,6 +241,27 @@ impl<'a> FilterBuilder<'a> {
     }
 
     Ok(filters.join(";"))
+  }
+
+  /// Аудио из встроенных дорожек видео-клипов (когда отдельных audio-треков нет).
+  /// Индексы входов совпадают с видео-клипами (0..N), т.к. этот путь работает только
+  /// при `!has_audio_tracks()`. Допущение: видео-клипы содержат аудиодорожку — клипы без
+  /// звука пока не отсеиваются (потребуют ffprobe); для видео-со-звуком покрывает типичный случай.
+  fn build_video_clips_audio_chain(&self) -> String {
+    let count: usize = self
+      .get_video_tracks()
+      .iter()
+      .filter(|t| t.enabled)
+      .map(|t| t.clips.len())
+      .sum();
+    match count {
+      0 => String::new(),
+      1 => "[0:a]anull[outa]".to_string(),
+      n => {
+        let inputs: String = (0..n).map(|i| format!("[{i}:a]")).collect();
+        format!("{inputs}concat=n={n}:v=0:a=1[outa]")
+      }
+    }
   }
 
   /// Построить цепочку аудио фильтров

--- a/crates/ts-render/src/video_compiler/core/ffmpeg_builder/filters.rs
+++ b/crates/ts-render/src/video_compiler/core/ffmpeg_builder/filters.rs
@@ -7,14 +7,12 @@ use crate::video_compiler::schema::{Clip, ProjectSchema, Track, TrackType, Trans
 
 use super::effects::EffectBuilder;
 use super::subtitles::SubtitleBuilder;
-use super::templates::TemplateBuilder;
 
 /// Построитель фильтров
 pub struct FilterBuilder<'a> {
   project: &'a ProjectSchema,
   effect_builder: EffectBuilder<'a>,
   subtitle_builder: SubtitleBuilder<'a>,
-  template_builder: TemplateBuilder<'a>,
 }
 
 impl<'a> FilterBuilder<'a> {
@@ -24,7 +22,6 @@ impl<'a> FilterBuilder<'a> {
       project,
       effect_builder: EffectBuilder::new(project),
       subtitle_builder: SubtitleBuilder::new(project),
-      template_builder: TemplateBuilder::new(project),
     }
   }
 
@@ -389,41 +386,38 @@ impl<'a> FilterBuilder<'a> {
     &self,
     clip: &Clip,
     input_index: usize,
-    track_index: usize,
+    _track_index: usize,
   ) -> Result<String> {
-    let mut filters = Vec::new();
-
-    // Базовые настройки клипа
-    let base_filter = format!(
-      "[{}:v]scale={}:{},setpts=PTS-STARTPTS[v{}]",
-      input_index,
+    // Тела фильтров клипа БЕЗ меток: база (scale/setpts) + эффекты/фильтры.
+    let mut bodies = vec![format!(
+      "scale={}:{},setpts=PTS-STARTPTS",
       self.project.settings.resolution.width,
-      self.project.settings.resolution.height,
-      input_index
+      self.project.settings.resolution.height
+    )];
+    bodies.extend(
+      self
+        .effect_builder
+        .build_clip_effects(clip, input_index)
+        .await?,
     );
-    filters.push(base_filter);
+    // NB: шаблоны клипа (template_id) пока не подключены к этой цепочке (отдельный путь).
 
-    // Применяем эффекты
-    let effects_filter = self
-      .effect_builder
-      .build_clip_effects(clip, input_index)
-      .await?;
-    if !effects_filter.is_empty() {
-      filters.push(effects_filter);
+    // Нанизываем тела в валидную цепочку:
+    // [{i}:v]base[v{i}_0];[v{i}_0]fx1[v{i}_1];…;[last]fxN[v{i}]
+    let last = bodies.len() - 1;
+    let mut parts = Vec::with_capacity(bodies.len());
+    let mut cur = format!("{input_index}:v");
+    for (k, body) in bodies.iter().enumerate() {
+      let out = if k == last {
+        format!("v{input_index}")
+      } else {
+        format!("v{input_index}_{k}")
+      };
+      parts.push(format!("[{cur}]{body}[{out}]"));
+      cur = out;
     }
 
-    // Применяем шаблоны
-    if let Some(template_id) = &clip.template_id {
-      let template_filter = self
-        .template_builder
-        .build_template_filter(template_id, input_index, track_index)
-        .await?;
-      if !template_filter.is_empty() {
-        filters.push(template_filter);
-      }
-    }
-
-    Ok(filters.join(";"))
+    Ok(parts.join(";"))
   }
 
   /// Построить фильтр для аудио клипа


### PR DESCRIPTION
Закрывает #117 (доделка эффектов) + re-land аудио-фикса, не попавшего в мерж #116 по таймингу.

## Эффекты (#117)
Раньше эффекты клипов были полу-реализованы:
1. `build_effect` обрабатывал лишь `ColorCorrection/Blur/Sharpen/ChromaKey/Custom` — `Brightness/Contrast/Saturation/HueRotate/Grayscale/Sepia/Invert/…` молча игнорились (`_ => Ok("")`).
2. Тела фильтров переиспользовали label `[v{i}]…[v{i}]` (один pad на входе и выходе) → невалидный filtergraph (`Output pad … already exists`).

Исправлено:
- **Цветовые/тоновые эффекты** на стандартных ffmpeg-фильтрах (без libfreetype): `Brightness/Contrast/Saturation` → `eq`, `HueRotate` → `hue`, `Grayscale/Noir` → `hue=s=0`, `Sepia` → `colorchannelmixer`, `Invert` → `negate`, `Vignette` → `vignette`, `FilmGrain` → `noise`.
- **Рефактор цепочки меток**: `build_effect`/`build_filter`/под-билдеры теперь возвращают ТЕЛО фильтра (без меток); `build_clip_effects` → `Vec<String>`; `build_clip_filter` нанизывает валидную цепочку `[i:v]base[v{i}_0];[v{i}_0]fx1[v{i}_1];…;[last]fxN[v{i}]`.
- Кастом-шаблоны (`{input}/{output}`) → тело; убран мёртвый `template_builder`.

## Аудио (re-land)
Фикс «аудио видео-клипов в выходе» (`build_video_clips_audio_chain`) был закоммичен в #116, но мерж #116 захватил только CLI+мультиклип (тайминг) — здесь восстановлен cherry-pick'ом.

## Проверка
- 1 клип + Brightness-эффект (через пул `project.effects` + ID в `clip.effects`) → filtergraph `…[v0_0];[v0_0]eq=brightness=0.1[v0];…`, выход **h264 + aac** валиден.
- `ts-render`: **472 теста зелёные**, сборка без варнингов.

Известные ограничения (TODO): шаблоны клипов не подключены к цепочке; переходы (xfade) не подключены; субтитры требуют ffmpeg c libfreetype. Эпик #91 / #90.
