### PR TITLE
chore(architecture): add Phase F package boundary baseline

### DIFF
--- a/config/package-boundaries.json
+++ b/config/package-boundaries.json
@@ -1,0 +1,71 @@
+{
+  "sourceRoot": "src",
+  "packages": [
+    {
+      "name": "core",
+      "paths": ["src/core/**"],
+      "description": "Platform-neutral ports, container and shared runtime types."
+    },
+    {
+      "name": "domains",
+      "paths": ["src/domains/**"],
+      "description": "Business domains and domain services."
+    },
+    {
+      "name": "adapters",
+      "paths": ["src/adapters/**"],
+      "description": "Platform and infrastructure implementations for core ports."
+    },
+    {
+      "name": "ui",
+      "paths": ["src/features/**", "src/components/ui/**"],
+      "description": "Reusable feature UI and shared UI components."
+    },
+    {
+      "name": "app-shell",
+      "paths": ["src/app/**", "src/cli/**", "src/config/**"],
+      "description": "Application wiring shells that compose UI, domains and adapters."
+    }
+  ],
+  "rules": [
+    {
+      "from": "core",
+      "disallow": ["domains", "adapters", "ui", "app-shell"],
+      "severity": "error",
+      "reason": "Core must stay platform-neutral and cannot depend on upper layers."
+    },
+    {
+      "from": "domains",
+      "disallow": ["adapters", "ui", "app-shell"],
+      "severity": "error",
+      "reason": "Domains must not depend on platform adapters, UI or app shells."
+    },
+    {
+      "from": "adapters",
+      "disallow": ["ui", "app-shell"],
+      "severity": "error",
+      "reason": "Adapters implement ports and cannot depend on UI or app shells."
+    },
+    {
+      "from": "ui",
+      "disallow": ["adapters"],
+      "severity": "error",
+      "reason": "UI packages must not import platform adapters directly."
+    },
+    {
+      "from": "ui",
+      "disallow": ["domains"],
+      "severity": "warn",
+      "reason": "UI-to-domain imports are legacy coupling to burn down through core ports."
+    }
+  ],
+  "ignore": [
+    "**/*.d.ts",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/__tests__/**",
+    "**/__mocks__/**"
+  ]
+}

--- a/docs/08_tasks/planned/monorepo-packages-migration.md
+++ b/docs/08_tasks/planned/monorepo-packages-migration.md
@@ -1,309 +1,149 @@
-# Миграция на монорепо с bun workspaces
+# Миграция на JS workspaces и модульную архитектуру
 
-**Статус:** Planned, tracked in [#150](https://github.com/chatman-media/timeline-studio/issues/150)
+**Статус:** Active, tracked in [#150](https://github.com/chatman-media/timeline-studio/issues/150)
 **Приоритет:** High
 **Создано:** 2025-11-29
 **Актуализировано:** 2026-06-07
 **Ответственный:** Architecture Team
 
-## 📋 Описание
+## Контекст
 
-Разделение проекта на независимые пакеты для улучшения модульности, тестируемости и возможности переиспользования кода. Использование bun workspaces для управления монорепо.
+Rust decomposition закрыта в [#91](https://github.com/chatman-media/timeline-studio/issues/91), `@timeline/shared-types` уже вынесен через [#104](https://github.com/chatman-media/timeline-studio/issues/104) и [#120](https://github.com/chatman-media/timeline-studio/issues/120). Следующий этап - перевести TypeScript/frontend часть на управляемые workspace-пакеты без большого одномоментного переноса файлов.
 
-## 🎯 Цели
+Главное ограничение Phase F: desktop app должен оставаться рабочим после каждого PR.
 
-1. **Независимость UI от адаптеров** - возможность тестировать UI с разными адаптерами (Tauri/Node/Mock)
-2. **Переиспользование кода** - использование core и domains в разных приложениях (Desktop, CLI, Web)
-3. **Изоляция изменений** - изменения в одном пакете не влияют на другие
-4. **Улучшение DX** - более понятная структура и зависимости
+## Цели
 
-## 🏗️ Целевая структура
+1. UI не импортирует platform adapters напрямую.
+2. Domains и adapters зависят от core-контрактов, а не друг от друга через app/runtime coupling.
+3. Core остается platform-neutral и пригодным для Desktop, CLI и будущего Web shell.
+4. Переход идет через проверяемые PR slices: каждый срез добавляет контракт, уменьшает coupling или готовит workspace split.
 
-```
+## Целевая структура
+
+```text
 timeline-studio/
 ├── packages/
-│   ├── core/                      # @timeline-studio/core
-│   │   ├── ports/                 # Интерфейсы сервисов
-│   │   ├── types/                 # Общие типы
-│   │   ├── container.ts           # DI контейнер
-│   │   └── package.json
-│   │
-│   ├── domains/                   # @timeline-studio/domains
-│   │   ├── ai-director/
-│   │   ├── media-management/
-│   │   ├── project-management/
-│   │   ├── video-editing/
-│   │   └── package.json           # зависит от: @timeline-studio/core
-│   │
-│   ├── adapters/                  # @timeline-studio/adapters
-│   │   ├── tauri/
-│   │   ├── node/
-│   │   ├── mock/
-│   │   └── package.json           # зависит от: @timeline-studio/core
-│   │
-│   └── ui/                        # @timeline-studio/ui
-│       ├── features/              # Все features
-│       ├── components/            # shadcn/ui компоненты
-│       └── package.json           # зависит от: @timeline-studio/core, @timeline-studio/types
-│
+│   ├── core/       # @timeline-studio/core
+│   ├── domains/    # @timeline-studio/domains
+│   ├── adapters/   # @timeline-studio/adapters
+│   ├── ui/         # @timeline-studio/ui
+│   └── shared-types/
 ├── apps/
-│   ├── desktop/                   # Desktop Tauri app
-│   │   ├── src-tauri/
-│   │   ├── src/
-│   │   │   └── app/               # Next.js App Router
-│   │   └── package.json           # зависит от: ui, domains, adapters
-│   │
-│   └── cli/                       # CLI приложение
-│       └── package.json           # зависит от: core, domains, adapters/node
-│
-├── package.json                   # Root workspace config
+│   ├── desktop/
+│   └── cli/
+├── package.json
 └── bun.lock
 ```
 
-## 📊 Граф зависимостей
+До физического split пакеты отражены bridge-алиасами в `tsconfig.json`:
 
-```
-apps/desktop → ui + domains + adapters/tauri
-apps/cli → domains + adapters/node
+- `@timeline-studio/core` -> `src/core`
+- `@timeline-studio/domains/*` -> `src/domains/*`
+- `@timeline-studio/adapters` -> `src/adapters`
+- `@timeline-studio/ui/features/*` -> `src/features/*`
+- `@timeline-studio/ui/components/*` -> `src/components/ui/*`
 
-ui → core
-domains → core
-adapters → core
-```
+Границы и правила описаны в [package-boundaries.md](../../engineering/package-boundaries.md) и `config/package-boundaries.json`.
 
-**Правило:** UI зависит ТОЛЬКО от core, не знает о domains и adapters напрямую.
+## Граф зависимостей
 
-## 🔧 Текущие проблемы
-
-### 1. Features напрямую импортирует из domains
-
-```typescript
-// ❌ Текущее состояние
-// features/transcription/hooks/use-transcription.ts
-import { TranscriptionService } from "@/domains/ai-services/services/transcription-service"
-
-// ✅ Должно быть
-import { getAI } from "@/core/container"
-import type { ITranscriptionService } from "@/core/ports"
+```text
+app-shell -> ui + domains + adapters
+ui -> core
+domains -> core
+adapters -> core
 ```
 
-### 2. Хуки из domains используются в features
+`app-shell` - это композиционный слой (`src/app`, `src/cli`, `src/config`), где допустимо связывать UI, domains и adapters. Все остальные слои должны двигаться к зависимостям через `core`.
 
-```typescript
-// ❌ Текущее
-import { useMediaManagement } from "@/domains/media-management"
+## Phase F PR slices
 
-// ✅ Должно быть
-import { useMediaManagement } from "@timeline-studio/core"
-// или через провайдер в core
+### F1: Package boundaries baseline
+
+**Цель:** зафиксировать правила до переноса файлов.
+
+- [x] Расширить root workspaces до `packages/*` и `apps/*`.
+- [x] Добавить bridge-алиасы `@timeline-studio/*` для текущей структуры `src/*`.
+- [x] Добавить `config/package-boundaries.json`.
+- [x] Добавить `bun run check:boundaries` в report-only режиме.
+- [x] Документировать PR slices и критерии проверки.
+
+### F2: Core bridge и ports
+
+**Цель:** убрать зависимость core от domains и начать снимать `ui -> domains` coupling.
+
+- [ ] Найти `core -> domains` импорты через `bun run check:boundaries`.
+- [ ] Вынести UI-facing контракты в `src/core/ports`.
+- [ ] Добавить bridge API в `src/core/container` или соседний composition module.
+- [ ] Перевести первый набор hooks/features с прямых domain imports на core API.
+- [ ] Оставить desktop поведение неизменным.
+
+### F3: Adapter contracts
+
+**Цель:** закрыть прямые импорты adapters из UI.
+
+- [ ] Найти `ui -> adapters` импорты через `bun run check:boundaries`.
+- [ ] Перенести нужные операции за core ports.
+- [ ] Инициализировать Tauri/Node/Mock implementations только в app-shell/adapters.
+- [ ] Подготовить mock adapter path для UI tests.
+
+### F4: UI pilot package
+
+**Цель:** проверить форму `@timeline-studio/ui` на одном вертикальном feature slice.
+
+- [ ] Выбрать feature с небольшим числом domain imports.
+- [ ] Перевести его public API на `@timeline-studio/ui/features/*`.
+- [ ] Убедиться, что feature не импортирует adapters и новые domain imports не добавляются.
+- [ ] Обновить relevant tests.
+
+### F5: Workspace split и CI
+
+**Цель:** физически создать пакеты/apps после burn-down основных циклов.
+
+- [ ] Создать `package.json` для `packages/core`, `packages/domains`, `packages/adapters`, `packages/ui`.
+- [ ] Создать `apps/desktop` и `apps/cli` без изменения runtime behavior.
+- [ ] Обновить build/test scripts, TypeScript references и lockfiles.
+- [ ] Настроить CI cache для workspace scripts.
+- [ ] Перевести boundary checker в strict mode или добавить CI gate по baseline.
+
+## Проверка каждого PR
+
+Минимальный набор для каждого Phase F slice:
+
+```bash
+bun install --frozen-lockfile --ignore-scripts
+bun run check:boundaries
+bun run check:type
 ```
 
-### 3. Типы разбросаны по domains
+Для PR, который меняет runtime wiring или adapters, дополнительно запускать targeted unit tests и relevant e2e/headless сценарии.
 
-Нужно вынести общие типы в `@timeline-studio/core/types`.
+## Текущий baseline
 
-## 📝 План миграции
+`bun run check:boundaries` сейчас работает в report-only режиме. Это намеренно: текущий код содержит известные нарушения, которые нужно снимать отдельными PR.
 
-### Phase 1: Подготовка (1-2 дня)
+Baseline на 2026-06-07:
 
-- [ ] Создать структуру workspaces
-- [ ] Настроить bun workspaces в `package.json`
-- [ ] Создать `package.json` для каждого пакета
-- [ ] Настроить TypeScript paths для workspaces
+- Scanned files: 1569
+- Violations: 506
+- `error`: 39
+- `warn`: 467
+- Edges: `core -> domains` 6, `domains -> app-shell` 3, `domains -> ui` 28, `ui -> adapters` 2, `ui -> domains` 467
 
-**Конфигурация:**
+Следующие PR должны уменьшать этот отчет и не добавлять новые нарушения без явного follow-up.
 
-```json
-// package.json (root)
-{
-  "workspaces": [
-    "packages/*",
-    "apps/*"
-  ]
-}
-```
+## Риски и митигация
 
-```json
-// packages/core/package.json
-{
-  "name": "@timeline-studio/core",
-  "version": "0.1.0",
-  "exports": {
-    ".": "./src/index.ts",
-    "./ports": "./src/ports/index.ts",
-    "./types": "./src/types/index.ts"
-  }
-}
-```
+| Риск | Влияние | Митигация |
+|------|---------|-----------|
+| Большой перенос файлов ломает desktop app | Высокое | Делать split только после F2-F4, когда alias и ports уже проверены |
+| Циклические зависимости остаются незаметными | Высокое | Запускать `bun run check:boundaries` в каждом PR |
+| UI продолжает импортировать Tauri adapters | Высокое | F3 закрывает `ui -> adapters`; после burn-down включить strict gate |
+| Lockfile drift между npm и bun | Среднее | После workspace/package changes запускать frozen install и держать `package-lock.json` metadata синхронной |
 
-### Phase 2: Рефакторинг типов (2-3 дня)
+## Связанные задачи
 
-- [ ] Вынести все общие типы в `@timeline-studio/core/types`
-- [ ] Обновить импорты типов в domains
-- [ ] Обновить импорты типов в features
-
-**Примеры:**
-
-```typescript
-// packages/core/types/media.ts
-export interface MediaMetadata { ... }
-export interface MediaFile { ... }
-
-// packages/domains/media-management/services/media-api.ts
-import type { MediaMetadata } from "@timeline-studio/core/types"
-```
-
-### Phase 3: Инверсия зависимостей (3-4 дня)
-
-- [ ] Убрать прямые импорты сервисов из domains в features
-- [ ] Все сервисы получать через `getXxx()` из core/container
-- [ ] Создать провайдеры для хуков domains в core
-- [ ] Обновить features для использования через core
-
-**Refactoring pattern:**
-
-```typescript
-// ❌ Было
-import { TranscriptionService } from "@/domains/ai-services"
-const service = new TranscriptionService()
-
-// ✅ Стало
-import { getAI } from "@timeline-studio/core"
-const service = getAI()
-```
-
-### Phase 4: Миграция пакетов (4-5 дней)
-
-- [ ] Переместить `src/core` → `packages/core`
-- [ ] Переместить `src/domains` → `packages/domains`
-- [ ] Переместить `src/adapters` → `packages/adapters`
-- [ ] Переместить `src/features` → `packages/ui`
-- [ ] Создать `apps/desktop` с Next.js shell
-- [ ] Создать `apps/cli`
-
-### Phase 5: Настройка сборки (2-3 дня)
-
-- [ ] Настроить сборку каждого пакета
-- [ ] Обновить Tauri конфигурацию
-- [ ] Обновить скрипты `package.json`
-- [ ] Проверить hot reload в dev режиме
-
-**Build configuration:**
-
-```json
-// packages/ui/package.json
-{
-  "scripts": {
-    "build": "tsc --noEmit && vite build",
-    "dev": "vite"
-  }
-}
-```
-
-### Phase 6: Тестирование (2-3 дня)
-
-- [ ] Обновить пути импортов в тестах
-- [ ] Запустить все unit тесты (11500+)
-- [ ] Запустить Rust тесты
-- [ ] Запустить E2E тесты
-- [ ] Проверить сборку desktop приложения
-- [ ] Проверить CLI
-
-### Phase 7: Документация (1 день)
-
-- [ ] Обновить README пакетов
-- [ ] Обновить architecture-overview.md
-- [ ] Обновить project-structure.md
-- [ ] Добавить migration guide
-- [ ] Обновить contributing guide
-
-## ✅ Критерии успеха
-
-1. ✅ UI пакет зависит ТОЛЬКО от core
-2. ✅ Можно собрать desktop и CLI независимо
-3. ✅ Все тесты проходят
-4. ✅ Dev режим работает с hot reload
-5. ✅ Production сборка работает
-6. ✅ TypeScript компилируется без ошибок
-7. ✅ Можно тестировать UI с mock адаптерами изолированно
-
-## 🚧 Риски и митигация
-
-| Риск | Вероятность | Влияние | Митигация |
-|------|-------------|---------|-----------|
-| Breaking changes в импортах | Высокая | Высокое | Постепенная миграция, автоматизация через codemod |
-| Циклические зависимости | Средняя | Высокое | Строгий контроль через eslint-plugin-import |
-| Проблемы с hot reload | Средняя | Среднее | Тестирование на ранних этапах |
-| Увеличение времени сборки | Низкая | Среднее | Использование turbo для кеширования |
-
-## 🔄 Автоматизация миграции
-
-### Codemod для импортов
-
-```typescript
-// scripts/migrate-imports.ts
-import { Project } from "ts-morph"
-
-const project = new Project()
-project.addSourceFilesAtPaths("src/**/*.ts")
-
-for (const sourceFile of project.getSourceFiles()) {
-  sourceFile.getImportDeclarations().forEach((importDecl) => {
-    const moduleSpecifier = importDecl.getModuleSpecifierValue()
-
-    // Заменить @/domains → @timeline-studio/domains
-    if (moduleSpecifier.startsWith("@/domains")) {
-      importDecl.setModuleSpecifier(
-        moduleSpecifier.replace("@/domains", "@timeline-studio/domains")
-      )
-    }
-  })
-
-  sourceFile.save()
-}
-```
-
-## 📚 Примеры из других проектов
-
-- [Turborepo Kitchen Sink](https://github.com/vercel/turborepo/tree/main/examples/kitchen-sink)
-- [tRPC monorepo](https://github.com/trpc/trpc/tree/main/packages)
-- [Prisma monorepo](https://github.com/prisma/prisma)
-
-## 📅 Временные рамки
-
-**Оценка:** 15-20 рабочих дней (3-4 недели)
-
-**Breakdown:**
-- Phase 1: 2 дня
-- Phase 2: 3 дня
-- Phase 3: 4 дня
-- Phase 4: 5 дней
-- Phase 5: 3 дня
-- Phase 6: 3 дня
-- Phase 7: 1 день
-
-## 🔗 Связанные задачи
-
-- [ ] Настройка Turborepo для кеширования сборки (опционально)
-- [ ] Настройка changesets для версионирования пакетов
-- [ ] CI/CD для монорепо
-- [ ] Storybook для @timeline-studio/ui
-
-## 📖 Дополнительные материалы
-
-- [Bun Workspaces Documentation](https://bun.sh/docs/install/workspaces)
-- [TypeScript Project References](https://www.typescriptlang.org/docs/handbook/project-references.html)
-- [Hexagonal Architecture Pattern](https://alistair.cockburn.us/hexagonal-architecture/)
-
----
-
-**Следующие шаги:**
-1. Review и обсуждение архитектуры с командой
-2. Создание proof-of-concept для одного пакета
-3. Утверждение плана миграции
-4. Начало Phase 1
-
----
-
-*Создано: 2025-11-29*
-*Обновлено: 2025-11-29*
+- [#150](https://github.com/chatman-media/timeline-studio/issues/150) - Epic: Phase F
+- [#91](https://github.com/chatman-media/timeline-studio/issues/91) - Rust decomposition
+- [#104](https://github.com/chatman-media/timeline-studio/issues/104), [#120](https://github.com/chatman-media/timeline-studio/issues/120) - shared types extraction

--- a/docs/engineering/package-boundaries.md
+++ b/docs/engineering/package-boundaries.md
@@ -1,0 +1,57 @@
+# Package Boundaries
+
+**Status:** Phase F baseline for [#150](https://github.com/chatman-media/timeline-studio/issues/150)
+**Updated:** 2026-06-07
+
+This document defines the TypeScript package boundaries used during the modular architecture migration. The code still lives under `src/*`, but the aliases and checks mirror the target workspace packages so every migration PR can be verified before files are physically moved.
+
+## Target Packages
+
+| Package | Current path | Bridge alias | Responsibility |
+|---------|--------------|--------------|----------------|
+| `@timeline-studio/core` | `src/core` | `@timeline-studio/core`, `@timeline-studio/core/*` | Platform-neutral ports, DI container, shared runtime types |
+| `@timeline-studio/domains` | `src/domains` | `@timeline-studio/domains/*` | Business domains and domain services |
+| `@timeline-studio/adapters` | `src/adapters` | `@timeline-studio/adapters`, `@timeline-studio/adapters/*` | Tauri, Node, HTTP and mock implementations for core ports |
+| `@timeline-studio/ui` | `src/features`, `src/components/ui` | `@timeline-studio/ui/features/*`, `@timeline-studio/ui/components/*` | Reusable feature UI and shared UI components |
+| `apps/*` | `src/app`, `src/cli`, `src/config` | not published | App shells that wire UI, domains and adapters |
+
+## Dependency Rules
+
+```text
+app-shell -> ui + domains + adapters
+ui -> core
+domains -> core
+adapters -> core
+```
+
+Rules enforced by `config/package-boundaries.json`:
+
+- `core` must not import `domains`, `adapters`, `ui` or `app-shell`.
+- `domains` must not import `adapters`, `ui` or `app-shell`.
+- `adapters` must not import `ui` or `app-shell`.
+- `ui` must not import `adapters` directly.
+- `ui -> domains` is currently reported as a warning because it is existing coupling that will be burned down through Phase F ports and bridge APIs.
+
+## Boundary Check
+
+Run the report locally:
+
+```bash
+bun run check:boundaries
+```
+
+The default mode is report-only and exits `0` while the Phase F baseline is being reduced. Use strict mode only after the remaining violations have dedicated migration PRs:
+
+```bash
+bun run check:boundaries:strict
+```
+
+Each Phase F PR should reduce or avoid increasing the report. A PR may introduce a temporary violation only when the issue body names the follow-up slice that removes it.
+
+## PR Slices
+
+1. **F1 boundaries baseline:** workspace globs, bridge aliases, boundary manifest, report-only checker, roadmap update.
+2. **F2 core bridge:** move UI-facing service access behind `src/core/ports` and `src/core/container`; stop `core -> domains` and start burning down `ui -> domains`.
+3. **F3 adapter contracts:** keep adapter implementations behind core ports; remove direct `ui -> adapters` imports.
+4. **F4 UI pilot package:** extract one feature vertical into the future `@timeline-studio/ui` shape without moving the whole app.
+5. **F5 workspace split:** create package/app `package.json` files, update build/test scripts, lockfiles and CI cache.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "3.61.1",
       "license": "SEE LICENSE IN LICENSE",
       "workspaces": [
-        "packages/*"
+        "packages/*",
+        "apps/*"
       ],
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "license": "SEE LICENSE IN LICENSE",
   "author": "Alexander Kireyev <ak.chatman.media@gmail.com>",
   "workspaces": [
-    "packages/*"
+    "packages/*",
+    "apps/*"
   ],
   "type": "module",
   "scripts": {
@@ -27,6 +28,8 @@
     "check:rust": "npm run lint:rust && npm run format:rust:check",
     "fix:rust": "npm run format:rust && npm run lint:rust:fix",
     "check:type": "tsc --noEmit",
+    "check:boundaries": "node scripts/check-package-boundaries.mjs",
+    "check:boundaries:strict": "node scripts/check-package-boundaries.mjs --strict",
     "check:all": "npm run lint && npm run lint:css && npm run check:rust && npm run test && npm run test:rust",
     "fix:all": "npm run lint:fix && npm run lint:css:fix && npm run fix:rust",
     "tauri": "tauri",

--- a/scripts/check-package-boundaries.mjs
+++ b/scripts/check-package-boundaries.mjs
@@ -1,0 +1,305 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+const defaultConfigPath = path.join(repoRoot, "config/package-boundaries.json")
+const supportedExtensions = new Set([".ts", ".tsx"])
+const maxDetailsDefault = 50
+
+const args = process.argv.slice(2)
+const strict = args.includes("--strict")
+const json = args.includes("--json")
+const maxDetails = Number.parseInt(
+  args.find((arg) => arg.startsWith("--max-details="))?.split("=")[1] ?? String(maxDetailsDefault),
+  10,
+)
+const configPath = path.resolve(
+  repoRoot,
+  args.find((arg) => arg.startsWith("--config="))?.split("=")[1] ?? defaultConfigPath,
+)
+
+const toPosix = (value) => value.split(path.sep).join("/")
+
+function normalizePattern(pattern) {
+  return pattern.replaceAll("\\", "/")
+}
+
+function matchesPattern(relativePath, pattern) {
+  const normalizedPath = toPosix(relativePath)
+  const normalizedPattern = normalizePattern(pattern)
+
+  if (normalizedPattern.startsWith("**/") && normalizedPattern.endsWith("/**")) {
+    const segment = normalizedPattern.slice(3, -3)
+    return normalizedPath.includes(`/${segment}/`) || normalizedPath.startsWith(`${segment}/`)
+  }
+
+  if (normalizedPattern.startsWith("**/*.")) {
+    return normalizedPath.endsWith(normalizedPattern.slice(4))
+  }
+
+  if (normalizedPattern.endsWith("/**")) {
+    const prefix = normalizedPattern.slice(0, -3)
+    return normalizedPath === prefix || normalizedPath.startsWith(`${prefix}/`)
+  }
+
+  return normalizedPath === normalizedPattern
+}
+
+function classifyPath(relativePath, packages) {
+  const normalizedPath = toPosix(relativePath)
+
+  for (const packageInfo of packages) {
+    for (const packagePath of packageInfo.paths) {
+      if (matchesPattern(normalizedPath, packagePath)) {
+        return packageInfo.name
+      }
+    }
+  }
+
+  return null
+}
+
+function resolveInternalSpecifier(sourceFile, specifier) {
+  const cleanSpecifier = specifier.split("?")[0]
+
+  if (cleanSpecifier.startsWith("@/")) {
+    return `src/${cleanSpecifier.slice(2)}`
+  }
+
+  if (cleanSpecifier.startsWith("@domains/")) {
+    return `src/domains/${cleanSpecifier.slice("@domains/".length)}`
+  }
+
+  if (cleanSpecifier.startsWith("@features/")) {
+    return `src/features/${cleanSpecifier.slice("@features/".length)}`
+  }
+
+  if (cleanSpecifier.startsWith("@ui/")) {
+    return `src/components/ui/${cleanSpecifier.slice("@ui/".length)}`
+  }
+
+  if (cleanSpecifier.startsWith("@types/")) {
+    return `src/types/${cleanSpecifier.slice("@types/".length)}`
+  }
+
+  if (cleanSpecifier === "@timeline-studio/core") {
+    return "src/core"
+  }
+
+  if (cleanSpecifier.startsWith("@timeline-studio/core/")) {
+    return `src/core/${cleanSpecifier.slice("@timeline-studio/core/".length)}`
+  }
+
+  if (cleanSpecifier.startsWith("@timeline-studio/domains/")) {
+    return `src/domains/${cleanSpecifier.slice("@timeline-studio/domains/".length)}`
+  }
+
+  if (cleanSpecifier === "@timeline-studio/adapters") {
+    return "src/adapters"
+  }
+
+  if (cleanSpecifier.startsWith("@timeline-studio/adapters/")) {
+    return `src/adapters/${cleanSpecifier.slice("@timeline-studio/adapters/".length)}`
+  }
+
+  if (cleanSpecifier.startsWith("@timeline-studio/ui/features/")) {
+    return `src/features/${cleanSpecifier.slice("@timeline-studio/ui/features/".length)}`
+  }
+
+  if (cleanSpecifier.startsWith("@timeline-studio/ui/components/")) {
+    return `src/components/ui/${cleanSpecifier.slice("@timeline-studio/ui/components/".length)}`
+  }
+
+  if (cleanSpecifier.startsWith(".")) {
+    return toPosix(path.normalize(path.join(path.dirname(sourceFile), cleanSpecifier)))
+  }
+
+  return null
+}
+
+async function readConfig() {
+  const rawConfig = await fs.readFile(configPath, "utf8")
+  return JSON.parse(rawConfig)
+}
+
+async function collectFiles(directory, config, files = []) {
+  const entries = await fs.readdir(directory, { withFileTypes: true })
+
+  for (const entry of entries) {
+    const absolutePath = path.join(directory, entry.name)
+    const relativePath = toPosix(path.relative(repoRoot, absolutePath))
+
+    if (entry.isDirectory()) {
+      if (matchesPattern(relativePath, "**/__tests__/**") || matchesPattern(relativePath, "**/__mocks__/**")) {
+        continue
+      }
+      await collectFiles(absolutePath, config, files)
+      continue
+    }
+
+    if (!entry.isFile() || !supportedExtensions.has(path.extname(entry.name))) {
+      continue
+    }
+
+    if (config.ignore.some((pattern) => matchesPattern(relativePath, pattern))) {
+      continue
+    }
+
+    files.push(relativePath)
+  }
+
+  return files
+}
+
+function extractImports(source) {
+  const imports = []
+  const staticPattern =
+    /(?:^|[\n;])\s*(?:import|export)\s+(?:type\s+)?(?:[^"']*?\s+from\s*)?["']([^"']+)["']/g
+  const dynamicPattern = /\b(?:import|require)\(\s*["']([^"']+)["']\s*\)/g
+
+  for (const pattern of [staticPattern, dynamicPattern]) {
+    for (const match of source.matchAll(pattern)) {
+      const startsAfterNewline = match[0].startsWith("\n")
+      imports.push({
+        specifier: match[1],
+        line: source.slice(0, match.index).split("\n").length + (startsAfterNewline ? 1 : 0),
+      })
+    }
+  }
+
+  return imports
+}
+
+function findRule(config, sourcePackage, targetPackage) {
+  return config.rules.find(
+    (rule) => rule.from === sourcePackage && rule.disallow.includes(targetPackage),
+  )
+}
+
+function summarizeViolations(violations) {
+  return violations.reduce(
+    (summary, violation) => {
+      summary.bySeverity[violation.severity] = (summary.bySeverity[violation.severity] ?? 0) + 1
+      const edge = `${violation.from} -> ${violation.to}`
+      summary.byEdge[edge] = (summary.byEdge[edge] ?? 0) + 1
+      return summary
+    },
+    { bySeverity: {}, byEdge: {} },
+  )
+}
+
+function printTextReport(config, files, violations) {
+  const summary = summarizeViolations(violations)
+  const mode = strict ? "strict" : "report-only"
+
+  console.log("Package boundary report")
+  console.log(`Config: ${toPosix(path.relative(repoRoot, configPath))}`)
+  console.log(`Mode: ${mode}`)
+  console.log(`Scanned files: ${files.length}`)
+  console.log(`Violations: ${violations.length}`)
+
+  if (violations.length === 0) {
+    console.log("Result: no package boundary violations found.")
+    return
+  }
+
+  console.log("")
+  console.log("By severity:")
+  for (const [severity, count] of Object.entries(summary.bySeverity).sort()) {
+    console.log(`- ${severity}: ${count}`)
+  }
+
+  console.log("")
+  console.log("By edge:")
+  for (const [edge, count] of Object.entries(summary.byEdge).sort()) {
+    console.log(`- ${edge}: ${count}`)
+  }
+
+  console.log("")
+  console.log(`Details (first ${Math.min(maxDetails, violations.length)}):`)
+  for (const violation of violations.slice(0, maxDetails)) {
+    console.log(
+      `[${violation.severity}] ${violation.file}:${violation.line} ${violation.from} -> ${violation.to} via "${violation.specifier}"`,
+    )
+    console.log(`  ${violation.reason}`)
+  }
+
+  if (!strict) {
+    console.log("")
+    console.log("Report-only mode: exiting 0. Use --strict after the Phase F baseline is burned down.")
+  }
+}
+
+async function main() {
+  const config = await readConfig()
+  const sourceRoot = path.join(repoRoot, config.sourceRoot)
+  const files = await collectFiles(sourceRoot, config)
+  const violations = []
+
+  for (const file of files) {
+    const sourcePackage = classifyPath(file, config.packages)
+
+    if (!sourcePackage) {
+      continue
+    }
+
+    const source = await fs.readFile(path.join(repoRoot, file), "utf8")
+
+    for (const importInfo of extractImports(source)) {
+      const targetPath = resolveInternalSpecifier(file, importInfo.specifier)
+
+      if (!targetPath) {
+        continue
+      }
+
+      const targetPackage = classifyPath(targetPath, config.packages)
+
+      if (!targetPackage || targetPackage === sourcePackage) {
+        continue
+      }
+
+      const rule = findRule(config, sourcePackage, targetPackage)
+
+      if (!rule) {
+        continue
+      }
+
+      violations.push({
+        file,
+        line: importInfo.line,
+        specifier: importInfo.specifier,
+        from: sourcePackage,
+        to: targetPackage,
+        severity: rule.severity,
+        reason: rule.reason,
+      })
+    }
+  }
+
+  violations.sort((left, right) => {
+    const severityOrder = { error: 0, warn: 1 }
+    return (
+      (severityOrder[left.severity] ?? 99) - (severityOrder[right.severity] ?? 99)
+      || left.file.localeCompare(right.file)
+      || left.line - right.line
+    )
+  })
+
+  if (json) {
+    console.log(JSON.stringify({ files: files.length, violations, summary: summarizeViolations(violations) }, null, 2))
+  } else {
+    printTextReport(config, files, violations)
+  }
+
+  if (strict && violations.length > 0) {
+    process.exitCode = 1
+  }
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,6 +36,27 @@
       "@features/*": [
         "./src/features/*"
       ],
+      "@timeline-studio/core": [
+        "./src/core/index.ts"
+      ],
+      "@timeline-studio/core/*": [
+        "./src/core/*"
+      ],
+      "@timeline-studio/domains/*": [
+        "./src/domains/*"
+      ],
+      "@timeline-studio/adapters": [
+        "./src/adapters/index.ts"
+      ],
+      "@timeline-studio/adapters/*": [
+        "./src/adapters/*"
+      ],
+      "@timeline-studio/ui/features/*": [
+        "./src/features/*"
+      ],
+      "@timeline-studio/ui/components/*": [
+        "./src/components/ui/*"
+      ],
       "@domains/*": [
         "./src/domains/*"
       ],


### PR DESCRIPTION
## Summary
- add Phase F package boundary manifest and report-only checker
- add bridge aliases for future @timeline-studio/* packages and apps/* workspace glob
- rewrite the monorepo migration roadmap into F1-F5 PR slices with the current boundary baseline

Refs #150

## Verification
- bun install --frozen-lockfile --ignore-scripts
- bun run check:boundaries --max-details=10
- bun run check:type
- node --check scripts/check-package-boundaries.mjs
- git diff --check

## Notes
- Boundary checker is intentionally report-only for F1. Current baseline: 506 violations across 1569 scanned files; strict mode is available as bun run check:boundaries:strict after burn-down.