### PR TITLE
fix(lint): исключить src/types/contracts из biome (М1 #120)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,7 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "includes": ["src/**/*.ts", "src/**/*.tsx"]
+    "includes": ["src/**/*.ts", "src/**/*.tsx", "!src/types/contracts/**"]
   },
   "formatter": {
     "enabled": true,


### PR DESCRIPTION
## Проблема

`src/types/contracts/project-schema.ts` — авто-генерированный файл (json-schema-to-typescript из Rust schemars). Biome ругается на его форматирование, которое не совпадает с biome-стилем.

## Фикс

Добавить `!src/types/contracts/**` в `files.includes` в `biome.json`.

Этот фикс уже дважды приземлялся (#126, #128→#129) и дважды терялся из-за squash-merge. Открыт отдельным PR чтобы не потерялся снова.

## Связанные

- M1 #120 (contracts)
- PR #127 (TS contract)

🤖 Generated with [Claude Code](https://claude.com/claude-code)