### PR TITLE
feat(ts-core-types): foundation crate — progress types + headless EventBus (#94)

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -3069,12 +3069,26 @@ dependencies = [
  "tokio",
  "ts-agent",
  "ts-analysis",
+ "ts-media",
  "ts-montage",
  "ts-platform",
  "ts-publish",
  "ts-recognition",
  "ts-render",
  "ts-schema",
+]
+
+[[package]]
+name = "ts-core-types"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-test",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -4,6 +4,7 @@
 [workspace]
 resolver = "2"
 members = [
+  "ts-core-types",
   "ts-cli",
   "ts-agent",
   "ts-platform", "ts-publish",

--- a/crates/ts-core-types/Cargo.toml
+++ b/crates/ts-core-types/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "ts-core-types"
+version = "0.1.0"
+edition = "2021"
+description = "Фундаментальные типы Timeline Studio: ошибки, прогресс, EventBus — без Tauri/ORT/specta. #94"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "1"
+tokio = { version = "1", features = ["sync", "rt"] }
+log = "0.4"
+uuid = { version = "1", features = ["v4"] }
+
+[dev-dependencies]
+tokio-test = "0.4"
+serde_json = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/ts-core-types/src/error.rs
+++ b/crates/ts-core-types/src/error.rs
@@ -1,0 +1,92 @@
+//! Общие error-типы для всех движков Timeline Studio.
+
+use thiserror::Error;
+
+/// Лёгкий общий error-тип, не тянущий тяжёлых зависимостей.
+///
+/// Используется как базовый `?`-конвертируемый тип в `ts-agent`,
+/// `ts-analysis`, `ts-publish` и других крейтах.
+#[derive(Debug, Error)]
+pub enum CoreError {
+    /// Операция введённых/выходных данных завершилась неудачно.
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// Ошибка сериализации/десериализации JSON.
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// Задача была отменена.
+    #[error("Operation cancelled")]
+    Cancelled,
+
+    /// Превышен лимит времени ожидания.
+    #[error("Operation timed out")]
+    Timeout,
+
+    /// Переданы некорректные входные данные.
+    #[error("Invalid input: {0}")]
+    InvalidInput(String),
+
+    /// Ресурс не найден.
+    #[error("Not found: {0}")]
+    NotFound(String),
+
+    /// Произошла внутренняя ошибка.
+    #[error("Internal error: {0}")]
+    Internal(String),
+}
+
+impl CoreError {
+    /// Удобный конструктор для [`CoreError::Internal`].
+    pub fn internal(msg: impl Into<String>) -> Self {
+        CoreError::Internal(msg.into())
+    }
+
+    /// Удобный конструктор для [`CoreError::InvalidInput`].
+    pub fn invalid_input(msg: impl Into<String>) -> Self {
+        CoreError::InvalidInput(msg.into())
+    }
+
+    /// Удобный конструктор для [`CoreError::NotFound`].
+    pub fn not_found(msg: impl Into<String>) -> Self {
+        CoreError::NotFound(msg.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constructors() {
+        let e = CoreError::internal("boom");
+        assert!(e.to_string().contains("boom"));
+
+        let e = CoreError::not_found("file.mp4");
+        assert!(e.to_string().contains("file.mp4"));
+
+        let e = CoreError::invalid_input("bad fps");
+        assert!(e.to_string().contains("bad fps"));
+    }
+
+    #[test]
+    fn from_io_error() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file missing");
+        let core_err: CoreError = io_err.into();
+        assert!(matches!(core_err, CoreError::Io(_)));
+    }
+
+    #[test]
+    fn from_json_error() {
+        let json_err = serde_json::from_str::<serde_json::Value>("{bad}").unwrap_err();
+        let core_err: CoreError = json_err.into();
+        assert!(matches!(core_err, CoreError::Json(_)));
+    }
+
+    #[test]
+    fn cancel_and_timeout_display() {
+        assert_eq!(CoreError::Cancelled.to_string(), "Operation cancelled");
+        assert_eq!(CoreError::Timeout.to_string(), "Operation timed out");
+    }
+}

--- a/crates/ts-core-types/src/events.rs
+++ b/crates/ts-core-types/src/events.rs
@@ -1,0 +1,226 @@
+//! Headless [`EventBus`] — mpsc-шина событий без Tauri/specta.
+//!
+//! В production-Tauri-приложении `src-tauri/src/core/events.rs` содержит
+//! более богатую реализацию с `specta::Type` и Tauri-emit. Этот модуль —
+//! облегчённый вариант только с tokio, пригодный в CLI / тестах / headless-рендере.
+
+use crate::progress::ProgressUpdate;
+use std::sync::Arc;
+use tokio::sync::broadcast;
+
+/// Ёмкость кольцевого буфера broadcast-канала по умолчанию.
+const DEFAULT_CAPACITY: usize = 256;
+
+/// Высокоуровневое событие приложения Timeline Studio.
+///
+/// Новые варианты добавляются без breaking change — получатели
+/// игнорируют незнакомые (через `_ => {}`).
+#[derive(Debug, Clone)]
+pub enum AppEvent {
+    /// Обновление прогресса рендеринга.
+    Progress(ProgressUpdate),
+    /// Информационное сообщение (для логов / UI-нотификаций).
+    Info(String),
+    /// Некритичное предупреждение.
+    Warning(String),
+    /// Критичная ошибка, требующая внимания пользователя.
+    Error(String),
+    /// Приложение завершает работу — слушатели должны остановиться.
+    Shutdown,
+}
+
+impl AppEvent {
+    /// Возвращает короткое имя варианта для логирования.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            AppEvent::Progress(_) => "Progress",
+            AppEvent::Info(_) => "Info",
+            AppEvent::Warning(_) => "Warning",
+            AppEvent::Error(_) => "Error",
+            AppEvent::Shutdown => "Shutdown",
+        }
+    }
+}
+
+/// Headless шина событий на базе `tokio::sync::broadcast`.
+///
+/// Клонирование `EventBus` — бесплатно (внутри `Arc`).
+///
+/// # Пример
+/// ```rust
+/// use ts_core_types::events::{AppEvent, EventBus};
+///
+/// # tokio_test::block_on(async {
+/// let bus = EventBus::new();
+/// let mut rx = bus.subscribe();
+///
+/// bus.emit(AppEvent::Info("hello".into())).await;
+///
+/// let event = rx.recv().await.unwrap();
+/// assert!(matches!(event, AppEvent::Info(_)));
+/// # });
+/// ```
+#[derive(Clone)]
+pub struct EventBus {
+    inner: Arc<EventBusInner>,
+}
+
+struct EventBusInner {
+    tx: broadcast::Sender<AppEvent>,
+}
+
+impl std::fmt::Debug for EventBus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EventBus")
+            .field("receiver_count", &self.inner.tx.receiver_count())
+            .finish()
+    }
+}
+
+impl EventBus {
+    /// Создаёт новый `EventBus` с ёмкостью [`DEFAULT_CAPACITY`].
+    pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_CAPACITY)
+    }
+
+    /// Создаёт `EventBus` с указанной ёмкостью кольцевого буфера.
+    pub fn with_capacity(capacity: usize) -> Self {
+        let (tx, _) = broadcast::channel(capacity);
+        EventBus {
+            inner: Arc::new(EventBusInner { tx }),
+        }
+    }
+
+    /// Отправляет событие всем активным подписчикам.
+    ///
+    /// Не блокирует — если буфер переполнен, старые события вытесняются.
+    /// Возвращает количество получателей, которым доставлено событие.
+    pub async fn emit(&self, event: AppEvent) -> usize {
+        match self.inner.tx.send(event) {
+            Ok(n) => n,
+            Err(_) => 0, // нет подписчиков — норма
+        }
+    }
+
+    /// Синхронная версия [`emit`](Self::emit) — удобна вне async-контекста.
+    pub fn emit_sync(&self, event: AppEvent) -> usize {
+        match self.inner.tx.send(event) {
+            Ok(n) => n,
+            Err(_) => 0,
+        }
+    }
+
+    /// Создаёт нового подписчика. Получает все события, отправленные после
+    /// момента вызова.
+    pub fn subscribe(&self) -> broadcast::Receiver<AppEvent> {
+        self.inner.tx.subscribe()
+    }
+
+    /// Количество активных подписчиков.
+    pub fn receiver_count(&self) -> usize {
+        self.inner.tx.receiver_count()
+    }
+
+    /// Рассылает [`AppEvent::Shutdown`] всем подписчикам.
+    pub async fn shutdown(&self) {
+        self.emit(AppEvent::Shutdown).await;
+    }
+}
+
+impl Default for EventBus {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ─── Тесты ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::progress::ProgressUpdate;
+
+    #[tokio::test]
+    async fn emit_and_receive() {
+        let bus = EventBus::new();
+        let mut rx = bus.subscribe();
+
+        bus.emit(AppEvent::Info("test".into())).await;
+
+        let ev = rx.recv().await.unwrap();
+        assert!(matches!(ev, AppEvent::Info(msg) if msg == "test"));
+    }
+
+    #[tokio::test]
+    async fn emit_progress_update() {
+        let bus = EventBus::new();
+        let mut rx = bus.subscribe();
+
+        let upd = ProgressUpdate::JobCancelled {
+            job_id: "j99".into(),
+        };
+        bus.emit(AppEvent::Progress(upd)).await;
+
+        let ev = rx.recv().await.unwrap();
+        assert!(matches!(ev, AppEvent::Progress(_)));
+    }
+
+    #[tokio::test]
+    async fn multiple_subscribers() {
+        let bus = EventBus::new();
+        let mut rx1 = bus.subscribe();
+        let mut rx2 = bus.subscribe();
+
+        bus.emit(AppEvent::Warning("warn".into())).await;
+
+        assert!(matches!(rx1.recv().await.unwrap(), AppEvent::Warning(_)));
+        assert!(matches!(rx2.recv().await.unwrap(), AppEvent::Warning(_)));
+    }
+
+    #[tokio::test]
+    async fn shutdown_event() {
+        let bus = EventBus::new();
+        let mut rx = bus.subscribe();
+
+        bus.shutdown().await;
+
+        let ev = rx.recv().await.unwrap();
+        assert!(matches!(ev, AppEvent::Shutdown));
+    }
+
+    #[tokio::test]
+    async fn no_subscribers_does_not_panic() {
+        let bus = EventBus::new();
+        // нет подписчиков — emit должен вернуть 0, не паниковать
+        let n = bus.emit(AppEvent::Info("hi".into())).await;
+        assert_eq!(n, 0);
+    }
+
+    #[test]
+    fn event_kind_labels() {
+        use crate::progress::{RenderProgress, RenderStatus};
+        let p = RenderProgress::new("j").with_status(RenderStatus::Queued);
+        let upd = ProgressUpdate::ProgressChanged(p);
+        assert_eq!(AppEvent::Progress(upd).kind(), "Progress");
+        assert_eq!(AppEvent::Shutdown.kind(), "Shutdown");
+        assert_eq!(AppEvent::Error("e".into()).kind(), "Error");
+    }
+
+    #[test]
+    fn emit_sync_no_panic() {
+        let bus = EventBus::new();
+        let _rx = bus.subscribe();
+        let n = bus.emit_sync(AppEvent::Info("sync".into()));
+        assert_eq!(n, 1);
+    }
+
+    #[test]
+    fn clone_shares_channel() {
+        let bus1 = EventBus::new();
+        let bus2 = bus1.clone();
+        let mut rx = bus1.subscribe();
+        bus2.emit_sync(AppEvent::Shutdown);
+        let ev = rx.try_recv().unwrap();
+        assert!(matches!(ev, AppEvent::Shutdown));
+    }
+}

