### PR TITLE
test(headless): add agent pipeline smoke

### DIFF
--- a/crates/ts-agent/src/pipeline.rs
+++ b/crates/ts-agent/src/pipeline.rs
@@ -1,6 +1,8 @@
 //! Сквозной агентный пайплайн: analyze → optimize → publish.
 
-use anyhow::Result;
+use std::path::Path;
+
+use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 
 use crate::steps;
@@ -49,6 +51,18 @@ pub struct PipelineResult {
   pub elapsed_secs: f64,
 }
 
+/// Результат быстрой проверки агентного pipeline без запуска ffmpeg/upload.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PipelineValidationResult {
+  pub mode: String,
+  pub input: String,
+  pub output: String,
+  pub platform: String,
+  pub scene_count: usize,
+  pub publish: Option<String>,
+  pub steps: Vec<String>,
+}
+
 // ─── pipeline ────────────────────────────────────────────────────────────────
 
 /// Агентный оркестратор: analyze → optimize → publish.
@@ -57,6 +71,74 @@ pub struct Pipeline;
 impl Pipeline {
   pub fn new() -> Self {
     Self
+  }
+
+  /// Проверить контракт pipeline без тяжелых операций и внешних токенов.
+  pub fn validate(&self, params: &PipelineParams) -> Result<PipelineValidationResult> {
+    if params.input.trim().is_empty() {
+      return Err(anyhow!("pipeline validate: input path is empty"));
+    }
+    if !Path::new(&params.input).exists() {
+      return Err(anyhow!(
+        "pipeline validate: input file not found: {}",
+        params.input
+      ));
+    }
+    if params.output.trim().is_empty() {
+      return Err(anyhow!("pipeline validate: output path is empty"));
+    }
+    if let Some(parent) = Path::new(&params.output).parent() {
+      if !parent.as_os_str().is_empty() && !parent.exists() {
+        return Err(anyhow!(
+          "pipeline validate: output directory not found: {}",
+          parent.display()
+        ));
+      }
+    }
+    if !matches!(
+      params.platform.as_str(),
+      "youtube" | "tiktok" | "reels" | "shorts" | "instagram" | "square"
+    ) {
+      return Err(anyhow!(
+        "pipeline validate: unsupported platform '{}'",
+        params.platform
+      ));
+    }
+    if params.scene_count == 0 {
+      return Err(anyhow!(
+        "pipeline validate: scene_count must be greater than zero"
+      ));
+    }
+
+    let mut steps = vec!["analyze".to_string(), "optimize".to_string()];
+    let publish = match &params.publish {
+      Some(PublishTarget::Telegram {
+        bot_token, chat_id, ..
+      }) => {
+        if bot_token.trim().is_empty() {
+          return Err(anyhow!("pipeline validate: telegram token is empty"));
+        }
+        if chat_id.trim().is_empty() {
+          return Err(anyhow!("pipeline validate: telegram chat is empty"));
+        }
+        steps.push("publish:telegram".to_string());
+        Some("telegram".to_string())
+      }
+      None => {
+        steps.push("publish:skipped".to_string());
+        None
+      }
+    };
+
+    Ok(PipelineValidationResult {
+      mode: "validate-only".to_string(),
+      input: params.input.clone(),
+      output: params.output.clone(),
+      platform: params.platform.clone(),
+      scene_count: params.scene_count,
+      publish,
+      steps,
+    })
   }
 
   /// Выполнить полный пайплайн.
@@ -85,7 +167,9 @@ impl Pipeline {
           bot_token,
           chat_id,
           caption,
-        } => steps::step_publish_telegram(&params.output, bot_token, chat_id, caption.clone()).await?,
+        } => {
+          steps::step_publish_telegram(&params.output, bot_token, chat_id, caption.clone()).await?
+        }
       };
       Some(msg.message_id)
     } else {
@@ -140,6 +224,49 @@ mod tests {
     let json = serde_json::to_string(&r).unwrap();
     assert!(json.contains("tiktok"));
     assert!(json.contains("6000"));
+  }
+
+  #[test]
+  fn pipeline_validate_catches_missing_input() {
+    let result = Pipeline::new().validate(&PipelineParams {
+      input: "/definitely/missing/video.mp4".into(),
+      platform: "youtube".into(),
+      output: "/tmp/out.mp4".into(),
+      publish: None,
+      scene_count: 1,
+    });
+
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("pipeline validate: input file not found"));
+  }
+
+  #[test]
+  fn pipeline_validate_accepts_publish_shape_without_network() {
+    let dir =
+      std::env::temp_dir().join(format!("timeline-pipeline-validate-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let input = dir.join("input.mp4");
+    std::fs::write(&input, b"not a real video").unwrap();
+
+    let result = Pipeline::new()
+      .validate(&PipelineParams {
+        input: input.to_string_lossy().to_string(),
+        platform: "youtube".into(),
+        output: dir.join("out.mp4").to_string_lossy().to_string(),
+        publish: Some(PublishTarget::Telegram {
+          bot_token: "fake-token".into(),
+          chat_id: "@timeline_smoke".into(),
+          caption: Some("smoke".into()),
+        }),
+        scene_count: 1,
+      })
+      .unwrap();
+
+    assert_eq!(result.mode, "validate-only");
+    assert_eq!(result.publish.as_deref(), Some("telegram"));
+    assert!(result.steps.contains(&"publish:telegram".to_string()));
+
+    let _ = std::fs::remove_dir_all(dir);
   }
 
   #[test]

--- a/crates/ts-cli/src/main.rs
+++ b/crates/ts-cli/src/main.rs
@@ -140,6 +140,9 @@ enum Cmd {
     /// число сцен для анализа
     #[arg(long, default_value_t = 8)]
     scenes: usize,
+    /// проверить контракт pipeline без ffmpeg/upload и внешних токенов
+    #[arg(long)]
+    validate_only: bool,
   },
   /// Анализировать медиафайл: ffprobe+ffmpeg → структурированный JSON
   Analyze {
@@ -322,7 +325,8 @@ async fn main() {
       chat,
       caption,
       scenes,
-    } => cmd_pipeline(input, platform, output, token, chat, caption, scenes).await,
+      validate_only,
+    } => cmd_pipeline(input, platform, output, token, chat, caption, scenes, validate_only).await,
     Cmd::Analyze {
       input,
       scenes,
@@ -693,6 +697,7 @@ async fn cmd_pipeline(
   chat: Option<String>,
   caption: Option<String>,
   scenes: usize,
+  validate_only: bool,
 ) {
   let publish = match (token, chat) {
     (Some(t), Some(c)) => Some(PublishTarget::Telegram {
@@ -703,16 +708,29 @@ async fn cmd_pipeline(
     _ => None,
   };
 
-  match Pipeline::new()
-    .run(PipelineParams {
-      input: input.clone(),
-      platform: platform.clone(),
-      output: output.clone(),
-      publish,
-      scene_count: scenes,
-    })
-    .await
-  {
+  let params = PipelineParams {
+    input: input.clone(),
+    platform: platform.clone(),
+    output: output.clone(),
+    publish,
+    scene_count: scenes,
+  };
+
+  if validate_only {
+    match Pipeline::new().validate(&params) {
+      Ok(r) => {
+        let json = serde_json::to_string_pretty(&r).unwrap();
+        println!("{json}");
+      }
+      Err(e) => {
+        eprintln!("❌ pipeline validate: {e}");
+        exit(1);
+      }
+    }
+    return;
+  }
+
+  match Pipeline::new().run(params).await {
     Ok(r) => {
       let json = serde_json::to_string_pretty(&r).unwrap();
       println!("{json}");

--- a/crates/ts-cli/tests/headless_pipeline_smoke.rs
+++ b/crates/ts-cli/tests/headless_pipeline_smoke.rs
@@ -1,0 +1,219 @@
+use std::{
+  fs,
+  path::{Path, PathBuf},
+  process::{Command, Output},
+  time::{SystemTime, UNIX_EPOCH},
+};
+
+use serde_json::Value;
+
+#[test]
+fn agent_produce_to_publish_headless_smoke() {
+  if !command_succeeds("ffmpeg", &["-version"]) || !command_succeeds("ffprobe", &["-version"]) {
+    eprintln!("skipping headless smoke: ffmpeg/ffprobe is not available");
+    return;
+  }
+
+  let workdir = temp_workdir();
+  fs::create_dir_all(&workdir).expect("create smoke temp dir");
+
+  let input = workdir.join("agent-input.mp4");
+  create_synthetic_video(&input);
+
+  let schema = run_timeline("emit-schema", &["emit-schema".into()]);
+  let schema_json: Value = parse_json("emit-schema stdout", &schema.stdout);
+  assert_eq!(schema_json["title"], "ProjectSchema");
+
+  let analysis_path = workdir.join("analysis.json");
+  run_timeline(
+    "analyze",
+    &[
+      "analyze".into(),
+      path_arg(&input),
+      "--scenes".into(),
+      "1".into(),
+      "--output".into(),
+      path_arg(&analysis_path),
+    ],
+  );
+  let analysis_json: Value = parse_json_file("analysis output", &analysis_path);
+  assert_eq!(analysis_json["file"]["media_type"], "video");
+  assert!(
+    analysis_json["scenes"]
+      .as_array()
+      .is_some_and(|s| !s.is_empty()),
+    "analyze should emit at least one sampled scene"
+  );
+
+  let validate_output = workdir.join("validate-only-should-not-exist.mp4");
+  let validation = run_timeline(
+    "pipeline validate-only",
+    &[
+      "pipeline".into(),
+      "--input".into(),
+      path_arg(&input),
+      "--platform".into(),
+      "square".into(),
+      "--output".into(),
+      path_arg(&validate_output),
+      "--token".into(),
+      "fake-token-for-shape-only".into(),
+      "--chat".into(),
+      "@timeline_smoke".into(),
+      "--caption".into(),
+      "smoke".into(),
+      "--scenes".into(),
+      "1".into(),
+      "--validate-only".into(),
+    ],
+  );
+  let validation_json: Value = parse_json("pipeline validate-only stdout", &validation.stdout);
+  assert_eq!(validation_json["mode"], "validate-only");
+  assert_eq!(validation_json["publish"], "telegram");
+  assert!(
+    validation_json["steps"]
+      .as_array()
+      .is_some_and(|steps| steps.iter().any(|step| step == "publish:telegram")),
+    "pipeline validate-only should cover the telegram publish leg"
+  );
+  assert!(
+    !validate_output.exists(),
+    "pipeline validate-only must not render or publish output"
+  );
+
+  let project_path = workdir.join("project.json");
+  let example = run_timeline("emit-example", &["emit-example".into(), path_arg(&input)]);
+  let project_json: Value = parse_json("emit-example stdout", &example.stdout);
+  assert_eq!(project_json["metadata"]["name"], "headless-single-clip");
+  fs::write(&project_path, &example.stdout).expect("write emitted ProjectSchema fixture");
+
+  let rendered_output = workdir.join("rendered.mp4");
+  run_timeline(
+    "render",
+    &[
+      "render".into(),
+      path_arg(&project_path),
+      path_arg(&rendered_output),
+    ],
+  );
+  assert_nonempty_file("render output", &rendered_output);
+
+  let optimized_output = workdir.join("optimized.mp4");
+  let pipeline = run_timeline(
+    "pipeline",
+    &[
+      "pipeline".into(),
+      "--input".into(),
+      path_arg(&input),
+      "--platform".into(),
+      "square".into(),
+      "--output".into(),
+      path_arg(&optimized_output),
+      "--scenes".into(),
+      "1".into(),
+    ],
+  );
+  let pipeline_json: Value = parse_json("pipeline stdout", &pipeline.stdout);
+  assert_eq!(pipeline_json["platform"], "square");
+  assert!(pipeline_json["message_id"].is_null());
+  assert_nonempty_file("pipeline optimized output", &optimized_output);
+
+  let _ = fs::remove_dir_all(&workdir);
+}
+
+fn run_timeline(step: &str, args: &[String]) -> Output {
+  let output = Command::new(env!("CARGO_BIN_EXE_timeline"))
+    .args(args)
+    .output()
+    .unwrap_or_else(|err| panic!("{step}: failed to spawn timeline: {err}"));
+
+  assert!(
+    output.status.success(),
+    "{step} failed\nargs: timeline {}\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
+    args.join(" "),
+    output.status,
+    String::from_utf8_lossy(&output.stdout),
+    String::from_utf8_lossy(&output.stderr)
+  );
+
+  output
+}
+
+fn command_succeeds(program: &str, args: &[&str]) -> bool {
+  Command::new(program)
+    .args(args)
+    .output()
+    .map(|output| output.status.success())
+    .unwrap_or(false)
+}
+
+fn create_synthetic_video(path: &Path) {
+  let output = Command::new("ffmpeg")
+    .args([
+      "-hide_banner",
+      "-loglevel",
+      "error",
+      "-f",
+      "lavfi",
+      "-i",
+      "testsrc=size=160x90:rate=15:duration=5",
+      "-pix_fmt",
+      "yuv420p",
+      "-c:v",
+      "libx264",
+      "-preset",
+      "ultrafast",
+      "-movflags",
+      "+faststart",
+      "-y",
+      &path_arg(path),
+    ])
+    .output()
+    .expect("spawn ffmpeg for synthetic video");
+
+  assert!(
+    output.status.success(),
+    "synthetic fixture generation failed\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
+    output.status,
+    String::from_utf8_lossy(&output.stdout),
+    String::from_utf8_lossy(&output.stderr)
+  );
+  assert_nonempty_file("synthetic input", path);
+}
+
+fn parse_json(label: &str, bytes: &[u8]) -> Value {
+  serde_json::from_slice(bytes).unwrap_or_else(|err| {
+    panic!(
+      "{label}: invalid JSON: {err}\n{}",
+      String::from_utf8_lossy(bytes)
+    )
+  })
+}
+
+fn parse_json_file(label: &str, path: &Path) -> Value {
+  let bytes =
+    fs::read(path).unwrap_or_else(|err| panic!("{label}: cannot read {}: {err}", path.display()));
+  parse_json(label, &bytes)
+}
+
+fn assert_nonempty_file(label: &str, path: &Path) {
+  let len = fs::metadata(path)
+    .unwrap_or_else(|err| panic!("{label}: missing {}: {err}", path.display()))
+    .len();
+  assert!(len > 0, "{label}: {} is empty", path.display());
+}
+
+fn temp_workdir() -> PathBuf {
+  let nanos = SystemTime::now()
+    .duration_since(UNIX_EPOCH)
+    .expect("system time")
+    .as_nanos();
+  std::env::temp_dir().join(format!(
+    "timeline-headless-smoke-{}-{nanos}",
+    std::process::id()
+  ))
+}
+
+fn path_arg(path: &Path) -> String {
+  path.to_string_lossy().into_owned()
+}

--- a/crates/ts-render/src/video_compiler/core/pipeline.rs
+++ b/crates/ts-render/src/video_compiler/core/pipeline.rs
@@ -840,7 +840,7 @@ impl CompositionStage {
     context: &PipelineContext,
     video_tracks: &[&crate::video_compiler::schema::Track],
   ) -> Result<Vec<String>> {
-    let mut command = vec!["ffmpeg".to_string()];
+    let mut command = vec!["ffmpeg".to_string(), "-y".to_string()];
 
     // Добавляем входные файлы
     let mut input_count = 0;
@@ -941,7 +941,7 @@ impl CompositionStage {
     context: &PipelineContext,
     audio_tracks: &[&crate::video_compiler::schema::Track],
   ) -> Result<Vec<String>> {
-    let mut command = vec!["ffmpeg".to_string()];
+    let mut command = vec!["ffmpeg".to_string(), "-y".to_string()];
 
     // Добавляем входные файлы
     let mut input_count = 0;
@@ -1854,6 +1854,7 @@ mod tests {
 
     // Check command structure
     assert_eq!(command[0], "ffmpeg");
+    assert_eq!(command[1], "-y");
     assert!(command.contains(&"-i".to_string()));
     assert!(command.contains(&video_file.to_string_lossy().to_string()));
   }

--- a/docs/engineering/AGENT_CONTRACT_REFERENCE.md
+++ b/docs/engineering/AGENT_CONTRACT_REFERENCE.md
@@ -298,6 +298,19 @@ let req: AnalysisRequest = serde_json::from_str(&json_str)?;
 let pub_req = PublishRequest::new("/project.json", "/output", RenderQuality::Web);
 ```
 
+## Headless smoke test
+
+Run the end-to-end agent smoke locally from the repository root:
+
+```bash
+cd crates && cargo test -p ts-cli --test headless_pipeline_smoke -- --nocapture
+```
+
+The test exercises the public `timeline` CLI contract without GUI/Tauri:
+`emit-schema`, synthetic media analysis, `pipeline --validate-only` with a
+Telegram publish target shape, `emit-example -> render`, and `pipeline`
+`analyze -> optimize` without external tokens.
+
 ---
 
 ## Versioning policy


### PR DESCRIPTION
## Summary
- add `timeline pipeline --validate-only` for token-free agent contract validation
- add a `ts-cli` integration smoke that drives the real `timeline` binary through schema emission, synthetic media analysis, validate-only publish shape, emit-example -> render, and analyze -> optimize pipeline
- document the one-command local smoke run in the agent contract reference

Closes #149

## Verification
- cd crates && cargo test -p ts-cli --test headless_pipeline_smoke -- --nocapture
- cd crates && cargo test -p ts-agent -p ts-cli --no-fail-fast
- cd crates && cargo test --workspace --no-fail-fast -- --test-threads=2
- git diff --check