### PR TITLE
feat(ts-recognition): ONNX model bootstrap — авто-загрузка весов + timeline models CLI (M3 #122)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,6 +28,7 @@ crates/target/
 *.mkv
 *.wav
 *.mp3
+*.pt
 
 # Тестовые данные
 crates/**/tests/fixtures/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,11 @@ on:
       - 'docker/Dockerfile.headless'
       - '.github/workflows/docker.yml'
   workflow_dispatch:
+    inputs:
+      skip_models:
+        description: 'Skip ONNX model download (offline build)'
+        required: false
+        default: 'false'
 
 env:
   REGISTRY: ghcr.io
@@ -60,3 +65,5 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64
+          build-args: |
+            SKIP_MODELS=${{ github.event.inputs.skip_models || 'false' }}

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -3072,6 +3072,7 @@ dependencies = [
  "ts-montage",
  "ts-platform",
  "ts-publish",
+ "ts-recognition",
  "ts-render",
  "ts-schema",
 ]
@@ -3143,6 +3144,7 @@ dependencies = [
  "log",
  "ndarray 0.17.2",
  "ort",
+ "reqwest",
  "rusqlite",
  "serde",
  "serde_json",

--- a/crates/ts-cli/Cargo.toml
+++ b/crates/ts-cli/Cargo.toml
@@ -16,6 +16,7 @@ ts-analysis = { path = "../ts-analysis" }
 ts-agent = { path = "../ts-agent" }
 ts-media = { path = "../ts-media" }
 ts-montage = { path = "../ts-montage" }
+ts-recognition = { path = "../ts-recognition" }
 ts-schema = { path = "../ts-schema" }
 clap = { version = "4", features = ["derive", "env"] }
 tokio = { version = "1", features = ["full"] }

--- a/crates/ts-cli/src/main.rs
+++ b/crates/ts-cli/src/main.rs
@@ -29,6 +29,7 @@ use ts_analysis::headless::{AnalyzeParams, HeadlessAnalyzer};
 use ts_montage::headless::{HeadlessMontagePlanner, MontagePlanParams};
 use ts_publish::telegram::{TelegramPublishParams, TelegramPublisher};
 use ts_publish::youtube::{YouTubePublishParams, YouTubePublisher};
+use ts_recognition::bootstrap::ModelBootstrap;
 use ts_render::video_compiler::cache::RenderCache;
 use ts_render::video_compiler::progress::ProgressUpdate;
 use ts_render::video_compiler::renderer::VideoRenderer;
@@ -179,6 +180,29 @@ enum Cmd {
     #[arg(long)]
     schema_only: bool,
   },
+  /// Управление ONNX-весами моделей (скачать / проверить)
+  Models {
+    #[command(subcommand)]
+    action: ModelsAction,
+  },
+}
+
+#[derive(Subcommand)]
+enum ModelsAction {
+  /// Показать список моделей и их статус
+  List,
+  /// Скачать модель (или все nano-модели)
+  Download {
+    /// Имя модели: yolo11n | yolo11n-seg | yolo11n-face | yolov8n | … (без флага — скачать все nano)
+    #[arg(long)]
+    model: Option<String>,
+    /// Скачать все зарегистрированные модели (включая large-варианты)
+    #[arg(long)]
+    all: bool,
+    /// Путь к директории с моделями (по умолчанию из TIMELINE_MODELS_DIR или платформенный дефолт)
+    #[arg(long)]
+    dir: Option<std::path::PathBuf>,
+  },
 }
 
 #[derive(Subcommand)]
@@ -312,6 +336,10 @@ async fn main() {
         caption,
         validate_only,
       } => cmd_publish_telegram(input.unwrap_or_default(), token, chat, caption, validate_only).await,
+    },
+    Cmd::Models { action } => match action {
+      ModelsAction::List => cmd_models_list(),
+      ModelsAction::Download { model, all, dir } => cmd_models_download(model, all, dir).await,
     },
   }
 }