--- a/crates/ts-core-types/src/lib.rs
+++ b/crates/ts-core-types/src/lib.rs
@@ -1,0 +1,17 @@
+//! `ts-core-types` — фундаментальные типы Timeline Studio (#94).
+//!
+//! Общие типы без тяжёлых зависимостей (no Tauri, no ORT, no specta):
+//! - [`RenderProgress`] / [`ProgressUpdate`] / [`RenderStatus`] — прогресс рендеринга
+//! - [`CoreError`] — общий error-тип для движков
+//! - [`EventBus`] — headless mpsc-шина событий
+//!
+//! Все движки (`ts-render`, `ts-agent`, `ts-analysis`, …) могут импортировать
+//! эти типы без зависимости друг от друга.
+
+pub mod error;
+pub mod events;
+pub mod progress;
+
+pub use error::CoreError;
+pub use events::{AppEvent, EventBus};
+pub use progress::{ProgressUpdate, RenderProgress, RenderStatus};

--- a/crates/ts-core-types/src/progress.rs
+++ b/crates/ts-core-types/src/progress.rs
@@ -1,0 +1,243 @@
+//! Типы прогресса рендеринга — без зависимости от Tauri/specta.
+//!
+//! Извлечено из `ts-render::video_compiler::core::progress` (#94).
+//! Тяжёлый `ProgressTracker` остался в `ts-render`.
+
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+/// Статус задачи рендеринга.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum RenderStatus {
+    /// Задача в очереди, ещё не начата.
+    Queued,
+    /// Подготовка ресурсов (загрузка ассетов, парсинг).
+    Preparing,
+    /// Идёт обработка кадров.
+    Processing,
+    /// Рендеринг завершён успешно.
+    Completed,
+    /// Рендеринг завершён с ошибкой.
+    Failed(String),
+    /// Задача отменена пользователем.
+    Cancelled,
+    /// Задача на паузе.
+    Paused,
+}
+
+impl RenderStatus {
+    /// Возвращает `true`, если задача завершена (успешно, с ошибкой или отменена).
+    pub fn is_terminal(&self) -> bool {
+        matches!(
+            self,
+            RenderStatus::Completed | RenderStatus::Failed(_) | RenderStatus::Cancelled
+        )
+    }
+
+    /// Возвращает `true`, если задача ещё выполняется.
+    pub fn is_active(&self) -> bool {
+        matches!(
+            self,
+            RenderStatus::Queued | RenderStatus::Preparing | RenderStatus::Processing
+        )
+    }
+}
+
+impl Default for RenderStatus {
+    fn default() -> Self {
+        RenderStatus::Queued
+    }
+}
+
+/// Снимок прогресса рендеринга для конкретного job-а.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RenderProgress {
+    /// Идентификатор задачи.
+    pub job_id: String,
+    /// Текущий этап (напр. "Encoding", "Mixing audio").
+    pub stage: String,
+    /// Процент выполнения от 0.0 до 100.0.
+    pub percentage: f32,
+    /// Текущий обработанный кадр.
+    pub current_frame: u64,
+    /// Общее количество кадров.
+    pub total_frames: u64,
+    /// Прошедшее время.
+    #[serde(with = "duration_serde")]
+    pub elapsed_time: Duration,
+    /// Оценка оставшегося времени (может быть `None` в начале).
+    #[serde(with = "option_duration_serde")]
+    pub estimated_remaining: Option<Duration>,
+    /// Текущий статус задачи.
+    pub status: RenderStatus,
+    /// Человекочитаемое сообщение о текущем действии.
+    pub message: Option<String>,
+}
+
+impl RenderProgress {
+    /// Создаёт начальный `RenderProgress` для нового job-а.
+    pub fn new(job_id: impl Into<String>) -> Self {
+        Self {
+            job_id: job_id.into(),
+            stage: String::new(),
+            percentage: 0.0,
+            current_frame: 0,
+            total_frames: 0,
+            elapsed_time: Duration::ZERO,
+            estimated_remaining: None,
+            status: RenderStatus::Queued,
+            message: None,
+        }
+    }
+
+    /// Клонирует с новым статусом.
+    pub fn with_status(mut self, status: RenderStatus) -> Self {
+        self.status = status;
+        self
+    }
+}
+
+/// Событие об изменении прогресса — рассылается через [`EventBus`].
+///
+/// [`EventBus`]: crate::events::EventBus
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum ProgressUpdate {
+    /// Job зарегистрирован и поставлен в очередь.
+    JobStarted {
+        job_id: String,
+        total_frames: u64,
+    },
+    /// Прогресс job-а обновился.
+    ProgressChanged(RenderProgress),
+    /// Job завершён успешно.
+    JobCompleted {
+        job_id: String,
+        /// Полное время рендеринга.
+        #[serde(with = "duration_serde")]
+        elapsed_time: Duration,
+    },
+    /// Job завершён с ошибкой.
+    JobFailed {
+        job_id: String,
+        error: String,
+    },
+    /// Job отменён.
+    JobCancelled {
+        job_id: String,
+    },
+    /// Job поставлен на паузу.
+    JobPaused {
+        job_id: String,
+    },
+    /// Job возобновлён.
+    JobResumed {
+        job_id: String,
+    },
+}
+
+impl ProgressUpdate {
+    /// Возвращает `job_id` из любого варианта.
+    pub fn job_id(&self) -> &str {
+        match self {
+            ProgressUpdate::JobStarted { job_id, .. } => job_id,
+            ProgressUpdate::ProgressChanged(p) => &p.job_id,
+            ProgressUpdate::JobCompleted { job_id, .. } => job_id,
+            ProgressUpdate::JobFailed { job_id, .. } => job_id,
+            ProgressUpdate::JobCancelled { job_id } => job_id,
+            ProgressUpdate::JobPaused { job_id } => job_id,
+            ProgressUpdate::JobResumed { job_id } => job_id,
+        }
+    }
+}
+
+// ─── serde helpers для Duration ─────────────────────────────────────────────
+
+mod duration_serde {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use std::time::Duration;
+
+    pub fn serialize<S: Serializer>(d: &Duration, s: S) -> Result<S::Ok, S::Error> {
+        d.as_secs_f64().serialize(s)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Duration, D::Error> {
+        let secs = f64::deserialize(d)?;
+        Ok(Duration::from_secs_f64(secs))
+    }
+}
+
+mod option_duration_serde {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use std::time::Duration;
+
+    pub fn serialize<S: Serializer>(opt: &Option<Duration>, s: S) -> Result<S::Ok, S::Error> {
+        opt.map(|d| d.as_secs_f64()).serialize(s)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Option<Duration>, D::Error> {
+        let opt = Option::<f64>::deserialize(d)?;
+        Ok(opt.map(Duration::from_secs_f64))
+    }
+}
+
+// ─── Тесты ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_status_terminal() {
+        assert!(RenderStatus::Completed.is_terminal());
+        assert!(RenderStatus::Failed("oops".into()).is_terminal());
+        assert!(RenderStatus::Cancelled.is_terminal());
+        assert!(!RenderStatus::Processing.is_terminal());
+    }
+
+    #[test]
+    fn render_status_active() {
+        assert!(RenderStatus::Queued.is_active());
+        assert!(RenderStatus::Preparing.is_active());
+        assert!(RenderStatus::Processing.is_active());
+        assert!(!RenderStatus::Completed.is_active());
+    }
+
+    #[test]
+    fn render_progress_new() {
+        let p = RenderProgress::new("job-1");
+        assert_eq!(p.job_id, "job-1");
+        assert_eq!(p.percentage, 0.0);
+        assert_eq!(p.status, RenderStatus::Queued);
+    }
+
+    #[test]
+    fn progress_update_job_id() {
+        let upd = ProgressUpdate::JobCancelled {
+            job_id: "abc".into(),
+        };
+        assert_eq!(upd.job_id(), "abc");
+    }
+
+    #[test]
+    fn progress_update_serde_roundtrip() {
+        let upd = ProgressUpdate::JobStarted {
+            job_id: "j1".into(),
+            total_frames: 300,
+        };
+        let json = serde_json::to_string(&upd).unwrap();
+        let back: ProgressUpdate = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.job_id(), "j1");
+    }
+
+    #[test]
+    fn render_progress_serde_roundtrip() {
+        let p = RenderProgress::new("j2").with_status(RenderStatus::Processing);
+        let json = serde_json::to_string(&p).unwrap();
+        let back: RenderProgress = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.job_id, "j2");
+        assert_eq!(back.status, RenderStatus::Processing);
+    }
+}


### PR DESCRIPTION
## Summary

- New crate `crates/ts-core-types` — фундаментальные типы без Tauri/specta/ORT зависимостей
- **`progress` module**: `RenderStatus`, `RenderProgress`, `ProgressUpdate` — извлечены из `ts-render`, pure serde types с Duration helpers
- **`error` module**: `CoreError` (thiserror) — IO / Json / Cancelled / Timeout / InvalidInput / NotFound / Internal
- **`events` module**: `AppEvent` enum + headless `EventBus` на `tokio::sync::broadcast` (clone = shared Arc, без specta)
- 18 unit tests + 1 doctest — **все зелёные**
- Добавлен в `crates/Cargo.toml` workspace members как первый (фундаментальный) крейт

## Closes

Closes #94 (Phase A — типы + EventBus)

## Test plan

- [x] `cargo test -p ts-core-types` — 18/18 pass
- [x] `cargo build -p ts-core-types` — без предупреждений
- [ ] В следующих PR: `ts-render` и `ts-cli` перейдут на `ts_core_types::ProgressUpdate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)