### PR TITLE
feat: контракт ProjectSchema — JSON Schema + TS shared-types (M1 #120/#104)

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -404,6 +404,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,6 +801,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -920,6 +932,17 @@ name = "imgref"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40fac9d56ed6437b198fddba683305e8e2d651aa42647f00f5ae542e7f5c94a2"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
 
 [[package]]
 name = "indexmap"
@@ -1797,6 +1820,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "indexmap 1.9.3",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1832,6 +1881,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2178,6 +2238,7 @@ dependencies = [
  "env_logger",
  "log",
  "regex",
+ "schemars",
  "serde",
  "serde_json",
  "tempfile",
@@ -2192,6 +2253,7 @@ name = "ts-schema"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "schemars",
  "serde",
  "serde_json",
  "specta",
@@ -2364,7 +2426,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -2377,7 +2439,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -2499,7 +2561,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -2530,7 +2592,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -2549,7 +2611,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",

--- a/crates/ts-render/Cargo.toml
+++ b/crates/ts-render/Cargo.toml
@@ -27,4 +27,5 @@ regex = "1"
 anyhow = "1"
 zstd = "0.13"
 env_logger = "0.11.10"
+schemars = "0.8"
 

--- a/crates/ts-render/src/bin/render.rs
+++ b/crates/ts-render/src/bin/render.rs
@@ -79,6 +79,18 @@ async fn main() {
       }
     }
 
+    // --- JSON Schema контракта ProjectSchema (машинный контракт для агента) ---
+    Some("--emit-schema") => {
+      let schema = schemars::schema_for!(ProjectSchema);
+      match serde_json::to_string_pretty(&schema) {
+        Ok(s) => println!("{s}"),
+        Err(e) => {
+          eprintln!("serialize failed: {e}");
+          std::process::exit(1);
+        }
+      }
+    }
+
     // --- удобный режим: обернуть одно видео в 1 клип ---
     Some(arg) if !arg.starts_with("--") && args.len() >= 3 => {
       let input = PathBuf::from(&args[1]);
@@ -95,6 +107,7 @@ async fn main() {
       eprintln!("  {prog} <input-video> <output.mp4>            обернуть 1 клип и отрендерить");
       eprintln!("  {prog} --project <project.json> <output.mp4>  отрендерить ProjectSchema из JSON");
       eprintln!("  {prog} --emit-example <input-video>           напечатать пример ProjectSchema JSON");
+      eprintln!("  {prog} --emit-schema                          напечатать JSON Schema контракта");
       std::process::exit(2);
     }
   }

--- a/crates/ts-schema/Cargo.toml
+++ b/crates/ts-schema/Cargo.toml
@@ -14,3 +14,4 @@ serde_json = "1"
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 specta = { version = "2.0.0-rc.21", features = ["derive"] }
+schemars = { version = "0.8", features = ["chrono", "preserve_order"] }

--- a/crates/ts-schema/src/common.rs
+++ b/crates/ts-schema/src/common.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 
 /// Соотношение сторон видео
-#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, schemars::JsonSchema)]
 pub enum AspectRatio {
   #[default]
   Ratio16x9, // 16:9 (широкоформатное)
@@ -37,7 +37,7 @@ impl AspectRatio {
 }
 
 /// Разрешение видео
-#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, schemars::JsonSchema)]
 pub struct Resolution {
   pub width: u32,
   pub height: u32,
@@ -72,21 +72,21 @@ impl Resolution {
 }
 
 /// Позиция в 2D пространстве
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct Position2D {
   pub x: f32,
   pub y: f32,
 }
 
 /// Размер в 2D пространстве
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct Size2D {
   pub width: f32,
   pub height: f32,
 }
 
 /// Режим подгонки контента
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub enum FitMode {
   /// Заполнить весь контейнер (может обрезать)
   Fill,
@@ -99,7 +99,7 @@ pub enum FitMode {
 }
 
 /// Выравнивание по горизонтали
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub enum AlignX {
   Left,
   Center,
@@ -107,7 +107,7 @@ pub enum AlignX {
 }
 
 /// Выравнивание по вертикали
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub enum AlignY {
   Top,
   Center,
@@ -356,7 +356,7 @@ mod tests {
 
 /// Тип медиа-файла (вынесен из монолитного state::project_state — общий фундамент,
 /// чтобы analysis-крейт и монолит использовали ОДИН тип; #94/#98).
-#[derive(Debug, Clone, Serialize, Deserialize, specta::Type, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type, PartialEq, Eq, schemars::JsonSchema)]
 pub enum MediaType {
   Video,
   Audio,

--- a/crates/ts-schema/src/effects.rs
+++ b/crates/ts-schema/src/effects.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 /// Эффект, применяемый к клипу или треку
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct Effect {
   /// Уникальный идентификатор эффекта
   pub id: String,
@@ -42,7 +42,7 @@ pub struct Effect {
 }
 
 /// Пресет эффекта
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct EffectPreset {
   /// Название пресета (локализованное)
   pub name: HashMap<String, String>,
@@ -78,7 +78,7 @@ impl Effect {
 }
 
 /// Тип эффекта
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, schemars::JsonSchema)]
 pub enum EffectType {
   /// Размытие
   Blur,
@@ -197,7 +197,7 @@ pub enum EffectType {
 }
 
 /// Категория эффекта
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, schemars::JsonSchema)]
 pub enum EffectCategory {
   /// Цветокоррекция
   ColorCorrection,
@@ -218,7 +218,7 @@ pub enum EffectCategory {
 }
 
 /// Сложность эффекта
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, schemars::JsonSchema)]
 pub enum EffectComplexity {
   /// Базовый
   Basic,
@@ -229,7 +229,7 @@ pub enum EffectComplexity {
 }
 
 /// Теги эффектов
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, schemars::JsonSchema)]
 pub enum EffectTag {
   /// Популярный
   Popular,
@@ -252,7 +252,7 @@ pub enum EffectTag {
 }
 
 /// Параметр эффекта
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub enum EffectParameter {
   /// Число с плавающей точкой
   Float(f32),
@@ -271,7 +271,7 @@ pub enum EffectParameter {
 }
 
 /// Фильтр для визуальных эффектов
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct Filter {
   /// Уникальный идентификатор фильтра
   pub id: String,
@@ -309,7 +309,7 @@ impl Filter {
 }
 
 /// Тип фильтра
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, schemars::JsonSchema)]
 pub enum FilterType {
   /// Яркость
   Brightness,
@@ -346,7 +346,7 @@ pub enum FilterType {
 }
 
 /// Переход между клипами
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct Transition {
   /// Уникальный идентификатор перехода
   pub id: String,
@@ -375,7 +375,7 @@ pub struct Transition {
 }
 
 /// Длительность перехода
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct TransitionDuration {
   /// Основная длительность в секундах
   pub value: f64,
@@ -392,7 +392,7 @@ impl std::fmt::Display for TransitionDuration {
 }
 
 /// Категория перехода
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, schemars::JsonSchema)]
 pub enum TransitionCategory {
   /// Базовые переходы
   Basic,
@@ -419,7 +419,7 @@ pub enum TransitionCategory {
 }
 
 /// Сложность перехода
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, schemars::JsonSchema)]
 pub enum TransitionComplexity {
   /// Простой
   Simple,
@@ -430,7 +430,7 @@ pub enum TransitionComplexity {
 }
 
 /// Теги переходов
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, schemars::JsonSchema)]
 pub enum TransitionTag {
   /// Плавный
   Smooth,
@@ -457,7 +457,7 @@ pub enum TransitionTag {
 }
 
 /// Видео фильтр
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct VideoFilter {
   /// ID фильтра
   pub id: String,
@@ -480,7 +480,7 @@ pub struct VideoFilter {
 }
 
 /// Категория фильтра
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, schemars::JsonSchema)]
 pub enum FilterCategory {
   /// Цветокоррекция
   ColorCorrection,
@@ -499,7 +499,7 @@ pub enum FilterCategory {
 }
 
 /// Сложность фильтра
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, schemars::JsonSchema)]
 pub enum FilterComplexity {
   /// Простой
   Simple,
@@ -510,7 +510,7 @@ pub enum FilterComplexity {
 }
 
 /// Теги фильтров
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, schemars::JsonSchema)]
 pub enum FilterTag {
   /// Цвет
   Color,

--- a/crates/ts-schema/src/export.rs
+++ b/crates/ts-schema/src/export.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use super::common::Resolution;
 
 /// Настройки проекта
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct ProjectSettings {
   /// Настройки экспорта
   pub export: ExportSettings,
@@ -25,7 +25,7 @@ pub struct ProjectSettings {
 }
 
 /// Настройки вывода (для обратной совместимости)
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct OutputSettings {
   /// Формат вывода
   pub format: OutputFormat,
@@ -66,7 +66,7 @@ impl Default for ProjectSettings {
 }
 
 /// Настройки экспорта
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct ExportSettings {
   /// Формат вывода
   pub format: OutputFormat,
@@ -147,7 +147,7 @@ impl Default for ExportSettings {
 }
 
 /// Формат вывода видео
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub enum OutputFormat {
   Mp4,
   Avi,
@@ -159,7 +159,7 @@ pub enum OutputFormat {
 }
 
 /// Настройки превью
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct PreviewSettings {
   /// Разрешение превью
   pub resolution: (u32, u32),
@@ -183,7 +183,7 @@ impl Default for PreviewSettings {
 }
 
 /// Формат превью
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub enum PreviewFormat {
   Jpeg,
   Png,

--- a/crates/ts-schema/src/project.rs
+++ b/crates/ts-schema/src/project.rs
@@ -10,7 +10,7 @@ use super::templates::{StyleTemplate, Template};
 use super::timeline::{Timeline, Track};
 
 /// Основная схема проекта Timeline Studio
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct ProjectSchema {
   /// Версия схемы проекта для совместимости
   pub version: String,
@@ -142,7 +142,7 @@ impl ProjectSchema {
 }
 
 /// Метаданные проекта
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct ProjectMetadata {
   /// Название проекта
   pub name: String,

--- a/crates/ts-schema/src/subtitles.rs
+++ b/crates/ts-schema/src/subtitles.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// Субтитр
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct Subtitle {
   /// Уникальный идентификатор субтитра
   pub id: String,
@@ -91,7 +91,7 @@ impl Subtitle {
 }
 
 /// Позиция субтитра на экране
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 #[serde(tag = "type")]
 pub enum SubtitlePosition {
   /// Абсолютная позиция
@@ -113,7 +113,7 @@ impl Default for SubtitlePosition {
 }
 
 /// Горизонтальное выравнивание субтитра
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, schemars::JsonSchema)]
 pub enum SubtitleAlignX {
   /// По левому краю
   Left,
@@ -124,7 +124,7 @@ pub enum SubtitleAlignX {
 }
 
 /// Вертикальное выравнивание субтитра
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, schemars::JsonSchema)]
 pub enum SubtitleAlignY {
   /// По верхнему краю
   Top,
@@ -137,7 +137,7 @@ pub enum SubtitleAlignY {
 }
 
 /// Отступы субтитра
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct SubtitleMargin {
   /// Отступ сверху в пикселях
   pub top: f32,
@@ -161,7 +161,7 @@ impl Default for SubtitleMargin {
 }
 
 /// Стиль субтитра
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct SubtitleStyle {
   /// Название шрифта
   pub font_family: String,
@@ -224,7 +224,7 @@ impl Default for SubtitleStyle {
 }
 
 /// Толщина шрифта субтитра
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, schemars::JsonSchema)]
 pub enum SubtitleFontWeight {
   /// Тонкий
   Thin,
@@ -241,7 +241,7 @@ pub enum SubtitleFontWeight {
 }
 
 /// Отступы текста внутри фона субтитра
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct SubtitlePadding {
   /// Отступ сверху
   pub top: f32,
@@ -265,7 +265,7 @@ impl Default for SubtitlePadding {
 }
 
 /// Анимация субтитра
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct SubtitleAnimation {
   /// Уникальный идентификатор анимации
   pub id: String,
@@ -302,7 +302,7 @@ impl SubtitleAnimation {
 }
 
 /// Тип анимации субтитра
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, schemars::JsonSchema)]
 pub enum SubtitleAnimationType {
   /// Появление с изменением прозрачности
   FadeIn,
@@ -333,7 +333,7 @@ pub enum SubtitleAnimationType {
 }
 
 /// Функция сглаживания анимации субтитра
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, schemars::JsonSchema)]
 pub enum SubtitleEasing {
   /// Линейная
   Linear,
@@ -352,7 +352,7 @@ pub enum SubtitleEasing {
 }
 
 /// Направление анимации субтитра
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, schemars::JsonSchema)]
 pub enum SubtitleDirection {
   /// Сверху
   Top,

--- a/crates/ts-schema/src/templates.rs
+++ b/crates/ts-schema/src/templates.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use super::common::{AlignX, AlignY, FitMode, Position2D, Size2D};
 
 /// Шаблон многокамерной раскладки
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct Template {
   /// Уникальный идентификатор шаблона
   pub id: String,
@@ -38,7 +38,7 @@ impl Template {
 }
 
 /// Тип шаблона
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, schemars::JsonSchema)]
 pub enum TemplateType {
   /// Вертикальное разделение
   Vertical,
@@ -53,7 +53,7 @@ pub enum TemplateType {
 }
 
 /// Ячейка шаблона
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct TemplateCell {
   /// Индекс ячейки (0-based)
   pub index: usize,
@@ -76,7 +76,7 @@ pub struct TemplateCell {
 }
 
 /// Регион шаблона (для обратной совместимости)
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct TemplateRegion {
   pub x: u32,
   pub y: u32,
@@ -86,7 +86,7 @@ pub struct TemplateRegion {
 }
 
 /// Стильный шаблон (интро, аутро, титры)
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct StyleTemplate {
   /// Уникальный идентификатор шаблона
   pub id: String,
@@ -128,7 +128,7 @@ impl StyleTemplate {
 }
 
 /// Категория стильного шаблона
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, schemars::JsonSchema)]
 pub enum StyleTemplateCategory {
   /// Интро
   Intro,
@@ -145,7 +145,7 @@ pub enum StyleTemplateCategory {
 }
 
 /// Стиль шаблона
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, schemars::JsonSchema)]
 pub enum StyleTemplateStyle {
   /// Современный
   Modern,
@@ -162,7 +162,7 @@ pub enum StyleTemplateStyle {
 }
 
 /// Элемент стильного шаблона
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct StyleTemplateElement {
   /// Уникальный идентификатор элемента
   pub id: String,
@@ -187,7 +187,7 @@ pub struct StyleTemplateElement {
 }
 
 /// Элемент стиля (для обратной совместимости)
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct StyleElement {
   pub id: String,
   pub element_type: StyleElementType,
@@ -199,7 +199,7 @@ pub struct StyleElement {
 }
 
 /// Стиль элемента (для обратной совместимости)
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct ElementStyle {
   pub font_family: Option<String>,
   pub font_size: Option<u32>,
@@ -208,7 +208,7 @@ pub struct ElementStyle {
 }
 
 /// Тип элемента стильного шаблона
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, schemars::JsonSchema)]
 pub enum StyleElementType {
   /// Текст
   Text,
@@ -227,7 +227,7 @@ pub enum StyleElementType {
 }
 
 /// Временные параметры элемента
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct ElementTiming {
   /// Время появления в секундах
   pub in_time: f64,
@@ -238,7 +238,7 @@ pub struct ElementTiming {
 }
 
 /// Свойства элемента стильного шаблона
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default, schemars::JsonSchema)]
 pub struct StyleElementProperties {
   /// Текстовое содержимое (для текстовых элементов)
   pub text: Option<String>,
@@ -283,7 +283,7 @@ pub struct StyleElementProperties {
 }
 
 /// Выравнивание текста
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, schemars::JsonSchema)]
 pub enum TextAlign {
   /// По левому краю
   Left,
@@ -296,7 +296,7 @@ pub enum TextAlign {
 }
 
 /// Толщина шрифта
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, schemars::JsonSchema)]
 pub enum FontWeight {
   /// Тонкий (100)
   Thin,
@@ -319,7 +319,7 @@ pub enum FontWeight {
 }
 
 /// Стиль шрифта
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, schemars::JsonSchema)]
 pub enum FontStyle {
   /// Обычный
   Normal,
@@ -330,7 +330,7 @@ pub enum FontStyle {
 }
 
 /// Режим масштабирования изображения
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, schemars::JsonSchema)]
 pub enum ObjectFit {
   /// Заполнить контейнер с обрезкой
   Cover,
@@ -345,7 +345,7 @@ pub enum ObjectFit {
 }
 
 /// Тип формы
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, schemars::JsonSchema)]
 pub enum ShapeType {
   /// Прямоугольник
   Rectangle,
@@ -366,7 +366,7 @@ pub enum ShapeType {
 }
 
 /// Свойства тени
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct ShadowProperties {
   /// Смещение по X
   pub offset_x: f32,
@@ -381,7 +381,7 @@ pub struct ShadowProperties {
 }
 
 /// Анимация элемента
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct ElementAnimation {
   /// Уникальный идентификатор анимации
   pub id: String,
@@ -402,7 +402,7 @@ pub struct ElementAnimation {
 }
 
 /// Тип анимации
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, schemars::JsonSchema)]
 pub enum AnimationType {
   /// Появление
   FadeIn,
@@ -435,7 +435,7 @@ pub enum AnimationType {
 }
 
 /// Функция сглаживания анимации
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, schemars::JsonSchema)]
 pub enum AnimationEasing {
   /// Линейная
   Linear,
@@ -470,7 +470,7 @@ pub enum AnimationEasing {
 }
 
 /// Направление анимации
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, schemars::JsonSchema)]
 pub enum AnimationDirection {
   /// Обычное
   Normal,

--- a/crates/ts-schema/src/timeline.rs
+++ b/crates/ts-schema/src/timeline.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use super::common::AspectRatio;
 
 /// Источник клипа
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub enum ClipSource {
   /// Файл на диске
   File(String),
@@ -19,7 +19,7 @@ pub enum ClipSource {
 }
 
 /// Настройки timeline
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct Timeline {
   /// Общая продолжительность в секундах
   pub duration: f64,
@@ -46,7 +46,7 @@ impl Default for Timeline {
 }
 
 /// Дорожка timeline (видео, аудио, субтитры)
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct Track {
   /// Уникальный идентификатор трека
   pub id: String,
@@ -117,7 +117,7 @@ impl Track {
 }
 
 /// Тип трека
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, schemars::JsonSchema)]
 pub enum TrackType {
   /// Видео трек
   Video,
@@ -128,7 +128,7 @@ pub enum TrackType {
 }
 
 /// Медиаклип на треке
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct Clip {
   /// Уникальный идентификатор клипа
   pub id: String,
@@ -234,7 +234,7 @@ impl Clip {
 }
 
 /// Настройки цветокоррекции
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct ColorCorrection {
   pub brightness: f32,
   pub contrast: f32,
@@ -264,7 +264,7 @@ impl Default for ColorCorrection {
 }
 
 /// Настройки обрезки (кроп)
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct CropSettings {
   pub left: u32,
   pub top: u32,
@@ -273,7 +273,7 @@ pub struct CropSettings {
 }
 
 /// Настройки трансформации
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, schemars::JsonSchema)]
 pub struct TransformSettings {
   pub scale_x: f32,
   pub scale_y: f32,
@@ -299,7 +299,7 @@ impl Default for TransformSettings {
 }
 
 /// Дополнительные свойства клипа
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default, schemars::JsonSchema)]
 pub struct ClipProperties {
   /// Заметки о клипе
   pub notes: Option<String>,


### PR DESCRIPTION
Ядро **M1 (#120)** эпика Agentic Timeline Studio (#119): единый язык «агент ↔ движок».

## Один источник правды
Rust serde (ts-schema) → **JSON Schema** (`timeline-render --emit-schema`) → **TS-типы** (json-schema-to-typescript).

## Что
1. **JSON Schema** — `schemars` + `#[derive(JsonSchema)]` на 78 типах; `timeline-render --emit-schema` → draft-07, title `ProjectSchema`, 11 top-level свойств, 70 definitions (~109KB). Машинный контракт для агента/tool-use.
2. **TS shared-types** (#104) — `src/types/contracts/project-schema.ts` (35 интерфейсов: ProjectSchema/Timeline/Track/Clip/Effect/Subtitle/…), автоген, коммитится. `scripts/gen-schema-types.sh` + `bun run gen:schema-types` — воспроизводимо.

## Зачем (агентность)
Агент и внешние продукты (Lead Engine / project-x) получают типизированный контракт машинно — без угадывания формы JSON и без ручной синхронизации типов.

## Проверка
`--emit-schema` → валидный JSON Schema; `tsc --strict` на TS-файле — без ошибок; ts-schema 136 + ts-render 472 теста зелёные.

Закрывает ядро #120 (контракт) и #104 (TS shared-types). Дальше M1: контракты результатов analysis/optimize/publish (по мере появления возможностей в M2/M3/M5).