### PR TITLE
fix(ci): sync workspace locks and headless doctest

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -144,6 +144,13 @@
         "onnxruntime-node": "^1.26.0",
       },
     },
+    "packages/shared-types": {
+      "name": "@timeline/shared-types",
+      "version": "1.0.0",
+      "devDependencies": {
+        "typescript": "^5.0.0",
+      },
+    },
   },
   "packages": {
     "@a2a-js/sdk": ["@a2a-js/sdk@0.3.11", "", { "dependencies": { "uuid": "^11.1.0" }, "peerDependencies": { "@bufbuild/protobuf": "^2.10.2", "@grpc/grpc-js": "^1.11.0", "express": "^4.21.2 || ^5.1.0" }, "optionalPeers": ["@bufbuild/protobuf", "@grpc/grpc-js", "express"] }, "sha512-pXjjlL0ZYHgAxObov1J+W3ylfQV0rOrDBB8Eo4a9eCunqs7iNW5OIfMcV8YnZQdzeVSRomj8jHeudVz0zc4RNw=="],
@@ -1205,6 +1212,8 @@
     "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
 
     "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
+
+    "@timeline/shared-types": ["@timeline/shared-types@workspace:packages/shared-types"],
 
     "@tootallnate/once": ["@tootallnate/once@2.0.0", "", {}, "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="],
 
@@ -3505,6 +3514,8 @@
     "@testing-library/jest-dom/dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
     "@testing-library/react/@babel/runtime": ["@babel/runtime@7.28.4", "", {}, "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ=="],
+
+    "@timeline/shared-types/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "@types/babel__core/@babel/parser": ["@babel/parser@7.28.5", "", { "dependencies": { "@babel/types": "^7.28.5" }, "bin": "./bin/babel-parser.js" }, "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ=="],
 

--- a/crates/ts-montage/src/headless.rs
+++ b/crates/ts-montage/src/headless.rs
@@ -6,9 +6,20 @@
 //! ```no_run
 //! use ts_montage::headless::{HeadlessMontagePlanner, MontagePlanParams};
 //! # async fn run() -> anyhow::Result<()> {
+//! let analyses = vec![serde_json::json!({
+//!   "video": { "duration_secs": 12.0 },
+//!   "scenes": [
+//!     { "start_secs": 0.0, "end_secs": 4.0, "brightness": 0.6, "contrast": 0.7, "saturation": 0.5 },
+//!     { "start_secs": 4.0, "end_secs": 8.0, "brightness": 0.8, "contrast": 0.6, "saturation": 0.8 }
+//!   ]
+//! })];
+//! let sources = vec!["/data/clip1.mp4".to_string()];
 //! let plan = HeadlessMontagePlanner::new()
-//!   .plan(MontagePlanParams {
-//!     inputs: vec!["/data/clip1.mp4".to_string(), "/data/clip2.mp4".to_string()],
+//!   .plan_from_analyses(
+//!     analyses,
+//!     sources.clone(),
+//!     MontagePlanParams {
+//!     inputs: sources,
 //!     platform: "tiktok".to_string(),
 //!     duration_secs: 30.0,
 //!     style: "social-media".to_string(),

--- a/docs/08_tasks/planned/monorepo-packages-migration.md
+++ b/docs/08_tasks/planned/monorepo-packages-migration.md
@@ -1,8 +1,9 @@
 # Миграция на монорепо с bun workspaces
 
-**Статус:** Planned
+**Статус:** Planned, tracked in [#150](https://github.com/chatman-media/timeline-studio/issues/150)
 **Приоритет:** High
 **Создано:** 2025-11-29
+**Актуализировано:** 2026-06-07
 **Ответственный:** Architecture Team
 
 ## 📋 Описание

--- a/docs/10_project_state/current-status.md
+++ b/docs/10_project_state/current-status.md
@@ -1,505 +1,81 @@
-# ТЕКУЩИЙ СТАТУС ПРОЕКТА TIMELINE STUDIO
-
-*Последнее обновление: 18 ноября 2025*
-
-## 🎉 ВАЖНОЕ ОБНОВЛЕНИЕ: Завершена волна 3 - MCP интеграция!
-
-**Дата завершения**: 18 ноября 2025
-**Волна 3**: MCP (Model Context Protocol) интеграция
-**Результат**: **Полная интеграция Claude Code с 18 инструментами видеомонтажа**
-
-### Ключевые достижения волны 3:
-
-- ✅ **MCP Backend интеграция** - Rust сервер с полным API
-- ✅ **TypeScript bindings** - Автогенерация типов через Specta
-- ✅ **UI настроек** - Секция MCP в User Settings с автосохранением
-- ✅ **Автоинициализация** - MCPProvider в цепочке приложения
-- ✅ **18 MCP Tools как IAITool** - Адаптеры для автоматической интеграции с AI Chat ✨ **НОВОЕ**
-- ✅ **Единый интерфейс** - MCP tools доступны через allAITools без отдельного UI ✨ **НОВОЕ**
-- ✅ **Исправлено 65+ TypeScript ошибок** - 6 параллельных агентов
-- ✅ **Общая готовность**: 96.5% → **96.8%** (+0.3%)
-
----
-
-## 🎉 ЗАВЕРШЕНЫ ВОЛНЫ ДОРАБОТОК 1-2!
-
-**Дата завершения**: 17 ноября 2025
-**Задействовано**: 12 параллельных агентов (2 волны по 6)
-**Результат**: **12 модулей доведены до 100% готовности**
-
-### Ключевые достижения:
-
-- ✅ **8 доменов доведены до 100%**: AI Services, AI Tools, Browser, Video Editing, Media Management, Project Management, System Integration, Shared
-- ✅ **4 feature модуля завершены**: Timeline, Effects, Filters, Transitions
-- ✅ **Создано**: ~25+ новых файлов (~3,500+ строк кода)
-- ✅ **Добавлено**: ~450+ новых тестов
-- ✅ **Исправлено**: 5 критических проблем (security, performance, memory leaks)
-- ✅ **Общая готовность**: 91.5% → **96.5%** (+5%)
-
-### Основные улучшения:
-
-**Безопасность и производительность:**
-- Input validation для AI Services (440 строк)
-- Rate limiting через p-limit
-- Устранение memory leaks (TTL cleanup)
-- O(n²) → O(n) оптимизация в Video Editing
-- Debounced drag & drop (60fps)
-
-**Новая функциональность:**
-- 5 новых сервисов в Media Management (~60KB)
-- Shared domain utils (38 функций) + contracts (12 интерфейсов)
-- Timeline integration для Effects и Filters
-- FFmpeg filter generator (240 строк)
-
-## 📊 Общий прогресс
-
-| Метрика | Значение |
-|---------|----------|
-| **Общая готовность** | 96.8% |
-| **Версия** | 2.13.0 |
-| **Архитектура** | Domain-Driven Design ✅ |
-| **Покрытие тестами** | 90%+ |
-| **Количество тестов** | 9,650+ |
-| **AI инструменты** | 66 (48 + 18 MCP Tools) ✅ |
-| **MCP интеграция** | Claude Code через IAITool ✅ |
-| **Поддержка языков** | 15 |
-| **Tauri команды** | 457 (+6 MCP) |
-
-## 🏗️ Доменная архитектура
-
-### Frontend Domains (9 доменов)
-
-#### ✅ Production Ready
-
-**AI Domains:**
-- **ai-services** (100%) ✅ - Унифицированные AI сервисы, 67 файлов, 3 XState машины
-  - Claude, OpenAI, DeepSeek, Ollama интеграция
-  - Content Intelligence (4 движка)
-  - Montage Planner с AI
-  - 95/95 тестов проходят ✅
-  - **Улучшения волны 1**: Rate limiting (p-limit), input validation (440 строк), TTL cleanup для memory leaks
-
-- **ai-tools** (100%) ✅ - **66 AI инструментов** с execution engine ✨ **+18 MCP**
-  - Base Infrastructure (100% tested, 126 тестов)
-  - Core Tools: 18 инструментов (Timeline, Browser, Resources, Player)
-  - Analysis Tools: 15 инструментов (100% готовность) ✅
-  - Automation Tools: 10 инструментов (100% готовность) ✅
-  - Integration Tools: 5 инструментов (100% готовность) ✅
-  - **MCP Tools: 18 инструментов (адаптеры IAITool)** ✨ **НОВОЕ** - `src/domains/ai-tools/tools/mcp/`
-    - 4 Analysis (analyze-video, detect-scenes, detect-moments, analyze-audio)
-    - 5 Timeline (create, add-clip, remove-clip, move-clip, split-clip)
-    - 4 Effects (apply-filter, add-transition, color-grading, text-overlay)
-    - 2 Export (export-video, create-preview)
-    - 3 Project (get-info, save, list-media-files)
-  - **Улучшения волны 1**: ExecutionEngine concurrency fix, AbortSignal propagation, auto-cleanup (TTL)
-  - **Волна 3**: Интеграция MCP через единый интерфейс IAITool
-
-**Core Domains:**
-- **browser** (100%) ✅ - Медиа браузер с 6 вкладками
-  - BackendSync интеграция
-  - 534/535 тестов ✅
-  - Event-driven architecture
-  - **Улучшения волны 1**: Resolved 5/5 TODOs, selectMediaDirectory(), estimateMemoryUsage()
-
-- **video-editing** (100%) ✅ - Центральная система редактирования
-  - 3 XState машины (Timeline, Player, Timeline Extended)
-  - Import/Export (AAF, EDL, FCPXML)
-  - Undo/Redo с группировкой
-  - 204/204 тестов ✅
-  - **Улучшения волны 1**: O(n²) → O(n) optimization, clip-transform.ts utility, type-validation.ts (224 строки)
-
-- **media-management** (100%) ✅ - Управление медиафайлами
-  - 2 XState машины (Media Import, File Operations)
-  - FFmpeg metadata extraction
-  - 105/105 тестов ✅
-  - **Улучшения волны 1**: ProxyGenerator, CameraImport, SmartOrganization, ErrorTracker, WaveformGenerator (~60KB кода)
-
-- **project-management** (100%) ✅ - Управление проектами
-  - App Machine, User Settings Machine
-  - Autosave и version control
-  - 179 тестов
-  - **Улучшения волны 2**: Dirty flag tracking, enhanced error handling, PerformanceMetricsTracker
-
-- **system-integration** (100%) ✅ - Системная интеграция
-  - Модальные окна (13 типов)
-  - Уведомления
-  - Update система
-  - 157/157 тестов ✅
-  - **Улучшения волны 2**: Fixed test imports, jsdom support, removed vi.mocked usage
-
-- **shared** (100%) ✅ - Общие компоненты
-  - Domain Event Bus
-  - 271/271 тестов ✅
-  - **Улучшения волны 1**: Созданы utils (id.ts, time.ts, file.ts, validation.ts - 38 функций), contracts.ts (12 интерфейсов), 176 новых тестов
-
-#### 🚧 Вспомогательные
-
-- **ai-core** (0%) - ❌ УДАЛЁН (функциональность мигрирована в backend AI proxy)
-
-### Frontend Features (40 модулей)
-
-#### ✅ Core Modules (100%)
-
-**Редактирование:**
-- **timeline** (100%) ✅ - 1,623/1,626 тестов, 205 файлов
-  - **Улучшения волны 2**: Debounced drag & drop (use-debounced-drag.ts), boundary checks, TimelineUIProvider context
-- **video-player** (100%) ✅ - 257 тестов, 40 файлов
-- **media-studio** (95%) - 65 тестов, 4 layout варианта
-
-**Эффекты и обработка:**
-- **effects** (100%) ✅ - 39 эффектов, WebGL2 рендеринг, 75+ тестов
-  - **Улучшения волны 2**: ClipEffectsService для Timeline интеграции, EffectDragSource, UserPresetsService
-- **filters** (100%) ✅ - 15 фильтров, LOG профили, 129/129 тестов
-  - **Улучшения волны 2**: useFilterTimelineIntegration hook, FilterParameterControls, ffmpeg-filter-generator.ts (240 строк)
-- **transitions** (95-98%) ✅ - 55+ переходов, 4 WebGL renderers (1850 строк), 127/127 тестов
-  - **Результаты волны 2**: Анализ показал 95-98% готовности (не 75-80% как документировано), все WebGL рендереры полностью реализованы
-- **color-grading** (90%) - Color Wheels, RGB Curves, LUT, Scopes
-- **fairlight-audio** (100%) ✅ - Профессиональный микшер, 33 тестовых файла
-
-**Экспорт и AI:**
-- **export** (95%) - YouTube, TikTok, Vimeo, Telegram интеграция
-- **ai-chat** (95%) ✨ **УЛУЧШЕНО** - 48 AI инструментов + 18 MCP Tools, Claude Code интеграция
-
-#### ✅ Advanced Features (95-100%)
-
-- **person-identification** (95%) - FaceNet, RetinaFace, DBSCAN
-- **montage-planner** (100%) - AI-powered планировщик монтажа
-- **transcription** (95%) - Whisper (3 варианта), 20+ языков
-- **subtitles** (100%) - 12 стилей, SRT/VTT/ASS
-- **templates** (100%) - 78+ многокамерных шаблонов
-- **style-templates** (100%) - 6 типов анимированных шаблонов
-- **voice-recording** (100%) - 5 форматов, 89 тестов
-- **camera-capture** (90%) - Захват камеры/экрана, 68 тестов
-
-#### 🚧 In Development (75-85%)
-
-- **recognition** (85%) - YOLO визуализация, требует Timeline интеграция
-- **multicam** (80%) - Переключение камер, ⚠️ аудио синхронизация
-
-### Backend Modules (10 Rust доменов)
-
-#### ✅ Production Ready (92%+)
-
-- **core** (100%) - DI Container, Event System, Plugin System, 153 теста
-- **video_compiler** (98%) - 220 файлов, 942 теста, FFmpeg + GPU
-- **analysis** (95%) - Content/Scene/Moment Engines, 19 тестов
-- **recognition** (95%) - YOLO, FaceNet, RetinaFace, MediaPipe, 81 тест
-- **media** (92%) - FFmpeg интеграция, 177 тестов
-- **montage_planner** (90%) - AI планирование, 143 теста
-- **security** (88%) - OAuth, Secure Storage, API validation, 110 тестов
-
-#### 🚧 Требует улучшений
-
-- **state** (85%) - ⚠️ Только 4 теста на 27K строк кода
-- **subtitles** (70%) - Базовый функционал, требует расширения
-- **commands** (75%) - Вспомогательный, требует рефакторинга
-
-## 🚀 Ключевые достижения
-
-### Недавно завершено (Ноябрь 2025)
-
-- ✅ **Доменная архитектура** - Полная миграция на DDD (9 доменов)
-- ✅ **Backend как Single Source of Truth** - BackendSync для всех доменов
-- ✅ **AI подсистема** - 48 инструментов + UnifiedAI с 4 провайдерами
-- ✅ **451 Tauri команды** - Comprehensive backend API
-- ✅ **Event-Driven Architecture** - Domain Event Bus для всех доменов
-- ✅ **Import/Export** - AAF, EDL, FCPXML support
-
-### Архитектурные улучшения
-
-- ✅ **XState v5** - 12+ state machines для сложных workflow
-- ✅ **TypeScript типизация** - Auto-generated из Rust через Specta
-- ✅ **Dependency Injection** - DI Container в core и ai-tools
-- ✅ **Command Pattern** - CommandQueue с приоритизацией
-- ✅ **Orchestrator Pattern** - Координация между доменами
-
-## 📈 Детальная готовность модулей
-
-### Frontend Domains
-
-| Домен | Готовность | Тесты | Файлов | Статус |
-|-------|-----------|-------|--------|--------|
-| ai-services | 100% ✅ | 100% (95/95) | 102 | ✅ Production |
-| ai-tools | 100% ✅ | 100% (126) | 84 | ✅ Production |
-| browser | 100% ✅ | ~99% (534/535) | 13 | ✅ Production |
-| video-editing | 100% ✅ | 100% (204/204) | 41 | ✅ Production |
-| media-management | 100% ✅ | 100% (105/105) | 24 | ✅ Production |
-| project-management | 100% ✅ | 100% (179) | ~20 | ✅ Production |
-| system-integration | 100% ✅ | ~98% (157/157) | ~25 | ✅ Production |
-| shared | 100% ✅ | 100% (271/271) | ~30 | ✅ Production |
-
-### Frontend Features (Топ-20)
-
-| Модуль | Готовность | Тесты | Статус |
-|--------|-----------|-------|--------|
-| timeline | 100% ✅ | 1,623/1,626 | ✅ Production |
-| video-player | 100% ✅ | 257 | ✅ Production |
-| media-studio | 95% | 65 | ✅ Production |
-| fairlight-audio | 100% ✅ | 33 файла | ✅ Завершен |
-| export | 95% | 24 файла | ✅ Production |
-| ai-chat | 95% ✨ | 7+ файлов | ✅ Production + MCP |
-| color-grading | 90% | 14 файлов | ✅ Готов |
-| effects | 100% ✅ | 75+ тестов | ✅ Завершен |
-| filters | 100% ✅ | 129/129 | ✅ Завершен |
-| person-identification | 95% | 10 файлов | ✅ Готов |
-| montage-planner | 100% ✅ | 1 файл | ✅ Готов |
-| transcription | 95% | 5 файлов | ⚠️ Speaker ID |
-| subtitles | 100% ✅ | 16 файлов | ✅ Готов |
-| templates | 100% ✅ | 11 файлов | ✅ Готов |
-| style-templates | 100% ✅ | 5 файлов | ✅ Готов |
-| camera-capture | 90% | 11 файлов | ⚠️ Интеграция |
-| voice-recording | 100% ✅ | 5 файлов | ✅ Готов |
-| transitions | 95-98% ✅ | 127/127 | ✅ Почти готов |
-| recognition | 85% | 2 файла | ⚠️ Визуализация |
-| multicam | 80% | 5 файлов | ⚠️ Синхронизация |
-
-### Backend Modules (Rust)
-
-| Модуль | Файлов | Тесты | Строк кода | Готовность | Статус |
-|--------|--------|-------|-----------|------------|--------|
-| video_compiler | 220 | 942 | 80,949 | 98% | ✅ Production |
-| state | 24 | 4 | 27,453 | 85% | ⚠️ Нужны тесты |
-| core | 36 | 153 | 23,249 | 100% | ✅ Production |
-| analysis | 39 | 19 | 19,881 | 95% | ✅ Production |
-| recognition | 31 | 81 | 12,988 | 95% | ✅ Production |
-| montage_planner | 24 | 143 | 12,357 | 90% | ✅ Production |
-| media | 24 | 177 | 7,820 | 92% | ✅ Production |
-| security | 16 | 110 | 5,013 | 88% | ✅ Ready |
-| subtitles | 3 | 3 | 762 | 70% | 🚧 Basic |
-| commands | 3 | 0 | ~500 | 75% | 🚧 Auxiliary |
-
-## 🎯 Основная функциональность
-
-### ✅ Полностью реализовано
-
-**Профессиональный монтаж:**
-- ✅ Многодорожечный timeline с drag & drop
-- ✅ Frame-accurate editing
-- ✅ Ripple, Roll, Slip, Slide режимы
-- ✅ Multi-select и batch operations
-- ✅ Keyframe animation
-- ✅ Markers и sections
-- ✅ Snap система
-- ✅ Undo/Redo с группировкой
-
-**AI возможности:**
-- ✅ 48 AI инструментов (Core, Analysis, Automation)
-- ✅ 18 MCP Tools (Model Context Protocol) ✨ **НОВОЕ**
-- ✅ Claude Code интеграция - используйте подписку прямо в редакторе ✨ **НОВОЕ**
-- ✅ 4 AI провайдера (Claude, OpenAI, DeepSeek, Ollama)
-- ✅ Автоматический анализ контента
-- ✅ Smart Montage Planner
-- ✅ Person Identification (FaceNet + RetinaFace)
-- ✅ Whisper транскрипция (3 варианта)
-- ✅ Content Intelligence (4 движка)
-
-**Медиа обработка:**
-- ✅ FFmpeg интеграция с GPU ускорением
-- ✅ Color Grading (DaVinci-level)
-- ✅ Professional Audio Mixer (Fairlight-like)
-- ✅ 100+ эффектов, фильтров, переходов
-- ✅ LUT support (.cube файлы)
-- ✅ Scopes (Waveform, Vectorscope, Histogram)
-
-**Экспорт и интеграция:**
-- ✅ YouTube, TikTok, Vimeo, Telegram
-- ✅ OAuth 2.0 интеграция
-- ✅ AAF, EDL, FCPXML import/export
-- ✅ Multiple formats (MP4, MOV, WebM)
-- ✅ Batch rendering
-
-### 🚧 В разработке
-
-- 🚧 WebGL transitions (40% готовности)
-- 🚧 Audio синхронизация в Multicam
-- 🚧 Speaker Identification (diarization)
-- 🚧 Shared domain utils и contracts
-- 🚧 AI Tools integration tools (0%)
-
-## 🐛 Известные проблемы
-
-### ✅ Исправлено в волнах 1-2
-
-1. ~~**AI Services Security** - нет input sanitization и rate limiting~~ ✅ **ИСПРАВЛЕНО**
-   - Добавлена валидация всех входных данных (validation.ts, 440 строк)
-   - Реализован rate limiting через p-limit
-   - TTL cleanup для предотвращения утечек памяти
-
-2. ~~**ExecutionEngine Concurrency** - executeParallel не учитывает maxConcurrent~~ ✅ **ИСПРАВЛЕНО**
-   - Добавлено ограничение конкурентности через p-limit
-   - Реализована поддержка AbortSignal
-   - Автоматический cleanup с TTL
-
-3. ~~**Shared Domain** - отсутствуют utils и contracts~~ ✅ **ИСПРАВЛЕНО**
-   - Созданы 4 utility модуля (38 функций): id.ts, time.ts, file.ts, validation.ts
-   - Добавлен contracts.ts с 12 интерфейсами между доменами
-   - 176 новых тестов (100% покрытие)
-
-4. ~~**Debouncing** - нет debouncing в drag & drop events~~ ✅ **ИСПРАВЛЕНО**
-   - Создан use-debounced-drag.ts hook
-   - Ограничение до 60fps (throttling 16ms)
-
-5. ~~**Video Editing Performance** - O(n²) в handleClipMoved~~ ✅ **ИСПРАВЛЕНО**
-   - Оптимизация: O(n²) → O(n) (single-pass алгоритм)
-   - Создана утилита clip-transform.ts (устранено ~200 строк дубликатов)
-
-### Критические (требуют немедленного исправления)
-
-1. **Video Player Memory Leak** - video elements не очищаются автоматически
-2. **State Module Testing** - только 4 теста на 27K строк кода
-
-### Важные (следующий спринт)
-
-3. **Performance** - snap engine O(n²) при большом количестве клипов
-4. **Input Validation** - недостаточная валидация числовых input (NaN, Infinity)
-5. **Backend FFmpeg** - нет валидации путей (command injection risk)
-
-### Минорные (backlog)
-
-6. Recognition - Timeline интеграция для визуализации
-7. Transcription - Speaker Identification через pyannote.audio
-8. Camera Capture - интеграция сохранения в медиатеку
-9. State Module - TOCTOU в autosave loop
-10. Memory Management - временные файлы не очищаются автоматически
-
-## 🎬 Что уже работает
-
-1. **Профессиональный монтаж** - многодорожечный timeline с 100+ эффектами
-2. **AI ассистент** - 48 инструментов с Function Calling
-3. **Локальный AI** - Ollama с бесплатными моделями
-4. **AI анализ видео** - детекция сцен, объектов, лиц
-5. **Генерация субтитров** - Whisper с 20+ языками
-6. **Person Identification** - распознавание и tracking
-7. **Smart Montage Planner** - автоматическое планирование монтажа
-8. **Цветокоррекция** - профессиональные инструменты (Color Wheels, Curves, LUT)
-9. **Аудио микширование** - Fairlight-подобная система
-10. **Экспорт и публикация** - прямая загрузка в соцсети
-11. **Профессиональный импорт/экспорт** - AAF, EDL, FCPXML
-
-## 📊 Технические метрики
-
-### Производительность
-- **Startup Time**: < 2 секунды
-- **Memory Usage**: ~200MB базовое потребление
-- **Export Speed**: 2-3x realtime с GPU
-- **Build Size**: ~50MB сжатый инсталлятор
-
-### Покрытие кода
-- **Frontend**: 85%+ для ключевых модулей
-- **Backend**: 80%+ (942 теста в video_compiler)
-- **Общее количество тестов**: 9,200+
-- **E2E тесты**: 54 web + 25 Tauri-specific
-
-### Архитектура
-- **Domains**: 9 frontend + 10 backend
-- **Features**: 40 модулей
-- **XState Machines**: 12+ state machines
-- **Tauri Commands**: 451
-- **Lines of Code**: ~300,000
-
-## 🔜 Следующие шаги
-
-### ✅ Завершено в волнах 1-2
-
-1. ✅ **Добавить security measures в AI Services**
-   - Input sanitization (validation.ts, 440 строк)
-   - Rate limiting (p-limit интеграция)
-   - TTL cleanup для памяти
-
-2. ✅ **Оптимизация производительности**
-   - ~~Snap engine caching~~ - Не требуется (O(n) приемлемо)
-   - Debouncing для drag & drop (use-debounced-drag.ts)
-   - Video Editing: O(n²) → O(n)
-
-3. ✅ **Завершить Shared Domain**
-   - Реализованы utils (id.ts, time.ts, file.ts, validation.ts)
-   - Добавлены contracts (12 интерфейсов)
-   - 176 новых тестов
-
-### Приоритет 1 (Критические)
-
-1. 🔧 **Исправить Video Player Memory Leak** (2-3 дня)
-2. 🔧 **Добавить тесты для State Module** (1 неделя)
-
-### Приоритет 2 (Важные)
-
-3. **FFmpeg Security** (2-3 дня)
-   - Валидация путей
-   - Ограничение размера output
-
-4. **Input Validation Enhancement** (1-2 дня)
-   - Числовые input (NaN, Infinity checks)
-
-### Приоритет 3 (Улучшения)
-
-5. **Recognition Timeline интеграция** (1 неделя)
-6. **Speaker Identification** через pyannote.audio (1-2 недели)
-7. **Comprehensive Resources Database** - 5000+ ресурсов
-8. **Performance Optimization** - Proxy файлы, 4K/8K
-
-### Приоритет 4 (Будущее)
-
-9. **Cloud Storage & Sync** - мультиплатформенная синхронизация
-10. **Cloud Rendering** - облачный рендеринг
-11. **Telegram Mini App** - мобильное приложение
-12. **Plugin System WASM** - WebAssembly плагины
-
-## 📞 Обратная связь
-
-**Нашли баг или есть предложения?**
-- GitHub Issues: https://github.com/chatman-media/timeline-studio/issues
-- Email: ak.chatman.media@gmail.com
-
----
-
-## 📝 Итоговая оценка по компонентам
-
-| Компонент | Готовность | Оценка качества | Статус |
-|-----------|-----------|----------------|--------|
-| **AI Подсистема** | 100% ✅ | 9.0/10 | ✅ Production Ready |
-| **Timeline & Editing** | 100% ✅ | 9.0/10 | ✅ Production Ready |
-| **Backend (Rust)** | 93% | 7.0/10 | ✅ Production Ready |
-| **Media Processing** | 100% ✅ | 9.0/10 | ✅ Production Ready |
-| **Экспорт и интеграция** | 95% | 8.5/10 | ✅ Production Ready |
-
-### **Общая готовность проекта: 96.8%**
-
-**Вердикт**: Timeline Studio находится на **финальной стадии разработки** с большинством компонентов полностью готовых к продакшену.
-
-### 🎉 Завершено в волнах 1-3:
-
-**Волна 1 (6 доменов):**
-- ✅ AI Services: 90% → 100% (security, rate limiting, validation)
-- ✅ AI Tools: 75% → 100% (concurrency fix, AbortSignal, TTL cleanup)
-- ✅ Browser: 95% → 100% (TODOs resolved, memory estimation)
-- ✅ Video Editing: 90% → 100% (O(n) optimization, type validation)
-- ✅ Media Management: 85% → 100% (5 новых сервисов ~60KB)
-- ✅ Shared: 75% → 100% (utils, contracts, 176 тестов)
-
-**Волна 2 (6 модулей):**
-- ✅ Project Management: 95% → 100% (dirty flags, error handling)
-- ✅ System Integration: 90% → 100% (test fixes, jsdom)
-- ✅ Timeline: 95% → 100% (debounced drag, boundary checks)
-- ✅ Effects: 90% → 100% (ClipEffectsService, drag & drop)
-- ✅ Filters: 85% → 100% (FFmpeg generator, Timeline integration)
-- ✅ Transitions: 75-80% → 95-98% (анализ показал полную готовность)
-
-**Волна 3 (MCP интеграция):** ✨ **18 ноября 2025**
-- ✅ MCP Backend: Rust сервер с 6 командами
-- ✅ TypeScript Bindings: Автогенерация через Specta (usize→u32 fix)
-- ✅ UI для настроек: Секция MCP в User Settings (ai-services-tab.tsx)
-- ✅ Автоинициализация: MCPProvider в цепочке приложения
-- ✅ 18 MCP Tools: IAITool адаптеры для видеомонтажа
-- ✅ 65+ TypeScript ошибок: Исправлено 6 параллельными агентами
-- ✅ AI Chat: 90% → 95% (интеграция Claude Code подписки)
-
-### Остается для Production-готовности:
-1. Исправить Video Player Memory Leak (2-3 дня)
-2. Добавить тесты для State Module (1 неделя)
-
-Проект готов к **открытому бета-тестированию** после исправления 2 критических проблем (~1-2 недели работы).
-
----
-
-*Этот документ обновляется на основе прогресса разработки*
-*Последняя полная ревизия: 17 ноября 2025*
+# Текущий статус Timeline Studio
+
+*Последнее обновление: 7 июня 2026*
+
+## Сводка
+
+Timeline Studio перешел от монолитного Rust/Tauri backend к модульной headless-ready архитектуре на `ts-*` крейтах. Эпики декомпозиции и agentic pipeline закрыты:
+
+- [#91](https://github.com/chatman-media/timeline-studio/issues/91) - декомпозиция монолита в layered Rust workspace.
+- [#119](https://github.com/chatman-media/timeline-studio/issues/119) - agent-driven headless produce-to-publish pipeline.
+- [#120](https://github.com/chatman-media/timeline-studio/issues/120) - агентные контракты и `@timeline/shared-types`.
+
+Текущий фокус: стабилизировать CI после вынесения workspace packages, добавить headless smoke coverage и продолжить Phase F для TypeScript packages/workspaces.
+
+## Архитектура
+
+### Rust backend
+
+Модульная структура находится в `crates/`:
+
+- `ts-schema` - `ProjectSchema` и контрактные типы.
+- `ts-core-types` - ошибки, EventBus, progress и общие DTO.
+- `ts-render` - headless render pipeline.
+- `ts-media`, `ts-recognition`, `ts-analysis`, `ts-montage`, `ts-subtitles` - доменные движки.
+- `ts-state` - headless `ProjectState` и `EventSink`.
+- `ts-agent` - agent orchestration и video tools.
+- `ts-platform`, `ts-publish`, `ts-cli` - оптимизация, публикация и единый headless CLI.
+
+`src-tauri` теперь выступает тонким host/glue слоем и подключает новые крейты path-зависимостями.
+
+### TypeScript packages
+
+Сейчас вынесен первый workspace package:
+
+- `packages/shared-types` - `@timeline/shared-types`, TS-зеркало Rust контрактов.
+
+Следующий трек описан в [#150](https://github.com/chatman-media/timeline-studio/issues/150): вынести `core`, `domains`, `adapters`, `ui` и подготовить `apps/desktop` / `apps/cli` без big-bang миграции.
+
+## Agent/headless integration
+
+Headless контур уже включает:
+
+- `timeline render` - `ProjectSchema` JSON to video.
+- `timeline analyze` - media analysis JSON.
+- `timeline montage-plan` - montage plan to `ProjectSchema`.
+- `timeline optimize` / `thumbnail` - platform processing.
+- `timeline publish telegram|youtube` - реальные publish paths.
+- `timeline pipeline` - базовый `analyze -> optimize -> publish` flow.
+- `timeline emit-schema` / `emit-example` - внешний контракт.
+
+Контракт документирован в [AGENT_CONTRACT_REFERENCE.md](../engineering/AGENT_CONTRACT_REFERENCE.md).
+
+## Текущие блокеры
+
+- [#147](https://github.com/chatman-media/timeline-studio/issues/147) - синхронизировать `bun.lock` и `package-lock.json` после `@timeline/shared-types`.
+- [#148](https://github.com/chatman-media/timeline-studio/issues/148) - исправить `ts-montage` doctest после смены API.
+
+Эта ветка содержит исправления для обоих пунктов; после merge нужно дождаться зеленого CI на `main`.
+
+## Следующие задачи
+
+- [#149](https://github.com/chatman-media/timeline-studio/issues/149) - добавить end-to-end smoke для headless agent pipeline.
+- [#150](https://github.com/chatman-media/timeline-studio/issues/150) - Phase F: JS packages/workspaces.
+- Закрыть документационный долг в связанных архитектурных страницах после стабилизации CI.
+
+## Проверки для ближайшего merge
+
+Минимальный набор:
+
+```bash
+bun install --frozen-lockfile
+npm ci --omit=optional
+cd crates && cargo test -p ts-montage --doc
+cd crates && cargo test --workspace --no-fail-fast -- --test-threads=2
+```
+
+Дополнительно для host changes:
+
+```bash
+cd src-tauri && cargo check
+```

--- a/docs/10_project_state/roadmap.md
+++ b/docs/10_project_state/roadmap.md
@@ -1,196 +1,108 @@
-# ДОРОЖНАЯ КАРТА TIMELINE STUDIO
+# Roadmap Timeline Studio
 
-## 🎯 Видение проекта
+*Последнее обновление: 7 июня 2026*
 
-Timeline Studio - это современный видеоредактор, сочетающий:
-- **Профессиональную мощь DaVinci Resolve** - полный контроль над монтажом
-- **Обширную творческую библиотеку** - эффекты, фильтры, переходы, шаблоны
-- **AI-скриптинг и автоматизацию** - автоматическая генерация контента
-- **Локальные AI модели** - работа без облачных сервисов через Ollama
+## Видение
 
-**Ключевая инновация**: Пользователю достаточно загрузить ресурсы, а AI автоматически создаст набор видео на разных языках, оптимизированных под разные платформы, и автоматически загрузит их во все социальные сети.
+Timeline Studio развивается в видеоредактор, которым можно пользоваться как через GUI, так и headless: агент получает цель, анализирует исходные медиа, строит `ProjectSchema`, рендерит, оптимизирует и публикует результат.
 
-## 📅 График релизов
+Ключевая архитектурная ставка: единый типизированный контракт между GUI, headless CLI, агентом и внешними интеграциями.
 
-### ✅ Alpha Release v0.60.0 (3 августа 2025) - ВЫПУЩЕН! 🎉
+## Завершено
 
-**Статус**: 100% готов и выпущен!
+### Rust modularization
 
-**Что включено**:
-- ✅ Профессиональный видеоредактор с timeline
-- ✅ 100+ эффектов, фильтров и переходов
-- ✅ Advanced Color Grading система
-- ✅ Fairlight Audio микшер
-- ✅ AI Chat интеграция (Claude/OpenAI/Ollama) с **257 AI инструментом** 🎯
-- ✅ **Ollama интеграция** - локальные AI модели (Llama 3.2, Phi-3, Gemma 2, Qwen 2.5)
-- ✅ AI Content Intelligence Suite (**4 движка**: Content Classification, Scene Analysis, Script Generation, Multi-Platform)
-- ✅ Person Identification - распознавание и управление персонами
-- ✅ Smart Montage Planner - AI-powered автоматический монтаж
-- ✅ Экспорт в основные форматы
-- ✅ OAuth публикация в соцсети
-- ✅ 15 языков локализации
-- ✅ **Унифицированная система ресурсов** - 8 типов с единым API
-- ✅ **Biome** - единый инструмент для линтинга и форматирования
-- ✅ **GitHub Actions** - автоматическая сборка для всех платформ
+Закрыт epic [#91](https://github.com/chatman-media/timeline-studio/issues/91): backend распилен на layered `ts-*` crates.
 
-**Достижения альфа-релиза**:
-- ✅ Интеграция с Ollama для бесплатных локальных AI моделей
-- ✅ Миграция с ESLint на Biome
-- ✅ Создание отдельной ветки `alpha-release-v0.60.0`
-- ✅ Автоматизация сборки через GitHub Actions
+Готово:
 
-### 🚀 Beta Release (Q4 2025) - 20% готов
+- Cargo workspace для `crates/*`.
+- `ts-schema` и `ts-core-types` как foundation layer.
+- `ts-render` и headless render path.
+- Доменные крейты `ts-media`, `ts-recognition`, `ts-analysis`, `ts-montage`, `ts-subtitles`.
+- `ts-state` без Tauri-зависимости.
+- `ts-agent` и headless video tools.
+- Slim Tauri host поверх новых крейтов.
+- Изоляция heavy deps: `tauri`, `ort`, `pyo3`, `wasmtime` не протекают в общий headless path.
 
-**Цель**: Стабильная версия с расширенными возможностями
+### Agentic headless pipeline
 
-**План работ до Beta**:
+Закрыт epic [#119](https://github.com/chatman-media/timeline-studio/issues/119).
 
-#### Приоритет 1 (Критично для Beta)
-- 🔧 **Исправление TypeScript ошибок** - снизить с 1860 до < 100
-- 🔧 **GPU ускорение для Ollama** - интеграция CUDA/Metal
-- 🔧 **Стриминг ответов AI** - реальное время вместо батчей
-- 🔧 **Whisper интеграция** - профессиональная транскрипция
+Готово:
 
-#### Приоритет 2 (Основные функции Beta)
-- **Comprehensive Resources Database** - 5000+ ресурсов уровня Filmora 🎯
-- **Cloud Storage & Sync** - мультиплатформенная синхронизация 🎯
-- **Cloud AI провайдеры** - опциональная поддержка OpenAI/Anthropic
-- Person Identification Advanced - ML модели, real-time трекинг
-- Effects Library Extension - 500+ профессиональных эффектов
-- Performance Optimization - proxy файлы для 4K/8K
-- Plugin System с WASM поддержкой
-- Расширенная документация и туториалы
+- Единый `timeline` CLI.
+- `render`, `ingest`, `analyze`, `montage-plan`, `optimize`, `thumbnail`.
+- `publish telegram` и `publish youtube`.
+- `pipeline` для базового produce-to-publish flow.
+- LLM planner через OpenAI-compatible BYOK endpoint.
 
-### 🌟 Version 1.0 (Q2 2026)
+### Contracts
 
-**Цель**: Полноценный релиз для массового использования
+Закрыт epic [#120](https://github.com/chatman-media/timeline-studio/issues/120).
 
-**Новые функции**:
-- Cloud Rendering - облачная обработка видео
-- Telegram Mini App - мобильное приложение
-- Project Version Control - Git для видеопроектов
-- Marketplace для плагинов и шаблонов
-- Enterprise функции (team collaboration)
-- **Collaborative editing** - совместная работа над проектами
+Готово:
 
-### 🔮 Version 2.0 (Q4 2026)
+- `ProjectSchema` JSON Schema.
+- `AnalysisResult`, `OptimizeRequest/Result`, `PublishRequest/Result`.
+- `@timeline/shared-types`.
+- [Agent Contract Reference](../engineering/AGENT_CONTRACT_REFERENCE.md).
 
-**Цель**: Революция в видеопроизводстве
+## Сейчас
 
-**Инновации**:
-- **DocuDrama-You** - AI создает фильмы из вашей жизни
-- **Living Series** - автоматические сериалы о людях
-- **Cinema Without Screenwriters** - AI находит сюжеты в raw footage
-- Интеграция с VR/AR
-- Real-time collaboration
-- **Mobile Apps** - полноценные iOS/Android приложения
+### P0: стабилизировать CI
 
-## 📊 Метрики успеха
+- [#147](https://github.com/chatman-media/timeline-studio/issues/147) - lock-файлы для `@timeline/shared-types`.
+- [#148](https://github.com/chatman-media/timeline-studio/issues/148) - `ts-montage` doctest/API drift.
 
-### Alpha (Текущая фаза - АКТИВНА)
-- ✅ Выпущена версия 0.60.0-alpha
-- 🎯 1,000+ early adopters (в процессе)
-- 🎯 50+ обработанных видео в день
-- 🎯 80%+ удовлетворенность пользователей
-- ✅ **257 AI инструмент** в использовании
-- ✅ **Локальные AI модели** через Ollama
+Acceptance:
 
-### Beta (Q4 2025)
-- 10,000+ активных пользователей
-- 500+ видео в день
-- Интеграция с 10+ платформами
-- **5000+ ресурсов** в базе данных
-- < 100 TypeScript ошибок
+- `bun install --frozen-lockfile` проходит.
+- `npm ci --omit=optional` проходит.
+- `cd crates && cargo test -p ts-montage --doc` проходит.
+- Crates workspace CI больше не падает на doctest.
 
-### v1.0 (Q2 2026)
-- 100,000+ пользователей
-- 5,000+ видео в день
-- Прибыльность через Pro подписки
-- **Мультиплатформенная синхронизация** активна
+### P1: защитить headless pipeline
 
-## 🛠️ Технический долг
+- [#149](https://github.com/chatman-media/timeline-studio/issues/149) - end-to-end smoke для agent produce-to-publish.
 
-### ✅ Завершено (Alpha)
-- ✅ Оптимизация памяти для больших проектов
-- ✅ Улучшение производительности timeline
-- ✅ Стабилизация экспорта
-- ✅ Интеграция Ollama для локальных AI
-- ✅ Миграция на Biome
-- ✅ CI/CD оптимизация
+Acceptance:
 
-### Приоритет 1 (до Beta)
-- 🔧 **TypeScript ошибки** - исправить 1860 ошибок
-- 🔧 **GPU ускорение** - для Ollama моделей
-- 🔧 **Стриминг AI** - реальное время ответов
-- 🔧 **Whisper** - транскрипция аудио
+- Быстрый smoke можно запускать локально и в CI.
+- Проверяется минимальный contract/render/analyze/pipeline path без GUI.
+- Failure clearly points to the broken pipeline step.
 
-### Приоритет 2 (до Beta)
-- **Comprehensive Resources Database** - создание базы 5000+ ресурсов
-- **Cloud Storage & Sync** - мультиплатформенная синхронизация
-- Рефакторинг системы плагинов
-- Миграция на новые API Tauri
-- Улучшение тестового покрытия до 90%
+### P1: Phase F TypeScript packages
 
-### Приоритет 3 (до v1.0)
-- Оптимизация bundle size
-- Улучшение startup time до 1 секунды
-- Полная документация API
-- **Collaborative editing** - совместная работа
+- [#150](https://github.com/chatman-media/timeline-studio/issues/150) - JS packages/workspaces для `core`, `domains`, `adapters`, `ui`.
 
-## 🤝 Вклад сообщества
+Acceptance:
 
-### Нужна помощь с:
-- **Тестированием альфа-версии** на разных платформах
-- **Обратной связью** по Ollama интеграции
-- Переводами на новые языки
-- Созданием туториалов и документации
-- Разработкой плагинов
-- Дизайном новых шаблонов
+- Есть пошаговый migration plan.
+- UI не импортирует platform-specific adapters напрямую.
+- Каждый slice оставляет desktop app buildable/testable.
 
-### Bounty программа
-- Bug fixes: $50-500
-- Новые функции: $200-2000
-- Плагины: $100-1000
-- Документация: $50-200
-- **Альфа-тестирование**: специальные награды early adopters
+## Далее
 
-## 📈 Бизнес-модель
+### Product hardening
 
-### Free Tier (Альфа-версия)
-- **Полный доступ** во время альфа-тестирования
-- Локальные AI модели через Ollama
-- Неограниченный экспорт
-- Обратная связь приветствуется
+- Реальные fixture-based integration tests для render/analyze/publish validate paths.
+- Улучшение diagnostics для CLI и agent contract validation.
+- Headless Docker image и runtime docs после стабилизации CI.
 
-### Pro ($19/месяц) - с Beta
-- Все функции
-- Cloud AI провайдеры
-- Приоритетная поддержка
-- Cloud rendering (ограничено)
+### Frontend architecture
 
-### Enterprise ($99/месяц) - с v1.0
-- Team collaboration
-- Неограниченный cloud rendering
-- Custom branding
-- API доступ
-- SLA поддержка
+- Перенести существующие Ports & Adapters правила из docs в enforceable import boundaries.
+- Начать package extraction с минимального shared/core слоя, затем adapters, затем UI/features.
 
-## 🎉 Текущий статус
+### Documentation
 
-**АЛЬФА-ВЕРСИЯ ДОСТУПНА ДЛЯ ТЕСТИРОВАНИЯ!**
+- Обновить architecture overview под `crates/*`, `packages/shared-types` и `timeline` CLI.
+- Связать user-facing docs с headless/agent flows только после green smoke coverage.
 
-- Версия: 0.60.0-alpha
-- Ветка: `alpha-release-v0.60.0`
-- Дата релиза: 3 августа 2025
-- Платформы: Windows, macOS, Linux
+## Источники правды
 
-**Как начать:**
-1. Установить Ollama
-2. Скачать модель `ollama pull llama3.2`
-3. Запустить Timeline Studio
-4. Наслаждаться локальным AI!
-
----
-
-*Дорожная карта обновляется на основе feedback сообщества*
-*Присоединяйтесь к альфа-тестированию!*
+- [Current Status](current-status.md)
+- [Agent Contract Reference](../engineering/AGENT_CONTRACT_REFERENCE.md)
+- [Rust crates workspace](../../crates/Cargo.toml)
+- [Shared TypeScript package](../../packages/shared-types/package.json)

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "timeline-studio",
       "version": "3.60.1",
       "license": "SEE LICENSE IN LICENSE",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
@@ -10798,6 +10801,10 @@
       "peerDependencies": {
         "@testing-library/dom": ">=7.21.4"
       }
+    },
+    "node_modules/@timeline/shared-types": {
+      "resolved": "packages/shared-types",
+      "link": true
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.1",
@@ -28000,6 +28007,28 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
+      }
+    },
+    "packages/shared-types": {
+      "name": "@timeline/shared-types",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "^5.0.0"
+      }
+    },
+    "packages/shared-types/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     }
   }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -25,15 +25,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,7 +356,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix 1.1.3",
+ "rustix",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -406,7 +397,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix 1.1.3",
+ "rustix",
 ]
 
 [[package]]
@@ -432,7 +423,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 1.1.3",
+ "rustix",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
@@ -767,9 +758,6 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
-dependencies = [
- "allocator-api2",
-]
 
 [[package]]
 name = "byte-unit"
@@ -867,48 +855,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cap-fs-ext"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5528f85b1e134ae811704e41ef80930f56e795923f866813255bc342cc20654"
-dependencies = [
- "cap-primitives 3.4.5",
- "cap-std 3.4.5",
- "io-lifetimes 2.0.4",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "cap-net-ext"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a158160765c6a7d0d8c072a53d772e4cb243f38b04bfcf6b4939cfbe7482e7"
-dependencies = [
- "cap-primitives 3.4.5",
- "cap-std 3.4.5",
- "rustix 1.1.3",
- "smallvec 1.15.1",
-]
-
-[[package]]
-name = "cap-primitives"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6cf3aea8a5081171859ef57bc1606b1df6999df4f1110f8eef68b30098d1d3a"
-dependencies = [
- "ambient-authority",
- "fs-set-times",
- "io-extras 0.18.4",
- "io-lifetimes 2.0.4",
- "ipnet",
- "maybe-owned",
- "rustix 1.1.3",
- "rustix-linux-procfs",
- "windows-sys 0.59.0",
- "winx",
-]
-
-[[package]]
 name = "cap-primitives"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,36 +862,14 @@ checksum = "f2738131575dbd2ca9e8e144a102ba4e534ca726e2446f1e92090a1cc08fe283"
 dependencies = [
  "ambient-authority",
  "fs-set-times",
- "io-extras 0.19.0",
+ "io-extras",
  "io-lifetimes 3.0.1",
  "ipnet",
  "maybe-owned",
- "rustix 1.1.3",
+ "rustix",
  "rustix-linux-procfs",
  "windows-sys 0.61.2",
  "winx",
-]
-
-[[package]]
-name = "cap-rand"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8144c22e24bbcf26ade86cb6501a0916c46b7e4787abdb0045a467eb1645a1d"
-dependencies = [
- "ambient-authority",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "cap-std"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6dc3090992a735d23219de5c204927163d922f42f575a0189b005c62d37549a"
-dependencies = [
- "cap-primitives 3.4.5",
- "io-extras 0.18.4",
- "io-lifetimes 2.0.4",
- "rustix 1.1.3",
 ]
 
 [[package]]
@@ -954,24 +878,10 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42d9210de501a941735b489ee5c41501283259ddf3fec9884ace40def0a80a11"
 dependencies = [
- "cap-primitives 4.0.0",
- "io-extras 0.19.0",
+ "cap-primitives",
+ "io-extras",
  "io-lifetimes 3.0.1",
- "rustix 1.1.3",
-]
-
-[[package]]
-name = "cap-time-ext"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def102506ce40c11710a9b16e614af0cde8e76ae51b1f48c04b8d79f4b671a80"
-dependencies = [
- "ambient-authority",
- "cap-primitives 3.4.5",
- "iana-time-zone",
- "once_cell",
- "rustix 1.1.3",
- "winx",
+ "rustix",
 ]
 
 [[package]]
@@ -1058,7 +968,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
 dependencies = [
  "smallvec 1.15.1",
- "target-lexicon 0.12.16",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -1159,15 +1069,6 @@ name = "clap_lex"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
-
-[[package]]
-name = "cobs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
-dependencies = [
- "thiserror 2.0.17",
-]
 
 [[package]]
 name = "color_quant"
@@ -1298,144 +1199,6 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "cranelift-assembler-x64"
-version = "0.127.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff9edf1a79ff137b5c9bc74aff5d8467a8bea67722d9f4a2a0dc555504e8dc66"
-dependencies = [
- "cranelift-assembler-x64-meta",
-]
-
-[[package]]
-name = "cranelift-assembler-x64-meta"
-version = "0.127.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed408aad286cb6433f3e361268b588566ac138dc0d8cf1c22af822c004250ad"
-dependencies = [
- "cranelift-srcgen",
-]
-
-[[package]]
-name = "cranelift-bforest"
-version = "0.127.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efddb47bd7fc6fb0fe9387a82c4cf1987b7402fefa694f73be1f3ae2b26663ab"
-dependencies = [
- "cranelift-entity",
-]
-
-[[package]]
-name = "cranelift-bitset"
-version = "0.127.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2922de888b20fedaff065be5a4044f5c3c13cb1132db8f1f56f7a5c03a768c81"
-dependencies = [
- "serde",
- "serde_derive",
-]
-
-[[package]]
-name = "cranelift-codegen"
-version = "0.127.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3172ca7ba0bf31cae6dd4dffbfc33e0afe5994eb3ec29608d0ab14bcb674cb"
-dependencies = [
- "bumpalo",
- "cranelift-assembler-x64",
- "cranelift-bforest",
- "cranelift-bitset",
- "cranelift-codegen-meta",
- "cranelift-codegen-shared",
- "cranelift-control",
- "cranelift-entity",
- "cranelift-isle",
- "gimli",
- "hashbrown 0.15.5",
- "log",
- "pulley-interpreter",
- "regalloc2",
- "rustc-hash",
- "serde",
- "smallvec 1.15.1",
- "target-lexicon 0.13.4",
- "wasmtime-internal-math",
-]
-
-[[package]]
-name = "cranelift-codegen-meta"
-version = "0.127.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2bad8d14320124ea673cb11b7db0176470279b7ec1d0f201f79a7c0213f52f6"
-dependencies = [
- "cranelift-assembler-x64-meta",
- "cranelift-codegen-shared",
- "cranelift-srcgen",
- "heck 0.5.0",
- "pulley-interpreter",
-]
-
-[[package]]
-name = "cranelift-codegen-shared"
-version = "0.127.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c414fe1c62e61d269a928594bd0f10fb6fa707e112b433fc19cc8d5aeaf08fda"
-
-[[package]]
-name = "cranelift-control"
-version = "0.127.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac90ac0e9a0dd900a880ee6b56f36e37ca5017af9f7d1390805dcb6f35e4064"
-dependencies = [
- "arbitrary",
-]
-
-[[package]]
-name = "cranelift-entity"
-version = "0.127.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c63209c9b060b3048b2cc6483bdba85e93118268d14b3ce1452615e7cb42010"
-dependencies = [
- "cranelift-bitset",
- "serde",
- "serde_derive",
-]
-
-[[package]]
-name = "cranelift-frontend"
-version = "0.127.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42ad0eeaa7f2c365a06ec50580ff6820f1ef45de1c784e8080f5b24bbe3a634"
-dependencies = [
- "cranelift-codegen",
- "log",
- "smallvec 1.15.1",
- "target-lexicon 0.13.4",
-]
-
-[[package]]
-name = "cranelift-isle"
-version = "0.127.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "316dd3048717d1ad577d23fb2773671bc4fe633b651bb0d41be79d1a2dd0121b"
-
-[[package]]
-name = "cranelift-native"
-version = "0.127.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dc065eb9d570d70360d9eceb5be0faf1e5871aa53973389a4a9d37bf2c748b5"
-dependencies = [
- "cranelift-codegen",
- "libc",
- "target-lexicon 0.13.4",
-]
-
-[[package]]
-name = "cranelift-srcgen"
-version = "0.127.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a628782eefce8d87340a08f635d19e55e2900a77706f56b75cf73f1efc880a3"
 
 [[package]]
 name = "crc"
@@ -1896,18 +1659,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
-name = "embedded-io"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
-
-[[package]]
-name = "embedded-io"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2121,17 +1872,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fd-lock"
-version = "4.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
-dependencies = [
- "cfg-if",
- "rustix 1.1.3",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2305,7 +2045,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes 2.0.4",
- "rustix 1.1.3",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -2568,7 +2308,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
- "rustix 1.1.3",
+ "rustix",
  "windows-link 0.2.1",
 ]
 
@@ -2628,17 +2368,6 @@ checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
 dependencies = [
  "color_quant",
  "weezl",
-]
-
-[[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
-dependencies = [
- "fallible-iterator",
- "indexmap 2.13.0",
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -2983,7 +2712,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.1.5",
- "serde",
 ]
 
 [[package]]
@@ -3404,12 +3132,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3519,15 +3241,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "infer"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3554,16 +3267,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
-]
-
-[[package]]
-name = "io-extras"
-version = "0.18.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
-dependencies = [
- "io-lifetimes 2.0.4",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3807,18 +3510,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "leb128"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "lebe"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3914,12 +3605,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
@@ -3979,15 +3664,6 @@ dependencies = [
  "objc2",
  "objc2-foundation",
  "time",
-]
-
-[[package]]
-name = "mach2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -4083,15 +3759,6 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
-
-[[package]]
-name = "memfd"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
-dependencies = [
- "rustix 1.1.3",
-]
 
 [[package]]
 name = "memoffset"
@@ -4839,18 +4506,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "crc32fast",
- "hashbrown 0.15.5",
- "indexmap 2.13.0",
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5499,7 +5154,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 1.1.3",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -5528,18 +5183,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
-]
-
-[[package]]
-name = "postcard"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
-dependencies = [
- "cobs",
- "embedded-io 0.4.0",
- "embedded-io 0.6.1",
- "serde",
 ]
 
 [[package]]
@@ -5773,96 +5416,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "pulley-interpreter"
-version = "40.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "004fcd8704734dbfe832bccd4577f0bf5a4fee9b3240e5afd966ab9e6f6718a2"
-dependencies = [
- "cranelift-bitset",
- "log",
- "pulley-macros",
- "wasmtime-internal-math",
-]
-
-[[package]]
-name = "pulley-macros"
-version = "40.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a39353997967faac3a65893dd956bc982b5fb16c5e435f221298b67d08d1124"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
 name = "pxfm"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "pyo3"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
-dependencies = [
- "indoc",
- "libc",
- "memoffset",
- "once_cell",
- "portable-atomic",
- "pyo3-build-config",
- "pyo3-ffi",
- "pyo3-macros",
- "unindent",
-]
-
-[[package]]
-name = "pyo3-build-config"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b455933107de8642b4487ed26d912c2d899dec6114884214a0b3bb3be9261ea6"
-dependencies = [
- "target-lexicon 0.13.4",
-]
-
-[[package]]
-name = "pyo3-ffi"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c85c9cbfaddf651b1221594209aed57e9e5cff63c4d11d1feead529b872a089"
-dependencies = [
- "libc",
- "pyo3-build-config",
-]
-
-[[package]]
-name = "pyo3-macros"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5b10c9bf9888125d917fb4d2ca2d25c8df94c7ab5a52e13313a07e050a3b02"
-dependencies = [
- "proc-macro2",
- "pyo3-macros-backend",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "pyo3-macros-backend"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b51720d314836e53327f5871d4c0cfb4fb37cc2c4a11cc71907a86342c40f9"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "pyo3-build-config",
- "quote",
- "syn 2.0.114",
 ]
 
 [[package]]
@@ -6250,20 +5809,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regalloc2"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08effbc1fa53aaebff69521a5c05640523fab037b34a4a2c109506bc938246fa"
-dependencies = [
- "allocator-api2",
- "bumpalo",
- "hashbrown 0.15.5",
- "log",
- "rustc-hash",
- "smallvec 1.15.1",
-]
-
-[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6513,19 +6058,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.13.0",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
@@ -6533,7 +6065,7 @@ dependencies = [
  "bitflags 2.13.0",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -6544,7 +6076,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
 dependencies = [
  "once_cell",
- "rustix 1.1.3",
+ "rustix",
 ]
 
 [[package]]
@@ -7755,22 +7287,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-interface"
-version = "0.27.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4592f674ce18521c2a81483873a49596655b179f71c5e05d10c1fe66c78745"
-dependencies = [
- "bitflags 2.13.0",
- "cap-fs-ext",
- "cap-std 3.4.5",
- "fd-lock",
- "io-lifetimes 2.0.4",
- "rustix 0.38.44",
- "windows-sys 0.59.0",
- "winx",
-]
-
-[[package]]
 name = "tabwriter"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7852,12 +7368,6 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
-
-[[package]]
-name = "target-lexicon"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1dd07eb858a2067e2f3c7155d54e929265c264e6f37efe3ee7a8d1b5a1dd0ba"
 
 [[package]]
 name = "tauri"
@@ -8347,7 +7857,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix 1.1.3",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -8360,15 +7870,6 @@ dependencies = [
  "futf",
  "mac",
  "utf-8",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -8483,7 +7984,7 @@ dependencies = [
  "async-trait",
  "axum",
  "base64 0.22.1",
- "cap-std 4.0.0",
+ "cap-std",
  "chrono",
  "criterion",
  "ctor 0.6.3",
@@ -8517,7 +8018,6 @@ dependencies = [
  "os_info",
  "parking_lot",
  "prometheus",
- "pyo3",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
  "regex",
@@ -8555,20 +8055,21 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "ts-agent",
  "ts-analysis",
+ "ts-core-types",
  "ts-media",
  "ts-montage",
  "ts-platform",
  "ts-recognition",
  "ts-render",
  "ts-schema",
+ "ts-state",
  "ts-subtitles",
  "url",
  "urlencoding",
  "uuid",
  "wasm-bindgen",
- "wasmtime",
- "wasmtime-wasi",
  "which",
  "zstd",
 ]
@@ -9044,6 +8545,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "ts-agent"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "log",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "ts-analysis",
+ "ts-platform",
+ "ts-publish",
+ "ts-render",
+ "ts-schema",
+ "ts-state",
+ "uuid",
+]
+
+[[package]]
 name = "ts-analysis"
 version = "0.1.0"
 dependencies = [
@@ -9059,6 +8579,18 @@ dependencies = [
  "ts-media",
  "ts-recognition",
  "ts-schema",
+ "uuid",
+]
+
+[[package]]
+name = "ts-core-types"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
  "uuid",
 ]
 
@@ -9104,6 +8636,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ts-publish"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
 name = "ts-recognition"
 version = "0.1.0"
 dependencies = [
@@ -9116,6 +8660,7 @@ dependencies = [
  "log",
  "ndarray 0.17.2",
  "ort",
+ "reqwest",
  "rusqlite",
  "serde",
  "serde_json",
@@ -9154,6 +8699,22 @@ dependencies = [
  "serde",
  "serde_json",
  "specta",
+ "uuid",
+]
+
+[[package]]
+name = "ts-state"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "log",
+ "serde",
+ "serde_json",
+ "specta",
+ "thiserror 1.0.69",
+ "tokio",
+ "ts-core-types",
+ "ts-schema",
  "uuid",
 ]
 
@@ -9304,18 +8865,6 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "universal-hash"
@@ -9566,16 +9115,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.243.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55db9c896d70bd9fa535ce83cd4e1f2ec3726b0edd2142079f594fc3be1cb35"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
 name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9586,310 +9125,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.243.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d8db401b0528ec316dfbe579e6ab4152d61739cfe076706d2009127970159d"
-dependencies = [
- "bitflags 2.13.0",
- "hashbrown 0.15.5",
- "indexmap 2.13.0",
- "semver",
- "serde",
-]
-
-[[package]]
-name = "wasmprinter"
-version = "0.243.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2b6035559e146114c29a909a3232928ee488d6507a1504d8934e8607b36d7b"
-dependencies = [
- "anyhow",
- "termcolor",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmtime"
-version = "40.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c37a54e95c2749c6d8d280d738966acd152bd892590ad1a77380799d78598484"
-dependencies = [
- "addr2line",
- "anyhow",
- "async-trait",
- "bitflags 2.13.0",
- "bumpalo",
- "cc",
- "cfg-if",
- "encoding_rs",
- "hashbrown 0.15.5",
- "indexmap 2.13.0",
- "libc",
- "log",
- "mach2",
- "memfd",
- "object",
- "once_cell",
- "postcard",
- "pulley-interpreter",
- "rustix 1.1.3",
- "semver",
- "serde",
- "serde_derive",
- "smallvec 1.15.1",
- "target-lexicon 0.13.4",
- "wasmparser",
- "wasmtime-environ",
- "wasmtime-internal-component-macro",
- "wasmtime-internal-component-util",
- "wasmtime-internal-cranelift",
- "wasmtime-internal-fiber",
- "wasmtime-internal-jit-debug",
- "wasmtime-internal-jit-icache-coherence",
- "wasmtime-internal-math",
- "wasmtime-internal-slab",
- "wasmtime-internal-unwinder",
- "wasmtime-internal-versioned-export-macros",
- "wasmtime-internal-winch",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "wasmtime-environ"
-version = "40.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4709e2612fa49178cdd341e8cd4c485ab729e948732951283bd271ee443e1ec0"
-dependencies = [
- "anyhow",
- "cranelift-bitset",
- "cranelift-entity",
- "gimli",
- "indexmap 2.13.0",
- "log",
- "object",
- "postcard",
- "semver",
- "serde",
- "serde_derive",
- "smallvec 1.15.1",
- "target-lexicon 0.13.4",
- "wasm-encoder",
- "wasmparser",
- "wasmprinter",
- "wasmtime-internal-component-util",
-]
-
-[[package]]
-name = "wasmtime-internal-component-macro"
-version = "40.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ce5c156db5391f2f7d7275f2eb9ca0fda7739ee90340d299a002634eb207747"
-dependencies = [
- "anyhow",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
- "wasmtime-internal-component-util",
- "wasmtime-internal-wit-bindgen",
- "wit-parser",
-]
-
-[[package]]
-name = "wasmtime-internal-component-util"
-version = "40.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27f58e0dcddebf1f116a75f71cf5f8fc3d14759fd753ed6d39ffa3bf4d95fdab"
-
-[[package]]
-name = "wasmtime-internal-cranelift"
-version = "40.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490c85aafb50a686f1d4dc53147ac65f51064bd226fd360825f5c647c9e3a565"
-dependencies = [
- "anyhow",
- "cfg-if",
- "cranelift-codegen",
- "cranelift-control",
- "cranelift-entity",
- "cranelift-frontend",
- "cranelift-native",
- "gimli",
- "itertools 0.14.0",
- "log",
- "object",
- "pulley-interpreter",
- "smallvec 1.15.1",
- "target-lexicon 0.13.4",
- "thiserror 2.0.17",
- "wasmparser",
- "wasmtime-environ",
- "wasmtime-internal-math",
- "wasmtime-internal-unwinder",
- "wasmtime-internal-versioned-export-macros",
-]
-
-[[package]]
-name = "wasmtime-internal-fiber"
-version = "40.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9cb3592b8ce9410a8e8b6abf79c1e10c34e3d6f0a8cccc05c544517102e189"
-dependencies = [
- "anyhow",
- "cc",
- "cfg-if",
- "libc",
- "rustix 1.1.3",
- "wasmtime-internal-versioned-export-macros",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "wasmtime-internal-jit-debug"
-version = "40.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02cbe560c79f17316ab188e5932aa533216ab5d5ab0608ac2f97c61452c8a059"
-dependencies = [
- "cc",
- "wasmtime-internal-versioned-export-macros",
-]
-
-[[package]]
-name = "wasmtime-internal-jit-icache-coherence"
-version = "40.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b4462e93068c8d73847a9d69c371b9dd8106cf020a736d43cdca519a20703b3"
-dependencies = [
- "anyhow",
- "cfg-if",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "wasmtime-internal-math"
-version = "40.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50a77e2f3f9009c5af4abb0c2875f64ab5f7c04875b3bcb8a8a120e22cdffe70"
-dependencies = [
- "libm",
-]
-
-[[package]]
-name = "wasmtime-internal-slab"
-version = "40.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d02ee7139a2c6454423d7cbb4723984f101c7c33b2617a90b43ff93c8ff198b"
-
-[[package]]
-name = "wasmtime-internal-unwinder"
-version = "40.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2002932b4978f372cba11dde7c3621b4634ad77eb0d10982887b628bace8cd3e"
-dependencies = [
- "anyhow",
- "cfg-if",
- "cranelift-codegen",
- "log",
- "object",
-]
-
-[[package]]
-name = "wasmtime-internal-versioned-export-macros"
-version = "40.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6453a1851a6d906c906fd6bc0b49041cd7b6f54226248b5a5c32ef50e094a0e5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "wasmtime-internal-winch"
-version = "40.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6da69b230b967f658e9a58928fada85d2e651b4d14713252c86b7e164d7e95e"
-dependencies = [
- "anyhow",
- "cranelift-codegen",
- "gimli",
- "log",
- "object",
- "target-lexicon 0.13.4",
- "wasmparser",
- "wasmtime-environ",
- "wasmtime-internal-cranelift",
- "winch-codegen",
-]
-
-[[package]]
-name = "wasmtime-internal-wit-bindgen"
-version = "40.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c92d907d4c1e9b6a04698eabb07ee2a8937ecebc700dfc3395ba43a849046c9"
-dependencies = [
- "anyhow",
- "bitflags 2.13.0",
- "heck 0.5.0",
- "indexmap 2.13.0",
- "wit-parser",
-]
-
-[[package]]
-name = "wasmtime-wasi"
-version = "40.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456260b09c346f2c3c21cbffa9beb5b80464800f27acfb8356b3fc401fe5067c"
-dependencies = [
- "anyhow",
- "async-trait",
- "bitflags 2.13.0",
- "bytes",
- "cap-fs-ext",
- "cap-net-ext",
- "cap-rand",
- "cap-std 3.4.5",
- "cap-time-ext",
- "fs-set-times",
- "futures",
- "io-extras 0.18.4",
- "io-lifetimes 2.0.4",
- "rustix 1.1.3",
- "system-interface",
- "thiserror 2.0.17",
- "tokio",
- "tracing",
- "url",
- "wasmtime",
- "wasmtime-wasi-io",
- "wiggle",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "wasmtime-wasi-io"
-version = "40.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4f812291d16c619e07c2e23569699dc904d076d55c81110cd29d957f1577e1"
-dependencies = [
- "anyhow",
- "async-trait",
- "bytes",
- "futures",
- "wasmtime",
-]
-
-[[package]]
-name = "wast"
-version = "35.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ef140f1b49946586078353a453a1d28ba90adfc54dde75710bc1931de204d68"
-dependencies = [
- "leb128",
 ]
 
 [[package]]
@@ -10023,7 +9258,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
 dependencies = [
  "env_home",
- "rustix 1.1.3",
+ "rustix",
  "winsafe",
 ]
 
@@ -10045,46 +9280,6 @@ checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
 dependencies = [
  "bytemuck",
  "safe_arch",
-]
-
-[[package]]
-name = "wiggle"
-version = "40.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704daebc51c911829fc14bf4293df5b286433503d25acc8d557fe7fdfac58cdd"
-dependencies = [
- "anyhow",
- "bitflags 2.13.0",
- "thiserror 2.0.17",
- "tracing",
- "wasmtime",
- "wiggle-macro",
-]
-
-[[package]]
-name = "wiggle-generate"
-version = "40.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ffa18973969c802f065390062fb68d129a55bb16d2dbfc235dd94620a7c4250"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
- "witx",
-]
-
-[[package]]
-name = "wiggle-macro"
-version = "40.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6142efa91a470033cdef55d1ff941a60913c891447e3d60c4967f44a03f2262a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
- "wiggle-generate",
 ]
 
 [[package]]
@@ -10117,26 +9312,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "winch-codegen"
-version = "40.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb7aa0d680c80b2f83dff67b3f56dcc9354f2f09a7249bf5bfc57565575b206"
-dependencies = [
- "anyhow",
- "cranelift-assembler-x64",
- "cranelift-codegen",
- "gimli",
- "regalloc2",
- "smallvec 1.15.1",
- "target-lexicon 0.13.4",
- "thiserror 2.0.17",
- "wasmparser",
- "wasmtime-environ",
- "wasmtime-internal-cranelift",
- "wasmtime-internal-math",
-]
 
 [[package]]
 name = "window-vibrancy"
@@ -10669,36 +9844,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
-name = "wit-parser"
-version = "0.243.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df983a8608e513d8997f435bb74207bf0933d0e49ca97aa9d8a6157164b9b7fc"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.13.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
-
-[[package]]
-name = "witx"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e366f27a5cabcddb2706a78296a40b8fcc451e1a6aba2fc1d94b4a01bdaaef4b"
-dependencies = [
- "anyhow",
- "log",
- "thiserror 1.0.69",
- "wast",
-]
-
-[[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10786,7 +9931,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
 dependencies = [
  "gethostname",
- "rustix 1.1.3",
+ "rustix",
  "x11rb-protocol",
 ]
 
@@ -10803,7 +9948,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix 1.1.3",
+ "rustix",
 ]
 
 [[package]]
@@ -10863,7 +10008,7 @@ dependencies = [
  "hex",
  "libc",
  "ordered-stream",
- "rustix 1.1.3",
+ "rustix",
  "serde",
  "serde_repr",
  "tracing",


### PR DESCRIPTION
## Summary
- sync npm/bun lockfiles after adding the @timeline/shared-types workspace
- fix the ts-montage headless planner doctest after the API change
- refresh current-status/roadmap docs and link the follow-up migration task to #150

Closes #147
Closes #148
Closes #151

## Verification
- cd crates && cargo test -p ts-montage --doc
- cd crates && cargo test --workspace --no-fail-fast -- --test-threads=2
- cd src-tauri && cargo check
- npm ci --omit=optional --ignore-scripts
- bun install --frozen-lockfile --ignore-scripts
- git diff --check

Note: exact npm/bun install without --ignore-scripts fails locally on Node 26 while compiling better-sqlite3 native bindings. The repo pins Node 24.10.0 and GitHub workflows use Node 24.