### PR TITLE
feat(ts-cli): единый headless timeline-бинарь (render/optimize/thumbnail/emit) — M2 #121

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -325,6 +325,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2022,6 +2062,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2173,6 +2219,20 @@ dependencies = [
  "ts-recognition",
  "ts-schema",
  "uuid",
+]
+
+[[package]]
+name = "ts-cli"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "env_logger",
+ "schemars",
+ "serde_json",
+ "tokio",
+ "ts-platform",
+ "ts-render",
+ "ts-schema",
 ]
 
 [[package]]

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -4,4 +4,5 @@
 [workspace]
 resolver = "2"
 members = [
+  "ts-cli",
   "ts-platform","ts-schema", "ts-render", "ts-recognition", "ts-subtitles", "ts-media", "ts-montage", "ts-analysis"]

--- a/crates/ts-cli/Cargo.toml
+++ b/crates/ts-cli/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "ts-cli"
+version = "0.1.0"
+edition = "2021"
+description = "timeline — единый headless-CLI Timeline Studio для агента (render/optimize/thumbnail/emit). M2 #121."
+
+[[bin]]
+name = "timeline"
+path = "src/main.rs"
+
+[dependencies]
+ts-render = { path = "../ts-render" }
+ts-platform = { path = "../ts-platform" }
+ts-schema = { path = "../ts-schema" }
+clap = { version = "4", features = ["derive"] }
+tokio = { version = "1", features = ["full"] }
+serde_json = "1"
+schemars = "0.8"
+env_logger = "0.11"

