### PR TITLE
feat(docker): Dockerfile.headless + CI — timeline-headless образ (M2 #121)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# Timeline Studio — исключения для Docker build context
+
+# Frontend / Node
+node_modules/
+.next/
+dist/
+.nuxt/
+
+# Tauri монолит (не нужен для headless-образа)
+src-tauri/target/
+
+# Cargo target в crates (пересобирается в builder)
+crates/target/
+
+# Git
+.git/
+.github/
+
+# IDE / OS
+.idea/
+.vscode/
+*.DS_Store
+
+# Большие медиафайлы
+*.mp4
+*.mov
+*.avi
+*.mkv
+*.wav
+*.mp3
+
+# Тестовые данные
+crates/**/tests/fixtures/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,62 @@
+name: Docker headless
+
+# Собирает и публикует ghcr.io/chatman-media/timeline-headless — M2 #121.
+# Запускается при push в main (если затронуты crates/ или Dockerfile)
+# или вручную (workflow_dispatch).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'crates/**'
+      - 'docker/Dockerfile.headless'
+      - '.github/workflows/docker.yml'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: chatman-media/timeline-headless
+
+jobs:
+  build-and-push:
+    name: Build & push timeline-headless
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix=sha-,format=short
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.headless
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64

--- a/docker/Dockerfile.headless
+++ b/docker/Dockerfile.headless
@@ -1,0 +1,73 @@
+# Timeline Studio headless runtime — `timeline` CLI + ffmpeg + ONNX Runtime
+#
+# Multi-stage:
+#   builder  — Rust + ffmpeg-dev + ONNX headers → compile `timeline` binary
+#   runtime  — slim Debian + ffmpeg + ONNX shared libs → final image
+#
+# Использование:
+#   docker build -f docker/Dockerfile.headless -t timeline-headless .
+#   docker run --rm -v $PWD:/data timeline-headless \
+#       timeline ingest /data/video.mp4
+#   docker run --rm -v $PWD:/data timeline-headless \
+#       timeline pipeline -i /data/video.mp4 -p tiktok -o /data/out.mp4
+
+# ──────────────────────────────────────────────────────────────────────────────
+# STAGE 1 — builder
+# ──────────────────────────────────────────────────────────────────────────────
+FROM rust:1.82-bookworm AS builder
+
+# Системные зависимости для компиляции
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    pkg-config \
+    libclang-dev \
+    clang \
+    libavcodec-dev \
+    libavformat-dev \
+    libavfilter-dev \
+    libavdevice-dev \
+    libswscale-dev \
+    libswresample-dev \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
+
+# ONNX Runtime (для ts-recognition)
+ARG ORT_VERSION=1.22.0
+RUN wget -q "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-linux-x64-${ORT_VERSION}.tgz" \
+    && tar -xzf "onnxruntime-linux-x64-${ORT_VERSION}.tgz" \
+    && cp "onnxruntime-linux-x64-${ORT_VERSION}/lib/"*.so* /usr/local/lib/ \
+    && cp -r "onnxruntime-linux-x64-${ORT_VERSION}/include/"* /usr/local/include/ \
+    && ldconfig \
+    && rm -rf "onnxruntime-linux-x64-${ORT_VERSION}"*
+
+ENV ORT_DYLIB_PATH=/usr/local/lib/libonnxruntime.so
+ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
+
+WORKDIR /src
+COPY crates/ ./crates/
+
+# Компилируем только ts-cli (и его зависимости) в release
+RUN cd crates && cargo build --release -p ts-cli
+
+# ──────────────────────────────────────────────────────────────────────────────
+# STAGE 2 — runtime
+# ──────────────────────────────────────────────────────────────────────────────
+FROM debian:bookworm-slim AS runtime
+
+# ffmpeg runtime + сертификаты для HTTPS (Telegram API)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ffmpeg \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# ONNX Runtime shared lib
+COPY --from=builder /usr/local/lib/libonnxruntime.so* /usr/local/lib/
+RUN ldconfig
+
+# timeline binary
+COPY --from=builder /src/crates/target/release/timeline /usr/local/bin/timeline
+
+# рабочая директория для монтирования данных
+WORKDIR /data
+
+ENTRYPOINT ["/usr/local/bin/timeline"]
+CMD ["--help"]


### PR DESCRIPTION
## Что

Headless Docker-образ `timeline` CLI — агент может запустить его без установки Rust/ffmpeg/ONNX.

### `docker/Dockerfile.headless` — multi-stage build

```
builder (rust:1.82-bookworm):
  apt: ffmpeg-dev + libclang + pkg-config
  ONNX Runtime 1.22.0 (headers + shared libs)
  cargo build --release -p ts-cli → /usr/local/bin/timeline

runtime (debian:bookworm-slim):
  apt: ffmpeg + ca-certificates
  COPY --from=builder libonnxruntime.so*
  COPY --from=builder timeline binary
  ENTRYPOINT: timeline
```

### `.github/workflows/docker.yml`

- Триггер: push main (`crates/**` / `Dockerfile`) + `workflow_dispatch`
- Публикует `ghcr.io/chatman-media/timeline-headless:latest` + `:sha-XXXXXX`
- BuildKit GHA cache

### `.dockerignore`

Исключает target/, node_modules/, медиа, .git — быстрый build context.

## Использование

```sh
# Собрать локально:
docker build -f docker/Dockerfile.headless -t timeline-headless .

# Запустить:
docker run --rm -v $PWD:/data timeline-headless ingest /data/video.mp4
docker run --rm -v $PWD:/data timeline-headless \
    pipeline -i /data/raw.mp4 -p tiktok -o /data/out.mp4 \
    --token TOKEN --chat @channel
```

## Закрывает

M2 #121 — Docker-образ (`timeline` + ffmpeg + ONNX).

🤖 Generated with [Claude Code](https://claude.com/claude-code)