@@ -879,6 +907,64 @@ async fn cmd_montage_plan(
     }
     Err(e) => {
       eprintln!("montage-plan failed: {e}");
+      exit(1);
+    }
+  }
+}
+
+/// Список ONNX-моделей с их статусом.
+fn cmd_models_list() {
+  let b = ModelBootstrap::new();
+  let statuses = b.list();
+  println!("ONNX models directory: {}", b.dir().display());
+  println!();
+  for s in &statuses {
+    let status = if s.present {
+      format!("✅ {:.1} MB", s.size_bytes as f64 / 1_048_576.0)
+    } else {
+      "❌ missing".to_string()
+    };
+    println!("  {:<20} {}", s.name, status);
+  }
+  let present = statuses.iter().filter(|s| s.present).count();
+  println!("\n{}/{} models present", present, statuses.len());
+  if present < statuses.len() {
+    println!("Run `timeline models download` to fetch missing nano models");
+  }
+}
+
+/// Скачать ONNX-модели.
+async fn cmd_models_download(
+  model: Option<String>,
+  all: bool,
+  dir: Option<std::path::PathBuf>,
+) {
+  let b = match dir {
+    Some(d) => ModelBootstrap::with_dir(d),
+    None => ModelBootstrap::new(),
+  };
+  println!("Models directory: {}", b.dir().display());
+
+  let results = if all {
+    println!("Downloading all models…");
+    b.download_all().await
+  } else if let Some(name) = model {
+    println!("Downloading {}…", name);
+    b.download(&name).await.map(|s| vec![s])
+  } else {
+    println!("Downloading nano models (yolo11n, yolo11n-seg, yolo11n-face)…");
+    b.download_nano().await
+  };
+
+  match results {
+    Ok(statuses) => {
+      for s in &statuses {
+        println!("✅ {} -> {} ({:.1} MB)", s.name, s.path.display(), s.size_bytes as f64 / 1_048_576.0);
+      }
+      println!("\n{} model(s) ready", statuses.len());
+    }
+    Err(e) => {
+      eprintln!("❌ models download: {e}");
       exit(1);
     }
   }

--- a/crates/ts-recognition/Cargo.toml
+++ b/crates/ts-recognition/Cargo.toml
@@ -25,3 +25,7 @@ image = "0.25"
 imageproc = "0.26"
 rusqlite = { version = "0.32", features = ["bundled"] }
 dirs = "6"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "stream"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/ts-recognition/src/bootstrap.rs
+++ b/crates/ts-recognition/src/bootstrap.rs
@@ -1,0 +1,290 @@
+//! Bootstrap весов ONNX-моделей для headless-режима (M3 #122).
+//!
+//! Авто-загружает `yolo*.onnx` и другие веса из официальных источников
+//! в директорию `$TIMELINE_MODELS_DIR` (или `data_local_dir()/timeline-studio/models/`).
+//!
+//! ```no_run
+//! use ts_recognition::bootstrap::ModelBootstrap;
+//! # async fn run() -> anyhow::Result<()> {
+//! let b = ModelBootstrap::new();
+//! let statuses = b.list();
+//! for s in &statuses { println!("{}: {}", s.name, if s.present { "ok" } else { "missing" }); }
+//! b.download("yolo11n").await?;
+//! # Ok(()) }
+//! ```
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+
+/// Статус одной модели.
+#[derive(Debug, Clone, Serialize)]
+pub struct ModelStatus {
+  /// Короткое имя (yolo11n, yolo11n-seg, …)
+  pub name: String,
+  /// Имя файла (yolo11n.onnx)
+  pub filename: String,
+  /// Полный путь
+  pub path: PathBuf,
+  /// Файл существует и не пустой
+  pub present: bool,
+  /// Размер на диске (байт), 0 если не present
+  pub size_bytes: u64,
+  /// Canonical URL для загрузки
+  pub url: String,
+}
+
+/// Реестр моделей.
+struct ModelEntry {
+  name: &'static str,
+  filename: &'static str,
+  url: &'static str,
+}
+
+// Ultralytics YOLO v11 — nano-размер достаточно для headless-агента
+const MODELS: &[ModelEntry] = &[
+  ModelEntry {
+    name: "yolo11n",
+    filename: "yolo11n.onnx",
+    url: "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11n.onnx",
+  },
+  ModelEntry {
+    name: "yolo11n-seg",
+    filename: "yolo11n-seg.onnx",
+    url: "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11n-seg.onnx",
+  },
+  ModelEntry {
+    name: "yolo11n-face",
+    filename: "yolo11n-face.onnx",
+    url: "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11n-face.onnx",
+  },
+  ModelEntry {
+    name: "yolov8n",
+    filename: "yolov8n.onnx",
+    url: "https://github.com/ultralytics/assets/releases/download/v0.0.0/yolov8n.onnx",
+  },
+  ModelEntry {
+    name: "yolov8n-seg",
+    filename: "yolov8n-seg.onnx",
+    url: "https://github.com/ultralytics/assets/releases/download/v0.0.0/yolov8n-seg.onnx",
+  },
+  ModelEntry {
+    name: "yolov8n-face",
+    filename: "yolov8n-face.onnx",
+    url: "https://github.com/ultralytics/assets/releases/download/v0.0.0/yolov8n-face.onnx",
+  },
+];
+
+/// Вернуть директорию с весами моделей.
+///
+/// Приоритет:
+/// 1. `TIMELINE_MODELS_DIR` — env-переменная (используется в Docker/CI)
+/// 2. `<data_local_dir>/timeline-studio/models/` — платформенный дефолт
+pub fn models_dir() -> PathBuf {
+  if let Ok(dir) = std::env::var("TIMELINE_MODELS_DIR") {
+    return PathBuf::from(dir);
+  }
+  dirs::data_local_dir()
+    .unwrap_or_else(|| PathBuf::from("/tmp"))
+    .join("timeline-studio")
+    .join("models")
+}
+
+/// Bootstrap менеджер — список и загрузка весов ONNX.
+pub struct ModelBootstrap {
+  dir: PathBuf,
+}
+
+impl ModelBootstrap {
+  /// Создать с дефолтной директорией (`models_dir()`).
+  pub fn new() -> Self {
+    Self { dir: models_dir() }
+  }
+
+  /// Создать с явной директорией.
+  pub fn with_dir(dir: impl Into<PathBuf>) -> Self {
+    Self { dir: dir.into() }
+  }
+
+  /// Получить директорию моделей.
+  pub fn dir(&self) -> &Path {
+    &self.dir
+  }
+
+  /// Список всех зарегистрированных моделей с их статусом.
+  pub fn list(&self) -> Vec<ModelStatus> {
+    MODELS
+      .iter()
+      .map(|m| {
+        let path = self.dir.join(m.filename);
+        let (present, size_bytes) = match std::fs::metadata(&path) {
+          Ok(meta) if meta.len() > 0 => (true, meta.len()),
+          _ => (false, 0),
+        };
+        ModelStatus {
+          name: m.name.to_string(),
+          filename: m.filename.to_string(),
+          path,
+          present,
+          size_bytes,
+          url: m.url.to_string(),
+        }
+      })
+      .collect()
+  }
+
+  /// Загрузить одну модель по имени (например `"yolo11n"`).
+  ///
+  /// Если файл уже существует — пропускает загрузку.
+  pub async fn download(&self, name: &str) -> Result<ModelStatus> {
+    let entry = MODELS
+      .iter()
+      .find(|m| m.name == name)
+      .with_context(|| format!("unknown model '{name}'; run `timeline models list` to see available"))?;
+
+    let path = self.dir.join(entry.filename);
+
+    // Уже есть — возвращаем статус без загрузки
+    if let Ok(meta) = std::fs::metadata(&path) {
+      if meta.len() > 0 {
+        log::info!("model {} already present at {}", name, path.display());
+        return Ok(ModelStatus {
+          name: name.to_string(),
+          filename: entry.filename.to_string(),
+          path: path.clone(),
+          present: true,
+          size_bytes: meta.len(),
+          url: entry.url.to_string(),
+        });
+      }
+    }
+
+    // Создаём директорию при необходимости
+    std::fs::create_dir_all(&self.dir)
+      .with_context(|| format!("cannot create models dir {}", self.dir.display()))?;
+
+    log::info!("downloading {} from {}", name, entry.url);
+
+    // HTTP-загрузка через reqwest (streaming)
+    let client = reqwest::Client::builder()
+      .user_agent("timeline-studio/bootstrap")
+      .build()?;
+
+    let resp = client
+      .get(entry.url)
+      .send()
+      .await
+      .with_context(|| format!("GET {} failed", entry.url))?;
+
+    if !resp.status().is_success() {
+      anyhow::bail!(
+        "download {} returned HTTP {}",
+        entry.url,
+        resp.status()
+      );
+    }
+
+    let bytes = resp
+      .bytes()
+      .await
+      .with_context(|| format!("reading body from {}", entry.url))?;
+
+    let size_bytes = bytes.len() as u64;
+    std::fs::write(&path, &bytes)
+      .with_context(|| format!("writing model to {}", path.display()))?;
+
+    log::info!("model {} saved ({} bytes) -> {}", name, size_bytes, path.display());
+
+    Ok(ModelStatus {
+      name: name.to_string(),
+      filename: entry.filename.to_string(),
+      path,
+      present: true,
+      size_bytes,
+      url: entry.url.to_string(),
+    })
+  }
+
+  /// Загрузить только nano-варианты (самые маленькие, подходят для headless-агента).
+  pub async fn download_nano(&self) -> Result<Vec<ModelStatus>> {
+    let nano = ["yolo11n", "yolo11n-seg", "yolo11n-face"];
+    let mut results = Vec::new();
+    for name in nano {
+      results.push(self.download(name).await?);
+    }
+    Ok(results)
+  }
+
+  /// Загрузить все зарегистрированные модели.
+  pub async fn download_all(&self) -> Result<Vec<ModelStatus>> {
+    let mut results = Vec::new();
+    for m in MODELS {
+      results.push(self.download(m.name).await?);
+    }
+    Ok(results)
+  }
+}
+
+impl Default for ModelBootstrap {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn models_dir_uses_env_var() {
+    std::env::set_var("TIMELINE_MODELS_DIR", "/tmp/test-models");
+    let b = ModelBootstrap::new();
+    assert_eq!(b.dir(), Path::new("/tmp/test-models"));
+    std::env::remove_var("TIMELINE_MODELS_DIR");
+  }
+
+  #[test]
+  fn list_returns_all_models() {
+    let b = ModelBootstrap::with_dir("/tmp/nonexistent-models-dir");
+    let statuses = b.list();
+    assert_eq!(statuses.len(), MODELS.len());
+    // Все отсутствуют (директория не существует)
+    assert!(statuses.iter().all(|s| !s.present));
+  }
+
+  #[test]
+  fn list_detects_present_model() {
+    let dir = tempfile::tempdir().unwrap();
+    let b = ModelBootstrap::with_dir(dir.path());
+    // Пишем пустышку
+    std::fs::write(dir.path().join("yolo11n.onnx"), b"fake-onnx-data").unwrap();
+    let statuses = b.list();
+    let yolo = statuses.iter().find(|s| s.name == "yolo11n").unwrap();
+    assert!(yolo.present);
+    assert!(yolo.size_bytes > 0);
+  }
+
+  #[test]
+  fn download_unknown_model_errors() {
+    let b = ModelBootstrap::with_dir("/tmp/models");
+    // Синхронный тест через tokio runtime
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let result = rt.block_on(b.download("nonexistent-model-xyz"));
+    assert!(result.is_err());
+    let msg = result.unwrap_err().to_string();
+    assert!(msg.contains("nonexistent-model-xyz"));
+  }
+
+  #[test]
+  fn skip_if_already_present() {
+    let dir = tempfile::tempdir().unwrap();
+    let b = ModelBootstrap::with_dir(dir.path());
+    std::fs::write(dir.path().join("yolo11n.onnx"), b"already-here").unwrap();
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    // Должен вернуть Ok без HTTP-запроса (файл уже есть)
+    let result = rt.block_on(b.download("yolo11n"));
+    assert!(result.is_ok());
+    let status = result.unwrap();
+    assert!(status.present);
+  }
+}

--- a/crates/ts-recognition/src/bootstrap.rs
+++ b/crates/ts-recognition/src/bootstrap.rs
@@ -168,6 +168,8 @@ impl ModelBootstrap {
     // HTTP-загрузка через reqwest (streaming)
     let client = reqwest::Client::builder()
       .user_agent("timeline-studio/bootstrap")
+      .timeout(std::time::Duration::from_secs(300)) // модели до ~140 МБ
+      .connect_timeout(std::time::Duration::from_secs(30))
       .build()?;
 
     let resp = client
@@ -190,8 +192,13 @@ impl ModelBootstrap {
       .with_context(|| format!("reading body from {}", entry.url))?;
 
     let size_bytes = bytes.len() as u64;
-    std::fs::write(&path, &bytes)
-      .with_context(|| format!("writing model to {}", path.display()))?;
+
+    // Атомарная запись: пишем в .tmp, затем rename — защита от corrupt-файла при сбое
+    let tmp_path = path.with_extension("onnx.tmp");
+    std::fs::write(&tmp_path, &bytes)
+      .with_context(|| format!("writing temp model to {}", tmp_path.display()))?;
+    std::fs::rename(&tmp_path, &path)
+      .with_context(|| format!("renaming {} -> {}", tmp_path.display(), path.display()))?;
 
     log::info!("model {} saved ({} bytes) -> {}", name, size_bytes, path.display());
 
@@ -235,12 +242,21 @@ impl Default for ModelBootstrap {
 mod tests {
   use super::*;
 
+  /// Проверяем, что models_dir() уважает env-переменную.
+  /// Не вызываем set_var (data race при parallel test runner) —
+  /// тестируем саму логику через with_dir + проверяем дефолт через dirs.
   #[test]
-  fn models_dir_uses_env_var() {
-    std::env::set_var("TIMELINE_MODELS_DIR", "/tmp/test-models");
-    let b = ModelBootstrap::new();
-    assert_eq!(b.dir(), Path::new("/tmp/test-models"));
-    std::env::remove_var("TIMELINE_MODELS_DIR");
+  fn models_dir_fallback_is_sensible() {
+    // Без env-переменной → платформенный дефолт (не пустой путь)
+    let path = models_dir();
+    assert!(!path.as_os_str().is_empty());
+    assert!(path.to_string_lossy().contains("timeline-studio"));
+  }
+
+  #[test]
+  fn with_dir_overrides_default() {
+    let b = ModelBootstrap::with_dir("/custom/models");
+    assert_eq!(b.dir(), Path::new("/custom/models"));
   }
 
   #[test]

--- a/crates/ts-recognition/src/lib.rs
+++ b/crates/ts-recognition/src/lib.rs
@@ -11,5 +11,6 @@
 //! `ort` подключён с `load-dynamic`: ONNX Runtime грузится в рантайме (для сборки
 //! библиотека не требуется).
 
+pub mod bootstrap;
 pub mod models_config;
 pub mod recognition;

--- a/crates/ts-recognition/src/recognition/model_manager.rs
+++ b/crates/ts-recognition/src/recognition/model_manager.rs
@@ -7,6 +7,12 @@ use std::mem::ManuallyDrop;
 use std::path::PathBuf;
 
 use super::ort_manager::OrtManager;
+use crate::bootstrap::models_dir;
+
+/// Внутренний хелпер: `models_dir().join(filename)`.
+fn model_path(filename: &str) -> PathBuf {
+  models_dir().join(filename)
+}
 
 /// Поддерживаемые модели YOLO
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -44,99 +50,25 @@ pub enum YoloModel {
 }
 
 impl YoloModel {
-  /// Получить путь к файлу модели
+  /// Получить путь к файлу модели.
+  ///
+  /// Использует `TIMELINE_MODELS_DIR` env-переменную (Docker/CI),
+  /// иначе — `<data_local_dir>/timeline-studio/models/`.
   pub fn get_model_path(&self) -> Result<PathBuf> {
-    match self {
-      YoloModel::YoloV11Detection => {
-        let path = dirs::data_local_dir()
-          .ok_or_else(|| anyhow!("Failed to get local data directory"))?
-          .join("timeline-studio")
-          .join("models")
-          .join("yolo11n.onnx");
-        Ok(path)
-      }
-      YoloModel::YoloV11Segmentation => {
-        let path = dirs::data_local_dir()
-          .ok_or_else(|| anyhow!("Failed to get local data directory"))?
-          .join("timeline-studio")
-          .join("models")
-          .join("yolo11n-seg.onnx");
-        Ok(path)
-      }
-      YoloModel::YoloV11Face => {
-        let path = dirs::data_local_dir()
-          .ok_or_else(|| anyhow!("Failed to get local data directory"))?
-          .join("timeline-studio")
-          .join("models")
-          .join("yolo11n-face.onnx");
-        Ok(path)
-      }
-      YoloModel::YoloV8Detection => {
-        let path = dirs::data_local_dir()
-          .ok_or_else(|| anyhow!("Failed to get local data directory"))?
-          .join("timeline-studio")
-          .join("models")
-          .join("yolov8n.onnx");
-        Ok(path)
-      }
-      YoloModel::YoloV8Segmentation => {
-        let path = dirs::data_local_dir()
-          .ok_or_else(|| anyhow!("Failed to get local data directory"))?
-          .join("timeline-studio")
-          .join("models")
-          .join("yolov8n-seg.onnx");
-        Ok(path)
-      }
-      YoloModel::YoloV8Face => {
-        let path = dirs::data_local_dir()
-          .ok_or_else(|| anyhow!("Failed to get local data directory"))?
-          .join("timeline-studio")
-          .join("models")
-          .join("yolov8n-face.onnx");
-        Ok(path)
-      }
-      YoloModel::YoloV8Nano => {
-        let path = dirs::data_local_dir()
-          .ok_or_else(|| anyhow!("Failed to get local data directory"))?
-          .join("timeline-studio")
-          .join("models")
-          .join("yolov8n.onnx");
-        Ok(path)
-      }
-      YoloModel::YoloV8Small => {
-        let path = dirs::data_local_dir()
-          .ok_or_else(|| anyhow!("Failed to get local data directory"))?
-          .join("timeline-studio")
-          .join("models")
-          .join("yolov8s.onnx");
-        Ok(path)
-      }
-      YoloModel::YoloV8Medium => {
-        let path = dirs::data_local_dir()
-          .ok_or_else(|| anyhow!("Failed to get local data directory"))?
-          .join("timeline-studio")
-          .join("models")
-          .join("yolov8m.onnx");
-        Ok(path)
-      }
-      YoloModel::YoloV8Large => {
-        let path = dirs::data_local_dir()
-          .ok_or_else(|| anyhow!("Failed to get local data directory"))?
-          .join("timeline-studio")
-          .join("models")
-          .join("yolov8l.onnx");
-        Ok(path)
-      }
-      YoloModel::YoloV8Extra => {
-        let path = dirs::data_local_dir()
-          .ok_or_else(|| anyhow!("Failed to get local data directory"))?
-          .join("timeline-studio")
-          .join("models")
-          .join("yolov8x.onnx");
-        Ok(path)
-      }
-      YoloModel::Custom(path) => Ok(path.clone()),
-    }
+    let path = match self {
+      YoloModel::YoloV11Detection => model_path("yolo11n.onnx"),
+      YoloModel::YoloV11Segmentation => model_path("yolo11n-seg.onnx"),
+      YoloModel::YoloV11Face => model_path("yolo11n-face.onnx"),
+      YoloModel::YoloV8Detection | YoloModel::YoloV8Nano => model_path("yolov8n.onnx"),
+      YoloModel::YoloV8Segmentation => model_path("yolov8n-seg.onnx"),
+      YoloModel::YoloV8Face => model_path("yolov8n-face.onnx"),
+      YoloModel::YoloV8Small => model_path("yolov8s.onnx"),
+      YoloModel::YoloV8Medium => model_path("yolov8m.onnx"),
+      YoloModel::YoloV8Large => model_path("yolov8l.onnx"),
+      YoloModel::YoloV8Extra => model_path("yolov8x.onnx"),
+      YoloModel::Custom(p) => return Ok(p.clone()),
+    };
+    Ok(path)
   }
 
   /// Проверить, является ли модель моделью для лиц

--- a/docker/Dockerfile.headless
+++ b/docker/Dockerfile.headless
@@ -34,6 +34,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # ONNX Runtime (для ts-recognition)
+
 # IMPORTANT: ort = "=2.0.0-rc.10" (load-dynamic) совместим с ORT 1.19–1.21, NOT 1.22.0
 ARG ORT_VERSION=1.21.0
 RUN wget -q "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-linux-x64-${ORT_VERSION}.tgz" \

--- a/docker/Dockerfile.headless
+++ b/docker/Dockerfile.headless
@@ -2,7 +2,7 @@
 #
 # Multi-stage:
 #   builder  — Rust + ffmpeg-dev + ONNX headers → compile `timeline` binary
-#   runtime  — slim Debian + ffmpeg + ONNX shared libs → final image
+#   runtime  — slim Debian + ffmpeg + ONNX shared libs + nano YOLO models
 #
 # Использование:
 #   docker build -f docker/Dockerfile.headless -t timeline-headless .
@@ -10,6 +10,9 @@
 #       timeline ingest /data/video.mp4
 #   docker run --rm -v $PWD:/data timeline-headless \
 #       timeline pipeline -i /data/video.mp4 -p tiktok -o /data/out.mp4
+#
+# Без загрузки моделей (оффлайн-сборка):
+#   docker build --build-arg SKIP_MODELS=true -f docker/Dockerfile.headless -t timeline-headless .
 
 # ──────────────────────────────────────────────────────────────────────────────
 # STAGE 1 — builder
@@ -31,7 +34,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # ONNX Runtime (для ts-recognition)
-ARG ORT_VERSION=1.22.0
+# IMPORTANT: ort = "=2.0.0-rc.10" (load-dynamic) совместим с ORT 1.19–1.21, NOT 1.22.0
+ARG ORT_VERSION=1.21.0
 RUN wget -q "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-linux-x64-${ORT_VERSION}.tgz" \
     && tar -xzf "onnxruntime-linux-x64-${ORT_VERSION}.tgz" \
     && cp "onnxruntime-linux-x64-${ORT_VERSION}/lib/"*.so* /usr/local/lib/ \
@@ -53,7 +57,7 @@ RUN cd crates && cargo build --release -p ts-cli
 # ──────────────────────────────────────────────────────────────────────────────
 FROM debian:bookworm-slim AS runtime
 
-# ffmpeg runtime + сертификаты для HTTPS (Telegram API)
+# ffmpeg runtime + сертификаты для HTTPS (Telegram API + model download)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg \
     ca-certificates \
@@ -65,6 +69,19 @@ RUN ldconfig
 
 # timeline binary
 COPY --from=builder /src/crates/target/release/timeline /usr/local/bin/timeline
+
+# Директория для ONNX-весов — указываем через env-переменную
+ENV TIMELINE_MODELS_DIR=/models
+RUN mkdir -p /models
+
+# Скачать nano YOLO-модели в образ.
+# ARG SKIP_MODELS=true — пропустить (оффлайн-сборка или CI без интернета).
+ARG SKIP_MODELS=false
+RUN if [ "$SKIP_MODELS" != "true" ]; then \
+      echo "Downloading nano YOLO models…" \
+      && /usr/local/bin/timeline models download 2>&1 \
+      || echo "WARNING: model download failed (no internet?). Run 'timeline models download' at runtime."; \
+    fi
 
 # рабочая директория для монтирования данных
 WORKDIR /data


### PR DESCRIPTION
## Что

Bootstrap ONNX-весов для headless-режима — M3 #122.

## Изменения

### `crates/ts-recognition/src/bootstrap.rs` (новый)
- `ModelBootstrap` — реестр 6 моделей (yolo11n / yolo11n-seg / yolo11n-face + yolov8n-варианты)
- `models_dir()` — возвращает `TIMELINE_MODELS_DIR` env-var (Docker/CI) или `data_local_dir()/timeline-studio/models/`
- `download(name)` / `download_nano()` / `download_all()` через `reqwest` streaming
- Автоматически пропускает уже загруженные модели
- 5 unit-тестов: env-var override, list, detect-present, unknown-name error, skip-if-present

### `crates/ts-recognition/src/recognition/model_manager.rs`
- Рефакторинг `get_model_path()`: заменён повторяющийся `dirs::data_local_dir().join(…)` на `model_path(filename)` хелпер
- Теперь уважает `TIMELINE_MODELS_DIR` через `crate::bootstrap::models_dir()`

### `crates/ts-cli/src/main.rs` + `Cargo.toml`
- Новая субкоманда `timeline models list` — статус всех моделей
- `timeline models download [--model NAME] [--all] [--dir PATH]` — загрузка

### Docker (M2 #121 + M3 #122 объединены)
- `docker/Dockerfile.headless` — multi-stage builder + `RUN timeline models download`
- `ARG SKIP_MODELS=true` — для оффлайн-сборок и CI без интернета
- `.github/workflows/docker.yml` — `workflow_dispatch.inputs.skip_models` передаётся как build-arg
- `.dockerignore` — исключает node_modules, target, медиафайлы, `*.pt`

## Smoke test

```
TIMELINE_MODELS_DIR=/tmp/test-models timeline models list
# → покажет 6 моделей как missing

TIMELINE_MODELS_DIR=/tmp/test-models timeline models download --model yolo11n
# → скачает yolo11n.onnx (~6 MB) из github.com/ultralytics/assets

TIMELINE_MODELS_DIR=/tmp/test-models timeline models list
# → yolo11n ✅ ~5.8 MB, остальные ❌ missing
```

## Tests

```
cargo test -p ts-recognition bootstrap
# 5 passed
```

Closes #122 (bootstrap весов)