--- a/crates/ts-cli/src/main.rs
+++ b/crates/ts-cli/src/main.rs
@@ -1,0 +1,284 @@
+//! `timeline` — единый headless-CLI Timeline Studio для агента (M2 #121).
+//!
+//! Субкоманды без Tauri / AppHandle / webview — единый интерфейс для агента:
+//! ```sh
+//! timeline render <project.json> <out.mp4>     # ProjectSchema → видео (ts-render)
+//! timeline optimize -i in.mp4 -o out.mp4 -p youtube   # ре-энкод под платформу (ts-platform)
+//! timeline thumbnail -i in.mp4 -o thumb.jpg          # кадр-превью (ts-platform)
+//! timeline emit-schema                                # JSON Schema контракта ProjectSchema
+//! timeline emit-example <video>                       # пример ProjectSchema JSON
+//! ```
+
+use std::path::{Path, PathBuf};
+use std::process::exit;
+use std::sync::Arc;
+
+use clap::{Parser, Subcommand};
+use tokio::sync::{mpsc, RwLock};
+
+use ts_platform::business_logic::{generate_thumbnail_logic, optimize_for_platform_logic};
+use ts_platform::types::{PlatformOptimizationParams, PlatformThumbnailParams};
+use ts_render::video_compiler::cache::RenderCache;
+use ts_render::video_compiler::progress::ProgressUpdate;
+use ts_render::video_compiler::renderer::VideoRenderer;
+use ts_render::video_compiler::schema::{
+  Clip, ExportSettings, OutputFormat, ProjectSchema, Track, TrackType,
+};
+use ts_render::video_compiler::CompilerSettings;
+
+const CLIP_SECONDS: f64 = 5.0;
+
+#[derive(Parser)]
+#[command(name = "timeline", version, about = "Headless Timeline Studio CLI для агента")]
+struct Cli {
+  #[command(subcommand)]
+  cmd: Cmd,
+}
+
+#[derive(Subcommand)]
+enum Cmd {
+  /// Отрендерить ProjectSchema (JSON) в mp4
+  Render {
+    /// project.json (ProjectSchema)
+    project: PathBuf,
+    /// выходной mp4
+    output: PathBuf,
+  },
+  /// Оптимизировать видео под платформу (ffmpeg re-encode под specs)
+  Optimize {
+    #[arg(short, long)]
+    input: String,
+    #[arg(short, long)]
+    output: String,
+    /// пресет: youtube | tiktok | reels | shorts | instagram | square
+    #[arg(short, long, default_value = "youtube")]
+    platform: String,
+    #[arg(long)]
+    width: Option<u32>,
+    #[arg(long)]
+    height: Option<u32>,
+    /// битрейт, кбит/с
+    #[arg(long)]
+    bitrate: Option<u32>,
+    #[arg(long)]
+    fps: Option<u32>,
+    /// кропнуть под целевое соотношение
+    #[arg(long)]
+    crop: bool,
+  },
+  /// Сгенерировать превью (кадр)
+  Thumbnail {
+    #[arg(short, long)]
+    input: String,
+    #[arg(short, long)]
+    output: String,
+    /// тайм-код кадра, сек
+    #[arg(long, default_value_t = 1.0)]
+    time: f64,
+    #[arg(long, default_value_t = 1280)]
+    width: u32,
+    #[arg(long, default_value_t = 720)]
+    height: u32,
+  },
+  /// Напечатать JSON Schema контракта ProjectSchema
+  EmitSchema,
+  /// Напечатать пример ProjectSchema JSON (обёртка одного видео)
+  EmitExample {
+    /// входное видео для примера
+    input: PathBuf,
+  },
+}
+
+#[tokio::main]
+async fn main() {
+  env_logger::init();
+  match Cli::parse().cmd {
+    Cmd::Render { project, output } => cmd_render(&project, &output).await,
+    Cmd::Optimize {
+      input,
+      output,
+      platform,
+      width,
+      height,
+      bitrate,
+      fps,
+      crop,
+    } => cmd_optimize(input, output, &platform, width, height, bitrate, fps, crop).await,
+    Cmd::Thumbnail {
+      input,
+      output,
+      time,
+      width,
+      height,
+    } => cmd_thumbnail(input, output, time, width, height).await,
+    Cmd::EmitSchema => {
+      let schema = schemars::schema_for!(ProjectSchema);
+      println!("{}", serde_json::to_string_pretty(&schema).unwrap());
+    }
+    Cmd::EmitExample { input } => {
+      let project = build_single_clip_project(input);
+      println!("{}", serde_json::to_string_pretty(&project).unwrap());
+    }
+  }
+}
+
+/// Пресеты платформ: (width, height, bitrate-kbps, fps).
+fn platform_preset(p: &str) -> (u32, u32, u32, u32) {
+  match p {
+    "tiktok" | "reels" | "shorts" => (1080, 1920, 6000, 30),
+    "instagram" | "square" => (1080, 1080, 5000, 30),
+    _ => (1920, 1080, 8000, 30), // youtube / default
+  }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn cmd_optimize(
+  input: String,
+  output: String,
+  platform: &str,
+  width: Option<u32>,
+  height: Option<u32>,
+  bitrate: Option<u32>,
+  fps: Option<u32>,
+  crop: bool,
+) {
+  let (pw, ph, pb, pf) = platform_preset(platform);
+  let params = PlatformOptimizationParams {
+    input_path: input,
+    output_path: output,
+    target_width: width.unwrap_or(pw),
+    target_height: height.unwrap_or(ph),
+    target_bitrate: bitrate.unwrap_or(pb),
+    target_framerate: fps.unwrap_or(pf),
+    audio_codec: "aac".to_string(),
+    video_codec: "libx264".to_string(),
+    crop_to_fit: crop,
+  };
+  match optimize_for_platform_logic(&params).await {
+    Ok(r) => println!(
+      "✅ optimize: {} ({}x{}, {}kbps, {} bytes) за {:.2}s",
+      r.output_path, r.width, r.height, r.bitrate, r.file_size, r.processing_time
+    ),
+    Err(e) => {
+      eprintln!("❌ optimize: {e}");
+      exit(1);
+    }
+  }
+}
+
+async fn cmd_thumbnail(input: String, output: String, time: f64, width: u32, height: u32) {
+  let params = PlatformThumbnailParams {
+    input_path: input,
+    output_path: output,
+    width,
+    height,
+    timestamp: time,
+    quality: Some(90),
+  };
+  match generate_thumbnail_logic(&params).await {
+    Ok(r) => println!(
+      "✅ thumbnail: {} ({}x{}, {} bytes)",
+      r.thumbnail_path, r.width, r.height, r.file_size
+    ),
+    Err(e) => {
+      eprintln!("❌ thumbnail: {e}");
+      exit(1);
+    }
+  }
+}
+
+/// Минимальный 1-клиповый проект (без Tauri) — для emit-example.
+fn build_single_clip_project(input: PathBuf) -> ProjectSchema {
+  let mut project = ProjectSchema::new("headless-single-clip".to_string());
+  project.timeline.fps = 30;
+  project.timeline.resolution = (1280, 720);
+  project.timeline.duration = CLIP_SECONDS;
+  project.settings.export = ExportSettings {
+    format: OutputFormat::Mp4,
+    hardware_acceleration: false,
+    ..Default::default()
+  };
+  let mut track = Track::new(TrackType::Video, "Video".to_string());
+  track.add_clip(Clip::new(input, 0.0, CLIP_SECONDS));
+  project.tracks.push(track);
+  project
+}
+
+/// Рендер ProjectSchema headless (без AppHandle/webview).
+async fn cmd_render(project_path: &Path, output: &Path) {
+  let json = match std::fs::read_to_string(project_path) {
+    Ok(s) => s,
+    Err(e) => {
+      eprintln!("cannot read {}: {e}", project_path.display());
+      exit(2);
+    }
+  };
+  let project: ProjectSchema = match serde_json::from_str(&json) {
+    Ok(p) => p,
+    Err(e) => {
+      eprintln!("invalid ProjectSchema JSON: {e}");
+      exit(2);
+    }
+  };
+
+  let settings = Arc::new(RwLock::new(CompilerSettings::default()));
+  let cache = Arc::new(RwLock::new(RenderCache::new()));
+  let (tx, mut rx) = mpsc::unbounded_channel::<ProgressUpdate>();
+
+  let mut renderer = match VideoRenderer::new(project, settings, cache, tx).await {
+    Ok(r) => r,
+    Err(e) => {
+      eprintln!("renderer init failed: {e}");
+      exit(1);
+    }
+  };
+
+  println!("rendering -> {} (headless)…", output.display());
+  if let Err(e) = renderer.render(output).await {
+    eprintln!("render start failed: {e}");
+    exit(1);
+  }
+
+  use std::io::Write;
+  while let Some(u) = rx.recv().await {
+    match u {
+      ProgressUpdate::ProgressChanged { .. } => {
+        print!(".");
+        let _ = std::io::stdout().flush();
+      }
+      ProgressUpdate::JobCompleted {
+        output_path,
+        duration,
+        ..
+      } => {
+        println!("\n✅ done in {duration:?} -> {output_path}");
+        return;
+      }
+      ProgressUpdate::JobFailed { error, .. } => {
+        eprintln!("\n❌ render failed: {error}");
+        exit(1);
+      }
+      ProgressUpdate::JobCancelled { .. } => {
+        eprintln!("\n⚠️ render cancelled");
+        exit(1);
+      }
+      _ => {}
+    }
+  }
+  eprintln!("progress channel closed before completion");
+  exit(1);
+}
+
+#[cfg(test)]
+mod tests {
+  use super::platform_preset;
+
+  #[test]
+  fn presets_map_correctly() {
+    assert_eq!(platform_preset("youtube"), (1920, 1080, 8000, 30));
+    assert_eq!(platform_preset("tiktok"), (1080, 1920, 6000, 30));
+    assert_eq!(platform_preset("reels"), (1080, 1920, 6000, 30));
+    assert_eq!(platform_preset("square"), (1080, 1080, 5000, 30));
+    assert_eq!(platform_preset("unknown"), (1920, 1080, 8000, 30)); // дефолт
+  }
+}


### PR DESCRIPTION
**M2-PR B (#121):** единый agent-интерфейс — один бинарь `timeline` с clap-субкомандами поверх `ts-render` + `ts-platform`, без Tauri/webview.

## Субкоманды
- `timeline render <project.json> <out.mp4>` — ProjectSchema → видео (ts-render).
- `timeline optimize -i -o -p <platform>` — ре-энкод под платформу (ts-platform). Пресеты youtube/tiktok/reels/shorts/instagram/square + override `--width/--height/--bitrate/--fps/--crop`.
- `timeline thumbnail -i -o` — кадр-превью (ts-platform).
- `timeline emit-schema` / `emit-example` — контракт ProjectSchema наружу.

## Зачем (агентность)
Агент управляет всем конвейером одним CLI: смонтировать (render) → оптимизировать под платформу (optimize) → [дальше publish в M5]. Каждая команда — чистый headless вызов.

## Проверка (локально)
- `emit-schema` → ProjectSchema (70 defs);
- `optimize -p youtube` → **1920×1080 / 8000k реальный ffmpeg re-encode**;
- `render` (emit-example → render) → video+audio;
- ts-cli unit-тест пресетов зелёный.

Старый `timeline-render` оставлен для обратной совместимости. Часть #121 / #119. Дальше M2: `ingest` + Docker + crate-type (#103).