### PR TITLE
feat(#102): slim Tauri host — wire ts-state + ts-agent via TauriEventSink

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -84,6 +84,10 @@ tauri-plugin-sql = { version = "2.3", features = ["sqlite"] }
 rusqlite = { version = "0.32", features = ["bundled", "vtab", "load_extension"] }
 # Video Compiler dependencies
 ts-schema = { path = "../crates/ts-schema" }
+# Headless crates (#91 decomp) — slim host wires these in (#102)
+ts-core-types = { path = "../crates/ts-core-types" }
+ts-state = { path = "../crates/ts-state", features = ["specta"] }
+ts-agent = { path = "../crates/ts-agent" }
 ts-platform = { path = "../crates/ts-platform" }
 ts-analysis = { path = "../crates/ts-analysis" }
 ts-render = { path = "../crates/ts-render" }

--- a/src-tauri/src/headless_bridge.rs
+++ b/src-tauri/src/headless_bridge.rs
@@ -1,0 +1,65 @@
+//! Thin glue between the headless `ts-state` crate and the Tauri host.
+//!
+//! `TauriEventSink` implements `ts_state::EventSink` by forwarding
+//! `ProjectEvent`s to the Tauri window via `app_handle.emit()`.
+//!
+//! This is the only Tauri-specific code needed to make the headless
+//! state machinery work inside the Tauri app.  All other state logic
+//! lives in the `ts-state` crate and is fully testable without Tauri.
+
+use std::sync::Arc;
+
+use tauri::{AppHandle, Emitter};
+use ts_state::sink::{EventSink, SinkFuture};
+use ts_state::ProjectEvent;
+
+/// Tauri implementation of [`EventSink`].
+///
+/// Serialises the event to JSON and emits it on the `"ts://project-event"`
+/// channel so the front-end can subscribe with `listen("ts://project-event", ...)`.
+pub struct TauriEventSink {
+    app: AppHandle,
+}
+
+impl TauriEventSink {
+    pub fn new(app: AppHandle) -> Self {
+        Self { app }
+    }
+}
+
+impl EventSink for TauriEventSink {
+    fn send(
+        &self,
+        event: ProjectEvent,
+        source: String,
+        version: u32,
+    ) -> SinkFuture {
+        let app = self.app.clone();
+        Box::pin(async move {
+            let payload = serde_json::json!({
+                "event": event,
+                "source": source,
+                "version": version,
+            });
+            // Best-effort: ignore errors (e.g. window closed during shutdown)
+            let _ = app.emit("ts://project-event", payload);
+        })
+    }
+}
+
+/// Build a `ts_state::StateManager` wired to the Tauri window.
+///
+/// Called once during app setup (`setup` hook in `lib.rs`).
+/// The returned manager is registered as managed state so every Tauri
+/// command can access it via `State<'_, HeadlessState>`.
+pub fn build_headless_state(app: AppHandle) -> HeadlessState {
+    let sink = Arc::new(TauriEventSink::new(app));
+    let manager = ts_state::StateManager::new(sink);
+    HeadlessState { manager }
+}
+
+/// Tauri managed state wrapper for the headless state manager.
+#[derive(Clone)]
+pub struct HeadlessState {
+    pub manager: ts_state::StateManager,
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use tauri::Manager;
 use tokio::sync::RwLock;
 
+// Headless bridge — wires ts-state + ts-agent into the Tauri host (#102)
+pub mod headless_bridge;
+
 // Core infrastructure modules
 pub mod core;
 use core::telemetry::{TelemetryConfig, TelemetryManager};
@@ -294,6 +297,11 @@ pub fn run() {
           }
         });
       }
+
+      // Initialize headless state bridge (ts-state + TauriEventSink) (#102)
+      let headless = headless_bridge::build_headless_state(app.handle().clone());
+      app.manage(headless);
+      log::info!("Headless state (ts-state) initialized");
 
       // Create YOLO Processor State
       let yolo_processor_state = YoloProcessorState::default();


### PR DESCRIPTION
## Summary
- Adds `src-tauri/src/headless_bridge.rs` with `TauriEventSink` — implements `ts_state::EventSink`, forwards `ProjectEvent`s to the window on `"ts://project-event"` channel
- Registers `HeadlessState` (wraps headless `ts_state::StateManager`) in the app setup hook
- Adds `ts-core-types`, `ts-state` (specta feature), `ts-agent` as deps in `src-tauri/Cargo.toml`

## Why
Closes #102. The Tauri host now depends on all headless crates from epic #91 decomp.
This is the "thin glue" layer — all state logic lives in `ts-state`, Tauri only holds the wiring.

## Test plan
- [x] `cargo check --lib` exits 0 with no errors
- [x] Existing `StateManager` (legacy) untouched — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)