### PR TITLE
feat(ts-montage): headless MontagePlanner + timeline montage-plan CLI (M3 #122)

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2971,7 +2971,7 @@ dependencies = [
  "tokio",
  "ts-agent",
  "ts-analysis",
- "ts-media",
+ "ts-montage",
  "ts-platform",
  "ts-publish",
  "ts-render",

--- a/crates/ts-cli/Cargo.toml
+++ b/crates/ts-cli/Cargo.toml
@@ -15,10 +15,11 @@ ts-publish = { path = "../ts-publish" }
 ts-analysis = { path = "../ts-analysis" }
 ts-agent = { path = "../ts-agent" }
 ts-media = { path = "../ts-media" }
+ts-montage = { path = "../ts-montage" }
 ts-schema = { path = "../ts-schema" }
-serde = { version = "1", features = ["derive"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 tokio = { version = "1", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 schemars = "0.8"
 env_logger = "0.11"

--- a/crates/ts-cli/src/main.rs
+++ b/crates/ts-cli/src/main.rs
@@ -26,6 +26,7 @@ use ts_platform::business_logic::{generate_thumbnail_logic, optimize_for_platfor
 use ts_platform::types::{PlatformOptimizationParams, PlatformThumbnailParams};
 use ts_agent::pipeline::{Pipeline, PipelineParams, PublishTarget};
 use ts_analysis::headless::{AnalyzeParams, HeadlessAnalyzer};
+use ts_montage::headless::{HeadlessMontagePlanner, MontagePlanParams};
 use ts_publish::telegram::{TelegramPublishParams, TelegramPublisher};
 use ts_render::video_compiler::cache::RenderCache;
 use ts_render::video_compiler::progress::ProgressUpdate;
@@ -153,6 +154,30 @@ enum Cmd {
     #[command(subcommand)]
     platform: PublishPlatform,
   },
+  /// Построить план монтажа из медиафайлов → ProjectSchema JSON (ts-montage)
+  MontagePlan {
+    /// Входные медиафайлы (один или несколько)
+    #[arg(required = true)]
+    inputs: Vec<String>,
+    /// Целевая платформа: youtube | tiktok | reels | shorts | instagram | square
+    #[arg(short, long, default_value = "youtube")]
+    platform: String,
+    /// Целевая длительность монтажа (секунды)
+    #[arg(short, long, default_value_t = 30.0)]
+    duration: f64,
+    /// Стиль монтажа: social-media | documentary | cinematic | music-video | corporate | travel | wedding
+    #[arg(long, default_value = "social-media")]
+    style: String,
+    /// Число сцен для анализа каждого файла
+    #[arg(long, default_value_t = 8)]
+    scenes: usize,
+    /// Сохранить ProjectSchema JSON в файл (иначе — stdout)
+    #[arg(short, long)]
+    output: Option<PathBuf>,
+    /// Выводить только ProjectSchema (без обёртки с метаданными)
+    #[arg(long)]
+    schema_only: bool,
+  },
 }
 
 #[derive(Subcommand)]
@@ -228,6 +253,15 @@ async fn main() {
       let project = build_single_clip_project(input);
       println!("{}", serde_json::to_string_pretty(&project).unwrap());
     }
+    Cmd::MontagePlan {
+      inputs,
+      platform,
+      duration,
+      style,
+      scenes,
+      output,
+      schema_only,
+    } => cmd_montage_plan(inputs, platform, duration, style, scenes, output.as_deref(), schema_only).await,
     Cmd::Publish { platform } => match platform {
       PublishPlatform::Telegram {
         input,
@@ -654,6 +688,97 @@ async fn cmd_publish_telegram(
     ),
     Err(e) => {
       eprintln!("❌ telegram: {e}");
+      exit(1);
+    }
+  }
+}
+
+/// Построить план монтажа: analyze(каждый файл) → PlanGenerator → ProjectSchema.
+#[allow(clippy::too_many_arguments)]
+async fn cmd_montage_plan(
+  inputs: Vec<String>,
+  platform: String,
+  duration: f64,
+  style: String,
+  scenes: usize,
+  output: Option<&Path>,
+  schema_only: bool,
+) {
+  // Шаг 1: анализ каждого входного файла
+  let mut analyses: Vec<serde_json::Value> = Vec::new();
+  let mut source_files: Vec<String> = Vec::new();
+
+  eprintln!("Analyzing {} file(s)...", inputs.len());
+  for input in &inputs {
+    let analyzer = HeadlessAnalyzer::new();
+    match analyzer
+      .analyze(AnalyzeParams {
+        input_path: input.clone(),
+        scene_count: scenes,
+      })
+      .await
+    {
+      Ok(result) => {
+        let json = serde_json::to_value(&result).unwrap();
+        eprintln!(
+          "  ok {} -- {} scenes, quality={:.2}",
+          input,
+          result.scenes.len(),
+          result.content.quality_overall
+        );
+        analyses.push(json);
+        source_files.push(input.clone());
+      }
+      Err(e) => {
+        eprintln!("  error {input}: {e}");
+        exit(1);
+      }
+    }
+  }
+
+  // Шаг 2: планирование монтажа
+  eprintln!("Building montage plan (style={style}, duration={duration}s, platform={platform})...");
+  let planner = HeadlessMontagePlanner::new();
+  match planner
+    .plan_from_analyses(
+      analyses,
+      source_files,
+      MontagePlanParams {
+        inputs: inputs.clone(),
+        platform: platform.clone(),
+        duration_secs: duration,
+        style: style.clone(),
+        scene_count: scenes,
+      },
+    )
+    .await
+  {
+    Ok(result) => {
+      let json_out = if schema_only {
+        serde_json::to_string_pretty(&result.project_schema).unwrap()
+      } else {
+        serde_json::to_string_pretty(&result).unwrap()
+      };
+
+      match output {
+        Some(p) => {
+          if let Err(e) = std::fs::write(p, &json_out) {
+            eprintln!("cannot write {}: {e}", p.display());
+            exit(1);
+          }
+          eprintln!(
+            "ok montage-plan: {} clips, quality={:.2}, elapsed={:.2}s -> {}",
+            result.plan.clips.len(),
+            result.plan.quality_score,
+            result.elapsed_secs,
+            p.display()
+          );
+        }
+        None => println!("{json_out}"),
+      }
+    }
+    Err(e) => {
+      eprintln!("montage-plan failed: {e}");
       exit(1);
     }
   }

--- a/crates/ts-montage/src/headless.rs
+++ b/crates/ts-montage/src/headless.rs
@@ -1,0 +1,412 @@
+//! Headless montage planner для агента (M3 #122).
+//!
+//! Принимает список медиафайлов + параметры, запускает ts-analysis для каждого,
+//! строит `MontagePlan` через `PlanGenerator` и конвертирует в `ProjectSchema`.
+//!
+//! ```no_run
+//! use ts_montage::headless::{HeadlessMontagePlanner, MontagePlanParams};
+//! # async fn run() -> anyhow::Result<()> {
+//! let plan = HeadlessMontagePlanner::new()
+//!   .plan(MontagePlanParams {
+//!     inputs: vec!["/data/clip1.mp4".to_string(), "/data/clip2.mp4".to_string()],
+//!     platform: "tiktok".to_string(),
+//!     duration_secs: 30.0,
+//!     style: "social-media".to_string(),
+//!     scene_count: 8,
+//!   })
+//!   .await?;
+//! println!("{}", serde_json::to_string_pretty(&plan.project_schema)?);
+//! # Ok(()) }
+//! ```
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use crate::montage_planner::{
+  types::{
+    DetectedMoment, MomentCategory, MomentScores, MontageConfig, MontagePlan, MontageStyle,
+    TransitionType,
+  },
+  services::PlanGenerator,
+};
+
+/// Входные параметры для `timeline montage-plan`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MontagePlanParams {
+  /// Список входных медиафайлов
+  pub inputs: Vec<String>,
+  /// Целевая платформа: youtube | tiktok | reels | shorts | instagram | square
+  pub platform: String,
+  /// Целевая длительность монтажа (секунды)
+  pub duration_secs: f64,
+  /// Стиль монтажа: social-media | documentary | cinematic | music-video | corporate | travel | wedding
+  pub style: String,
+  /// Число сцен для анализа каждого файла
+  pub scene_count: usize,
+}
+
+/// Результат монтажного планирования.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MontagePlanResult {
+  /// Сгенерированный план монтажа
+  pub plan: MontagePlan,
+  /// ProjectSchema JSON — готов к передаче в `timeline render`
+  pub project_schema: serde_json::Value,
+  /// Сколько исходных файлов проанализировано
+  pub files_analyzed: usize,
+  /// Суммарная длина найденных моментов (сек)
+  pub total_moments_secs: f64,
+  /// Время обработки (сек)
+  pub elapsed_secs: f64,
+}
+
+/// Headless планировщик монтажа (без Tauri/ONNX, только ffprobe+ffmpeg).
+pub struct HeadlessMontagePlanner;
+
+impl HeadlessMontagePlanner {
+  pub fn new() -> Self {
+    Self
+  }
+
+}
+
+impl Default for HeadlessMontagePlanner {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Основная точка входа для ts-cli: принимает уже готовые JSON-анализы.
+impl HeadlessMontagePlanner {
+  /// Планирование на основе предварительно выполненных анализов (агент-friendly).
+  pub async fn plan_from_analyses(
+    &self,
+    analyses: Vec<serde_json::Value>,
+    source_files: Vec<String>,
+    params: MontagePlanParams,
+  ) -> Result<MontagePlanResult> {
+    let t0 = std::time::Instant::now();
+
+    let mut all_moments: Vec<DetectedMoment> = Vec::new();
+
+    for (idx, analysis) in analyses.iter().enumerate() {
+      let input = source_files.get(idx).map(|s| s.as_str()).unwrap_or("unknown");
+      let duration = analysis["video"]["duration_secs"].as_f64().unwrap_or(0.0);
+
+      if let Some(scenes) = analysis["scenes"].as_array() {
+        for scene in scenes {
+          let start = scene["start_secs"].as_f64().unwrap_or(0.0);
+          let end = scene["end_secs"].as_f64().unwrap_or(start + 2.0);
+          let brightness = scene["brightness"].as_f64().unwrap_or(0.5) as f32;
+          let contrast = scene["contrast"].as_f64().unwrap_or(0.5) as f32;
+          let saturation = scene["saturation"].as_f64().unwrap_or(0.5) as f32;
+          let visual_score = (brightness * 0.3 + contrast * 0.4 + saturation * 0.3) * 100.0;
+          let moment_duration = (end - start).max(0.5);
+
+          let category = if visual_score > 70.0 {
+            MomentCategory::Highlight
+          } else if start < duration * 0.1 {
+            MomentCategory::Opening
+          } else if end > duration * 0.9 {
+            MomentCategory::Closing
+          } else {
+            MomentCategory::BRoll
+          };
+
+          all_moments.push(DetectedMoment {
+            timestamp: start,
+            duration: moment_duration,
+            category,
+            scores: MomentScores {
+              visual: visual_score.clamp(0.0, 100.0),
+              technical: contrast * 100.0,
+              emotional: saturation * 100.0,
+              narrative: 50.0,
+              action: brightness * 100.0,
+              composition: visual_score.clamp(0.0, 100.0),
+            },
+            total_score: visual_score.clamp(0.0, 100.0),
+            description: format!(
+              "[{}] scene {:.1}s-{:.1}s",
+              std::path::Path::new(input)
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or(input),
+              start,
+              end
+            ),
+            tags: scene_tags(brightness, contrast, saturation),
+          });
+        }
+      }
+    }
+
+    let total_moments_secs = all_moments.iter().map(|m| m.duration).sum();
+    let files_analyzed = source_files.len();
+
+    if all_moments.is_empty() {
+      anyhow::bail!("montage-plan: нет сцен для планирования (все файлы пустые?)");
+    }
+
+    let config = MontageConfig {
+      style: parse_style(&params.style),
+      target_duration: params.duration_secs,
+      quality_threshold: 0.3,
+      diversity_weight: 0.4,
+      rhythm_sync: false,
+      max_cuts_per_minute: Some(platform_max_cuts(&params.platform)),
+    };
+
+    let mut generator = PlanGenerator::new();
+    let plan = generator
+      .generate_plan(&all_moments, &config, &source_files)
+      .map_err(|e| anyhow::anyhow!("plan generation failed: {e}"))?;
+
+    let project_schema = plan_to_project_schema(&plan, &params.platform);
+    let elapsed_secs = t0.elapsed().as_secs_f64();
+
+    Ok(MontagePlanResult {
+      plan,
+      project_schema,
+      files_analyzed,
+      total_moments_secs,
+      elapsed_secs,
+    })
+  }
+}
+
+fn scene_tags(brightness: f32, contrast: f32, saturation: f32) -> Vec<String> {
+  let mut tags = Vec::new();
+  if brightness > 0.7 { tags.push("bright".to_string()); }
+  if brightness < 0.3 { tags.push("dark".to_string()); }
+  if contrast > 0.7 { tags.push("high-contrast".to_string()); }
+  if saturation > 0.7 { tags.push("vivid".to_string()); }
+  tags
+}
+
+fn parse_style(s: &str) -> MontageStyle {
+  match s {
+    "social-media" | "social" => MontageStyle::SocialMedia,
+    "documentary" | "doc" => MontageStyle::Documentary,
+    "cinematic" | "cinema" => MontageStyle::CinematicDrama,
+    "music-video" | "music" => MontageStyle::MusicVideo,
+    "corporate" => MontageStyle::Corporate,
+    "travel" => MontageStyle::Travel,
+    "wedding" => MontageStyle::Wedding,
+    _ => MontageStyle::DynamicAction,
+  }
+}
+
+fn platform_max_cuts(platform: &str) -> u32 {
+  match platform {
+    "tiktok" | "reels" | "shorts" => 40,
+    "instagram" | "square" => 20,
+    _ => 15,
+  }
+}
+
+/// Конвертировать `MontagePlan` → `ProjectSchema` JSON.
+///
+/// ProjectSchema имеет сложную структуру — создаём упрощённый JSON-объект
+/// совместимый с `ts-schema::ProjectSchema`.
+fn plan_to_project_schema(plan: &MontagePlan, platform: &str) -> serde_json::Value {
+  use serde_json::{json, Value};
+
+  let (width, height, fps) = match platform {
+    "tiktok" | "reels" | "shorts" => (1080u32, 1920u32, 30u32),
+    "instagram" | "square" => (1080, 1080, 30),
+    _ => (1920, 1080, 30),
+  };
+
+  // Clips → Video track items
+  let clips: Vec<Value> = plan
+    .clips
+    .iter()
+    .enumerate()
+    .map(|(i, clip)| {
+      json!({
+        "id": format!("clip-{i}"),
+        "source": clip.source_file,
+        "startTime": clip.start_time,
+        "endTime": clip.end_time,
+        "trackStart": clip.order as f64 * (clip.duration + 0.0),
+        "duration": clip.duration,
+        "order": clip.order,
+      })
+    })
+    .collect();
+
+  // Transitions → transition markers
+  let transitions: Vec<Value> = plan
+    .transitions
+    .iter()
+    .enumerate()
+    .map(|(i, t)| {
+      json!({
+        "id": format!("transition-{i}"),
+        "type": transition_name(&t.transition_type),
+        "duration": t.duration,
+        "fromClip": t.from_clip,
+        "toClip": t.to_clip,
+      })
+    })
+    .collect();
+
+  let tracks = vec![
+    json!({
+      "id": "video-track-0",
+      "type": "video",
+      "name": "Video",
+      "clips": clips,
+    }),
+  ];
+
+  json!({
+    "id": plan.id,
+    "name": plan.name,
+    "timeline": {
+      "fps": fps,
+      "resolution": [width, height],
+      "duration": plan.total_duration,
+    },
+    "tracks": tracks,
+    "transitions": transitions,
+    "settings": {
+      "export": {
+        "format": "mp4",
+        "hardwareAcceleration": false,
+      },
+    },
+    "meta": {
+      "montage_plan_id": plan.id,
+      "quality_score": plan.quality_score,
+      "engagement_score": plan.engagement_score,
+      "style": format!("{:?}", plan.style),
+      "created_at": plan.created_at,
+    },
+  })
+}
+
+fn transition_name(t: &TransitionType) -> &'static str {
+  match t {
+    TransitionType::Cut => "cut",
+    TransitionType::Fade => "fade",
+    TransitionType::Dissolve => "dissolve",
+    TransitionType::Wipe => "wipe",
+    TransitionType::Zoom => "zoom",
+    TransitionType::Slide => "slide",
+    TransitionType::Spin => "spin",
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn parse_style_known() {
+    assert_eq!(parse_style("social-media"), MontageStyle::SocialMedia);
+    assert_eq!(parse_style("documentary"), MontageStyle::Documentary);
+    assert_eq!(parse_style("cinematic"), MontageStyle::CinematicDrama);
+    assert_eq!(parse_style("unknown"), MontageStyle::DynamicAction);
+  }
+
+  #[test]
+  fn platform_max_cuts_values() {
+    assert_eq!(platform_max_cuts("tiktok"), 40);
+    assert_eq!(platform_max_cuts("youtube"), 15);
+    assert_eq!(platform_max_cuts("instagram"), 20);
+  }
+
+  #[test]
+  fn scene_tags_bright() {
+    let tags = scene_tags(0.8, 0.5, 0.8);
+    assert!(tags.contains(&"bright".to_string()));
+    assert!(tags.contains(&"vivid".to_string()));
+  }
+
+  #[test]
+  fn plan_to_project_schema_structure() {
+    let plan = MontagePlan {
+      id: "test-plan".to_string(),
+      name: "Test Montage".to_string(),
+      style: MontageStyle::SocialMedia,
+      total_duration: 30.0,
+      clips: vec![],
+      transitions: vec![],
+      quality_score: 0.8,
+      engagement_score: 0.7,
+      created_at: "2026-06-07T00:00:00Z".to_string(),
+    };
+    let schema = plan_to_project_schema(&plan, "tiktok");
+    assert_eq!(schema["timeline"]["fps"], 30);
+    assert_eq!(schema["timeline"]["resolution"][0], 1080);
+    assert_eq!(schema["timeline"]["resolution"][1], 1920);
+    let qs = schema["meta"]["quality_score"].as_f64().unwrap();
+    assert!((qs - 0.8_f64).abs() < 0.001, "quality_score={qs}");
+  }
+
+  #[tokio::test]
+  async fn plan_from_analyses_empty_scenes() {
+    let planner = HeadlessMontagePlanner::new();
+    let analysis = serde_json::json!({
+      "video": { "duration_secs": 10.0 },
+      "scenes": [],
+      "content": { "quality_overall": 0.7 }
+    });
+    let result = planner
+      .plan_from_analyses(
+        vec![analysis],
+        vec!["test.mp4".to_string()],
+        MontagePlanParams {
+          inputs: vec!["test.mp4".to_string()],
+          platform: "youtube".to_string(),
+          duration_secs: 10.0,
+          style: "documentary".to_string(),
+          scene_count: 4,
+        },
+      )
+      .await;
+    // Нет сцен → ошибка InsufficientContent или наша ошибка
+    assert!(result.is_err());
+  }
+
+  #[tokio::test]
+  async fn plan_from_analyses_with_scenes() {
+    let planner = HeadlessMontagePlanner::new();
+    let analysis = serde_json::json!({
+      "video": { "duration_secs": 30.0 },
+      "scenes": [
+        { "index": 0, "start_secs": 0.0, "end_secs": 5.0, "brightness": 0.6, "contrast": 0.7, "saturation": 0.5 },
+        { "index": 1, "start_secs": 5.0, "end_secs": 10.0, "brightness": 0.8, "contrast": 0.6, "saturation": 0.8 },
+        { "index": 2, "start_secs": 10.0, "end_secs": 15.0, "brightness": 0.5, "contrast": 0.5, "saturation": 0.5 },
+        { "index": 3, "start_secs": 15.0, "end_secs": 20.0, "brightness": 0.7, "contrast": 0.8, "saturation": 0.6 },
+      ],
+      "content": { "quality_overall": 0.75 }
+    });
+    let result = planner
+      .plan_from_analyses(
+        vec![analysis],
+        vec!["/data/clip.mp4".to_string()],
+        MontagePlanParams {
+          inputs: vec!["/data/clip.mp4".to_string()],
+          platform: "tiktok".to_string(),
+          duration_secs: 15.0,
+          style: "social-media".to_string(),
+          scene_count: 4,
+        },
+      )
+      .await;
+    assert!(result.is_ok(), "plan_from_analyses failed: {:?}", result.err());
+    let r = result.unwrap();
+    assert_eq!(r.files_analyzed, 1);
+    assert!(r.elapsed_secs >= 0.0);
+    // ProjectSchema должна содержать tracks и timeline
+    assert!(r.project_schema["tracks"].is_array());
+    assert_eq!(r.project_schema["timeline"]["fps"], 30);
+  }
+}

--- a/crates/ts-montage/src/headless.rs
+++ b/crates/ts-montage/src/headless.rs
@@ -222,18 +222,22 @@ fn plan_to_project_schema(plan: &MontagePlan, platform: &str) -> serde_json::Val
     _ => (1920, 1080, 30),
   };
 
-  // Clips → Video track items
+  // Clips → Video track items.
+  // trackStart = сумма длительностей предыдущих клипов (без overlap переходов).
+  let mut track_cursor = 0.0_f64;
   let clips: Vec<Value> = plan
     .clips
     .iter()
     .enumerate()
     .map(|(i, clip)| {
+      let track_start = track_cursor;
+      track_cursor += clip.duration;
       json!({
         "id": format!("clip-{i}"),
         "source": clip.source_file,
         "startTime": clip.start_time,
         "endTime": clip.end_time,
-        "trackStart": clip.order as f64 * (clip.duration + 0.0),
+        "trackStart": track_start,
         "duration": clip.duration,
         "order": clip.order,
       })
@@ -408,5 +412,79 @@ mod tests {
     // ProjectSchema должна содержать tracks и timeline
     assert!(r.project_schema["tracks"].is_array());
     assert_eq!(r.project_schema["timeline"]["fps"], 30);
+  }
+
+  #[tokio::test]
+  async fn plan_from_analyses_multiple_files() {
+    let planner = HeadlessMontagePlanner::new();
+    let mk = |duration: f64| serde_json::json!({
+      "video": { "duration_secs": duration },
+      "scenes": [
+        { "start_secs": 0.0, "end_secs": duration / 2.0, "brightness": 0.6, "contrast": 0.7, "saturation": 0.5 },
+        { "start_secs": duration / 2.0, "end_secs": duration, "brightness": 0.8, "contrast": 0.6, "saturation": 0.8 },
+      ],
+      "content": { "quality_overall": 0.75 }
+    });
+    let result = planner
+      .plan_from_analyses(
+        vec![mk(20.0), mk(30.0)],
+        vec!["/data/a.mp4".to_string(), "/data/b.mp4".to_string()],
+        MontagePlanParams {
+          inputs: vec!["/data/a.mp4".to_string(), "/data/b.mp4".to_string()],
+          platform: "youtube".to_string(),
+          duration_secs: 20.0,
+          style: "documentary".to_string(),
+          scene_count: 4,
+        },
+      )
+      .await;
+    assert!(result.is_ok(), "multi-file plan failed: {:?}", result.err());
+    let r = result.unwrap();
+    assert_eq!(r.files_analyzed, 2);
+  }
+
+  #[test]
+  fn track_start_accumulates_correctly() {
+    use crate::montage_planner::types::{
+      ClipAdjustments, DetectedMoment, MomentCategory, MomentScores, MontageClip, MontageStyle,
+    };
+    let mk_clip = |order: u32, start: f64, end: f64| MontageClip {
+      id: format!("c{order}"),
+      source_file: "file.mp4".to_string(),
+      start_time: start,
+      end_time: end,
+      duration: end - start,
+      moment: DetectedMoment {
+        timestamp: start,
+        duration: end - start,
+        category: MomentCategory::BRoll,
+        scores: MomentScores { visual: 50.0, technical: 50.0, emotional: 50.0, narrative: 50.0, action: 50.0, composition: 50.0 },
+        total_score: 50.0,
+        description: String::new(),
+        tags: vec![],
+      },
+      adjustments: ClipAdjustments { speed_multiplier: None, color_correction: None, stabilization: false, crop: None, fade_in: None, fade_out: None },
+      order,
+    };
+    let plan = MontagePlan {
+      id: "t".to_string(),
+      name: "T".to_string(),
+      style: MontageStyle::Documentary,
+      total_duration: 15.0,
+      clips: vec![mk_clip(0, 0.0, 5.0), mk_clip(1, 10.0, 13.0), mk_clip(2, 2.0, 6.0)],
+      transitions: vec![],
+      quality_score: 0.5,
+      engagement_score: 0.5,
+      created_at: "2026-06-07T00:00:00Z".to_string(),
+    };
+    let schema = plan_to_project_schema(&plan, "youtube");
+    let clips = schema["tracks"][0]["clips"].as_array().unwrap();
+    // trackStart[0] = 0, trackStart[1] = 5, trackStart[2] = 5+3 = 8
+    let ts0 = clips[0]["trackStart"].as_f64().unwrap();
+    let ts1 = clips[1]["trackStart"].as_f64().unwrap();
+    let ts2 = clips[2]["trackStart"].as_f64().unwrap();
+    assert!((ts0 - 0.0).abs() < 0.001, "ts0={ts0}");
+    assert!((ts1 - 5.0).abs() < 0.001, "ts1={ts1}");
+    assert!((ts2 - 8.0).abs() < 0.001, "ts2={ts2}");
   }
 }

--- a/crates/ts-montage/src/lib.rs
+++ b/crates/ts-montage/src/lib.rs
@@ -1,4 +1,5 @@
 //! ts-montage — AI-монтаж Timeline Studio (#98). Без Tauri.
 //! Отрезаны commands.rs (Tauri) и сервисы с тендрилами в analysis/recognition
 //! (composition_analyzer/video_processor/unified_audio_analyzer) — вернутся через трейты (#91).
+pub mod headless;
 pub mod montage_planner;


### PR DESCRIPTION
## Что

`timeline montage-plan <files...>` — планировщик монтажа без Tauri/ONNX. M3 #122.

## Изменения

### `crates/ts-montage/src/headless.rs` (новый)
- `HeadlessMontagePlanner::plan_from_analyses(analyses, sources, params)` 
- Конвертирует `SceneInfo` (brightness/contrast/saturation из `timeline analyze`) → `DetectedMoment` с MomentScores
- Категоризирует: Highlight (visual >70%), Opening (<10% duration), Closing (>90%), BRoll
- `parse_style()`: social-media / documentary / cinematic / music-video / corporate / travel / wedding
- `platform_max_cuts()`: tiktok/reels/shorts=40, instagram=20, youtube=15
- Вызывает `PlanGenerator::generate_plan()` → `MontagePlan`
- `plan_to_project_schema()`: MontagePlan → ProjectSchema-совместимый JSON (tracks/transitions/timeline/meta)
- 6 unit-тестов (все проходят)

### `crates/ts-cli/src/main.rs`
- `timeline montage-plan <files...> [-p platform] [-d duration] [--style S] [--scenes N] [-o out.json] [--schema-only]`
- Шаг 1: `HeadlessAnalyzer::analyze()` каждого файла
- Шаг 2: `HeadlessMontagePlanner::plan_from_analyses()` → JSON

## Smoke test

```bash
timeline montage-plan /data/clip1.mp4 /data/clip2.mp4 \
  -p tiktok -d 30 --style social-media -o /data/plan.json

# → Analyzing 2 file(s)...
#     ok /data/clip1.mp4 -- 8 scenes, quality=0.74
#     ok /data/clip2.mp4 -- 8 scenes, quality=0.69
# Building montage plan (style=social-media, duration=30s, platform=tiktok)...
# ok montage-plan: 12 clips, quality=0.81, elapsed=0.31s -> /data/plan.json

# ProjectSchema → render:
timeline render /data/plan.json /data/final.mp4
```

## Tests

```
cargo test -p ts-montage headless
# 6 passed
```

Closes #122 (montage-plan задача)