### PR TITLE
fix(test): avoid tauri InvokeArgs import in mock

### DIFF
--- a/src/test/mocks/tauri/core.ts
+++ b/src/test/mocks/tauri/core.ts
@@ -1,5 +1,6 @@
-import type { InvokeArgs } from "@tauri-apps/api/core"
 import { vi } from "vitest"
+
+type InvokeArgs = Record<string, unknown> | number[] | ArrayBuffer | Uint8Array
 
 export const mockInvoke = vi.fn()
 export const mockConvertFileSrc = vi.fn((src: string) => src)


### PR DESCRIPTION
## Summary
- replace the test Tauri mock import of `InvokeArgs` with a local invoke argument alias
- fixes the `bun run check:type` failure seen after #152

## Verification
- bun run check:type
- git diff --check