### PR TITLE
fix(crate-type): remove staticlib + unused pyo3/wasmtime deps (#103)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,7 +18,10 @@ autobins = false
 # to make the lib name unique and wouldn't conflict with the bin name.
 # This seems to be only an issue on Windows, see https://github.com/rust-lang/cargo/issues/8519
 name = "timeline_studio_lib"
-crate-type = ["staticlib", "cdylib", "rlib"]
+# staticlib removed: caused link-ICE (rustc_codegen_ssa/back/link.rs unwrap NotFound)
+# when building standalone [[bin]] targets on desktop. staticlib only needed for
+# iOS/Android native builds — re-add per-platform via build.rs if needed. (#103)
+crate-type = ["cdylib", "rlib"]
 
 [[bin]]
 name = "timeline-studio"
@@ -112,8 +115,8 @@ tower-http = { version = "0.6.6", features = ["cors", "fs"] }
 md5 = "0.8.0"
 dirs = "6.0.0"
 anyhow = "1.0"
-# Python interop for Faster Whisper
-pyo3 = { version = "0.27.1", features = ["auto-initialize"] }
+# pyo3 removed: declared but unused in all .rs files (#103)
+# Will be re-added to a dedicated ts-whisper crate when Faster Whisper integration lands
 # Security and API keys management
 aes-gcm = "0.10"
 argon2 = "0.5"
@@ -145,10 +148,9 @@ tracing = "0.1"
 tracing-opentelemetry = "0.32.0"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 tonic = "0.14.2"
-# WebAssembly runtime dependencies
-wasmtime = { version = "40.0", default-features = false }
+# wasmtime/wasmtime-wasi removed: declared but unused in all .rs files (#103)
+# Will be re-added to ts-plugins crate when WASM plugin sandbox lands
 filetime = "0.2"
-wasmtime-wasi = "40.0"
 wasm-bindgen = "0.2"
 # Additional security dependencies
 cap-std = "4.0.0"


### PR DESCRIPTION
## Summary

- **`crate-type`**: `["staticlib", "cdylib", "rlib"]` → `["cdylib", "rlib"]`
  `staticlib` вызывал link-ICE (`rustc_codegen_ssa/back/link.rs unwrap NotFound`) при сборке standalone `[[bin]]` на desktop. Homebrew `ar` не справляется с >6 ГБ `libtimeline_studio_lib`. `staticlib` нужен только для iOS/Android.

- **`pyo3 = "0.27.1"`** удалён: задекларирован «для Faster Whisper», но `grep -rn "use pyo3" src-tauri/src/` → 0 вхождений. Переедет в `ts-whisper`.

- **`wasmtime = "40.0"` + `wasmtime-wasi = "40.0"`** удалены: задекларированы «для WASM-плагинов», 0 использований. Переедут в `ts-plugins`.

## Closes

Closes #103

## Verification

- [x] `cargo check` (src-tauri, rustup 1.90) — **exit 0** после удалений
- [x] Grep all `.rs`: `use pyo3`, `use wasmtime` — **0 matches**

## Before / After

**До:** `cargo build --bin generate_types` падал с:
```
LLVM error: truncated or malformed object (string table with size 8 overlaps section contents with size 6101943840)
```
**После:** `staticlib`-архив не создаётся → ICE устранён.

🤖 Generated with [Claude Code](https://claude.com/claude-code)