### PR TITLE
refactor(core): route hooks through core ports

### DIFF
--- a/src/core/hooks/use-favorites.ts
+++ b/src/core/hooks/use-favorites.ts
@@ -1,14 +1,167 @@
-/**
- * Core hook для работы с избранными медиафайлами
- * Re-exports useFavorites from project-management domain for convenience
- *
- * @example
- * ```tsx
- * const { favorites, isFavorite, toggleFavorite } = useFavorites()
- *
- * const handleToggle = () => {
- *   toggleFavorite(mediaFile)
- * }
- * ```
- */
-export { useFavorites } from "@/domains/project-management/hooks"
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { container } from "../container"
+import type { BrowserState, BrowserTab, ProjectState } from "../types"
+
+type FavoritesByType = Record<string, string[]>
+
+const emptyFavorites: FavoritesByType = {
+  transition: [],
+  effect: [],
+  template: [],
+  filter: [],
+  subtitle: [],
+  media: [],
+  music: [],
+  styleTemplate: [],
+}
+
+const typeToTabMap: Record<string, BrowserTab> = {
+  transition: "transitions",
+  effect: "effects",
+  template: "templates",
+  filter: "filters",
+  subtitle: "subtitles",
+  media: "media",
+  music: "music",
+  styleTemplate: "style_templates",
+}
+
+const tabToTypeMap: Partial<Record<BrowserTab, string>> = {
+  transitions: "transition",
+  effects: "effect",
+  templates: "template",
+  filters: "filter",
+  subtitles: "subtitle",
+  media: "media",
+  music: "music",
+  style_templates: "styleTemplate",
+}
+
+function getBrowserState(projectState: ProjectState | null): BrowserState | null {
+  return projectState?.browser_state ?? ((projectState?.ui_state?.browser_state as BrowserState | null) || null)
+}
+
+function mapFavorites(browserState: BrowserState | null): FavoritesByType {
+  const result: FavoritesByType = { ...emptyFavorites }
+
+  if (!browserState?.favorites) {
+    return result
+  }
+
+  for (const [tab, fileIds] of Object.entries(browserState.favorites)) {
+    const type = tabToTypeMap[tab as BrowserTab]
+
+    if (type) {
+      result[type] = fileIds as string[]
+    }
+  }
+
+  return result
+}
+
+export function useFavorites() {
+  const [browserState, setBrowserState] = useState<BrowserState | null>(null)
+
+  useEffect(() => {
+    let isMounted = true
+
+    if (!container.hasBackend()) {
+      return
+    }
+
+    const backend = container.getBackend()
+
+    backend
+      .getProjectState()
+      .then((projectState) => {
+        if (isMounted) {
+          setBrowserState(getBrowserState(projectState))
+        }
+      })
+      .catch(() => {
+        if (isMounted) {
+          setBrowserState(null)
+        }
+      })
+
+    const unsubscribe = backend.onStateChange((projectState) => {
+      if (isMounted) {
+        setBrowserState(getBrowserState(projectState))
+      }
+    })
+
+    return () => {
+      isMounted = false
+      unsubscribe()
+    }
+  }, [])
+
+  const favorites = useMemo(() => mapFavorites(browserState), [browserState])
+
+  const addToFavorites = useCallback(async (item: any, type: string) => {
+    const tab = typeToTabMap[type]
+
+    if (!tab || !container.hasBackend()) {
+      return
+    }
+
+    await container.getBackend().executeCommand({
+      type: "BrowserAddToFavorites",
+      params: { file_id: item.id, tab },
+    })
+
+    setBrowserState((current) => ({
+      ...(current ?? {
+        active_tab: tab,
+        selected_files: {},
+        tab_settings: {},
+        favorites: {},
+      }),
+      favorites: {
+        ...(current?.favorites ?? {}),
+        [tab]: Array.from(new Set([...(current?.favorites?.[tab] ?? []), item.id])),
+      },
+    }))
+  }, [])
+
+  const removeFromFavorites = useCallback(async (item: any, type: string) => {
+    const tab = typeToTabMap[type]
+
+    if (!tab || !container.hasBackend()) {
+      return
+    }
+
+    await container.getBackend().executeCommand({
+      type: "BrowserRemoveFromFavorites",
+      params: { file_id: item.id, tab },
+    })
+
+    setBrowserState((current) => {
+      if (!current) {
+        return current
+      }
+
+      return {
+        ...current,
+        favorites: {
+          ...current.favorites,
+          [tab]: (current.favorites?.[tab] ?? []).filter((fileId) => fileId !== item.id),
+        },
+      }
+    })
+  }, [])
+
+  const isItemFavorite = useCallback(
+    (item: any, type: string) => {
+      return favorites[type]?.includes(item.id) || false
+    },
+    [favorites],
+  )
+
+  return {
+    favorites,
+    addToFavorites,
+    removeFromFavorites,
+    isItemFavorite,
+  }
+}

--- a/src/core/hooks/use-notifications.ts
+++ b/src/core/hooks/use-notifications.ts
@@ -1,19 +1,135 @@
-/**
- * Core hook для работы с уведомлениями
- * Re-exports useNotifications from system-integration domain for convenience
- *
- * @example
- * ```tsx
- * const { showSuccess, showError } = useNotifications()
- *
- * const handleExport = async () => {
- *   try {
- *     await exportVideo()
- *     showSuccess("Export Complete", "Video exported successfully")
- *   } catch (error) {
- *     showError("Export Failed", error.message)
- *   }
- * }
- * ```
- */
-export { useNotifications } from "@/domains/system-integration"
+import { useCallback, useEffect, useRef, useState } from "react"
+import { container } from "../container"
+
+export type CoreNotificationType = "info" | "success" | "warning" | "error"
+
+export interface NotificationAction {
+  label: string
+  action: () => void
+  style?: "primary" | "secondary" | "danger"
+}
+
+export interface SystemNotification {
+  id: string
+  notification_type: CoreNotificationType
+  type: CoreNotificationType
+  title: string
+  message: string
+  timestamp: Date
+  duration?: number
+  actions?: NotificationAction[]
+}
+
+let notificationCounter = 0
+
+export function useNotifications() {
+  const [notifications, setNotifications] = useState<SystemNotification[]>([])
+  const timeoutsRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set())
+
+  useEffect(() => {
+    const timeouts = timeoutsRef.current
+
+    return () => {
+      for (const timeout of timeouts) {
+        clearTimeout(timeout)
+      }
+
+      timeouts.clear()
+    }
+  }, [])
+
+  const dismissNotification = useCallback((id: string) => {
+    setNotifications((current) => current.filter((notification) => notification.id !== id))
+  }, [])
+
+  const showNotification = useCallback(
+    (
+      type: CoreNotificationType,
+      title: string,
+      message: string,
+      options?: {
+        duration?: number
+        actions?: NotificationAction[]
+      },
+    ) => {
+      const id = `notification-${++notificationCounter}`
+      const notification: SystemNotification = {
+        id,
+        notification_type: type,
+        type,
+        title,
+        message,
+        timestamp: new Date(),
+        duration: options?.duration,
+        actions: options?.actions,
+      }
+
+      setNotifications((current) => [...current, notification])
+
+      if (container.hasPlatform()) {
+        void container
+          .getPlatform()
+          .showNotification({ title, body: message })
+          .catch(() => {
+            // UI notifications must not fail because native notifications are unavailable.
+          })
+      }
+
+      if (options?.duration) {
+        const timeout = setTimeout(() => {
+          dismissNotification(id)
+          timeoutsRef.current.delete(timeout)
+        }, options.duration)
+
+        timeoutsRef.current.add(timeout)
+      }
+
+      return id
+    },
+    [dismissNotification],
+  )
+
+  const showInfo = useCallback(
+    (title: string, message: string, duration?: number) => {
+      return showNotification("info", title, message, { duration })
+    },
+    [showNotification],
+  )
+
+  const showSuccess = useCallback(
+    (title: string, message: string, duration = 3000) => {
+      return showNotification("success", title, message, { duration })
+    },
+    [showNotification],
+  )
+
+  const showWarning = useCallback(
+    (title: string, message: string, duration?: number) => {
+      return showNotification("warning", title, message, { duration })
+    },
+    [showNotification],
+  )
+
+  const showError = useCallback(
+    (title: string, message: string, duration?: number) => {
+      return showNotification("error", title, message, { duration })
+    },
+    [showNotification],
+  )
+
+  const clearNotifications = useCallback(() => {
+    setNotifications([])
+  }, [])
+
+  return {
+    notifications,
+    hasNotifications: notifications.length > 0,
+    showNotification,
+    dismissNotification,
+    clearNotifications,
+    showInfo,
+    showSuccess,
+    showWarning,
+    showError,
+  }
+}

--- a/src/core/hooks/use-project-loader.ts
+++ b/src/core/hooks/use-project-loader.ts
@@ -1,8 +1,5 @@
 import { useCallback, useMemo } from "react"
-import {
-  loadProject as loadProjectFn,
-  saveProject as saveProjectFn,
-} from "@/domains/project-management/services/project-file-service"
+import { getPlatform } from "../container"
 
 /**
  * Core hook для загрузки и сохранения проектов
@@ -20,11 +17,23 @@ import {
  */
 export function useProjectLoader() {
   const loadProject = useCallback(async (path: string): Promise<any> => {
-    return await loadProjectFn(path)
+    const content = await getPlatform().readTextFile(path)
+    return JSON.parse(content)
   }, [])
 
   const saveProject = useCallback(async (path: string, data: any): Promise<void> => {
-    return await saveProjectFn(path, data)
+    const payload =
+      data && typeof data === "object"
+        ? {
+            ...data,
+            meta: {
+              ...data.meta,
+              lastModified: Date.now(),
+            },
+          }
+        : data
+
+    await getPlatform().writeTextFile(path, JSON.stringify(payload, null, 2))
   }, [])
 
   return useMemo(

--- a/src/core/hooks/use-render-queue.ts
+++ b/src/core/hooks/use-render-queue.ts
@@ -1,9 +1,40 @@
 import { useCallback, useMemo } from "react"
-import {
-  cancelRender as cancelRenderFn,
-  getActiveJobs as getActiveJobsFn,
-  renderProject as renderProjectFn,
-} from "@/domains/video-editing"
+import { getVideo } from "../container"
+import type { RenderJob } from "../types"
+
+const statusMap: Record<string, RenderJob["status"]> = {
+  pending: "Pending",
+  running: "Processing",
+  completed: "Completed",
+  failed: "Failed",
+  cancelled: "Cancelled",
+}
+
+function normalizeRenderJob(job: any): RenderJob {
+  const status = statusMap[job.status] ?? job.status
+  const progressValue = typeof job.progress === "number" ? job.progress : (job.progress?.percentage ?? 0)
+
+  return {
+    ...job,
+    status,
+    project_name: job.project_name ?? job.projectName ?? job.outputPath?.split("/").pop() ?? "Render job",
+    output_path: job.output_path ?? job.outputPath ?? "",
+    created_at: job.created_at ?? job.startedAt ?? new Date().toISOString(),
+    error_message: job.error_message ?? job.error,
+    progress:
+      job.progress && typeof job.progress === "object"
+        ? job.progress
+        : {
+            job_id: job.id,
+            stage: status,
+            percentage: progressValue,
+            current_frame: 0,
+            total_frames: 0,
+            elapsed_time: 0,
+            status,
+          },
+  }
+}
 
 /**
  * Core hook для работы с очередью рендеринга
@@ -21,15 +52,16 @@ import {
  */
 export function useRenderQueue() {
   const renderProject = useCallback(async (schema: any, outputPath: string): Promise<string> => {
-    return await renderProjectFn(schema, outputPath)
+    return await getVideo().renderProject(schema, outputPath)
   }, [])
 
   const cancelRender = useCallback(async (jobId: string): Promise<boolean> => {
-    return await cancelRenderFn(jobId)
+    return await getVideo().cancelRender(jobId)
   }, [])
 
-  const getActiveJobs = useCallback(async (): Promise<any[]> => {
-    return await getActiveJobsFn()
+  const getActiveJobs = useCallback(async (): Promise<RenderJob[]> => {
+    const jobs = await getVideo().getActiveJobs()
+    return jobs.map(normalizeRenderJob)
   }, [])
 
   return useMemo(

--- a/src/core/types/video-editing.ts
+++ b/src/core/types/video-editing.ts
@@ -1,9 +1,89 @@
 /**
- * Re-export commonly used types from video-editing domain
- * This allows features to import types from @/core/types instead of directly from domains
+ * Core-facing video compiler types.
+ * Keep this file independent from domain packages so `@timeline-studio/core`
+ * can be extracted before the video-editing domain is moved.
  */
 
-export type { ProjectSchema, RenderJob } from "@/domains/video-editing/types"
+// The Rust-generated ProjectSchema and legacy video-compiler schema are not
+// structurally identical yet. Keep this loose bridge shape until Phase F can
+// converge callers on @timeline/shared-types end to end.
+export interface ProjectSchema {
+  version: string
+  metadata: any
+  timeline: any
+  tracks: Array<{
+    id: string
+    track_type: any
+    name: string
+    enabled: boolean
+    locked: boolean
+    volume: number
+    clips: any[]
+    effects: string[]
+    filters: string[]
+    [key: string]: any
+  }>
+  effects: any[]
+  transitions: any[]
+  filters: any[]
+  templates: any[]
+  style_templates: any[]
+  subtitles: any[]
+  settings: any
+  [key: string]: any
+}
 
-// Export enums as both type and value
-export { AspectRatio, OutputFormat, RenderStatus } from "@/domains/video-editing/types"
+export const AspectRatio = {
+  Ratio16x9: "Ratio16x9",
+  Ratio4x3: "Ratio4x3",
+  Ratio21x9: "Ratio21x9",
+  Ratio1x1: "Ratio1x1",
+  Ratio9x16: "Ratio9x16",
+  Custom: "Custom",
+} as const
+
+export type AspectRatio = (typeof AspectRatio)[keyof typeof AspectRatio]
+
+export const OutputFormat = {
+  Mp4: "Mp4",
+  Avi: "Avi",
+  Mov: "Mov",
+  Mkv: "Mkv",
+  WebM: "WebM",
+  Gif: "Gif",
+} as const
+
+export type OutputFormat = (typeof OutputFormat)[keyof typeof OutputFormat]
+
+export const RenderStatus = {
+  Pending: "Pending",
+  Processing: "Processing",
+  Completed: "Completed",
+  Failed: "Failed",
+  Cancelled: "Cancelled",
+} as const
+
+export type RenderStatus = (typeof RenderStatus)[keyof typeof RenderStatus]
+
+export interface RenderProgress {
+  job_id: string
+  stage: string
+  percentage: number
+  current_frame: number
+  total_frames: number
+  elapsed_time: number
+  estimated_remaining?: number
+  status: RenderStatus
+  message?: string
+  progress?: number
+}
+
+export interface RenderJob {
+  id: string
+  project_name: string
+  output_path: string
+  status: RenderStatus
+  created_at: string
+  progress: RenderProgress
+  error_message?: string
+}

--- a/src/features/browser/__tests__/components/layout/favorite-button.test.tsx
+++ b/src/features/browser/__tests__/components/layout/favorite-button.test.tsx
@@ -50,7 +50,7 @@ const mockFavorites: Record<string, string[]> = {
   styleTemplate: [],
 }
 
-vi.mock("@/domains/project-management/hooks", () => ({
+vi.mock("@/core/hooks", () => ({
   useFavorites: () => ({
     addToFavorites: mockAddToFavorites,
     removeFromFavorites: mockRemoveFromFavorites,

--- a/src/features/effects/hooks/use-effect-preview-generator.ts
+++ b/src/features/effects/hooks/use-effect-preview-generator.ts
@@ -4,7 +4,7 @@
 
 import { useCallback, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { useNotifications } from "@/domains/system-integration"
+import { useNotifications } from "@/core/hooks"
 import type { BaseEffect } from "../types"
 import {
   type EffectPreviewConfig,

--- a/src/features/export/__tests__/hooks/use-render-queue.test.ts
+++ b/src/features/export/__tests__/hooks/use-render-queue.test.ts
@@ -25,43 +25,28 @@ vi.mock("@/core", () => ({
   },
 }))
 
-// Mock video-editing domain services
-vi.mock("@/domains/video-editing", () => ({
-  getActiveJobs: (args?: any) => mockGetActiveJobs(args),
-  cancelRender: (jobId: string) => mockCancelRender(jobId),
-  renderProject: (schema: any, path: string) => mockRenderProject(schema, path),
-  RenderStatus: {
-    Pending: "Pending",
-    Processing: "Processing",
-    Completed: "Completed",
-    Failed: "Failed",
-    Cancelled: "Cancelled",
-  },
-  OutputFormat: {
-    Mp4: "Mp4",
-    Mov: "Mov",
-    Mkv: "Mkv",
-    Avi: "Avi",
-    WebM: "WebM",
-    Gif: "Gif",
-  },
+// Mock core hook bridge used by the export feature.
+vi.mock("@/core/hooks", () => ({
+  useProjectLoader: () => ({
+    loadProject: vi.fn().mockResolvedValue({
+      id: "test-project",
+      settings: {
+        aspectRatio: { width: 1920, height: 1080 },
+        resolution: "1920x1080",
+        frameRate: "30",
+        colorSpace: "sdr",
+      },
+    }),
+  }),
+  useRenderQueue: () => ({
+    getActiveJobs: () => mockGetActiveJobs(),
+    cancelRender: (jobId: string) => mockCancelRender(jobId),
+    renderProject: (schema: any, path: string) => mockRenderProject(schema, path),
+  }),
 }))
 
 // Get mocked logError
 const mockLogError = vi.mocked(logError)
-
-// Mock loadProject function
-vi.mock("@/domains/project-management/services/project-file-service", () => ({
-  loadProject: vi.fn().mockResolvedValue({
-    id: "test-project",
-    settings: {
-      aspectRatio: { width: 1920, height: 1080 },
-      resolution: "1920x1080",
-      frameRate: "30",
-      colorSpace: "sdr",
-    },
-  }),
-}))
 
 // Mock timeline utils
 vi.mock("@/features/timeline/utils/timeline-to-project", () => ({

--- a/src/features/export/__tests__/hooks/use-social-export.test.ts
+++ b/src/features/export/__tests__/hooks/use-social-export.test.ts
@@ -25,7 +25,7 @@ vi.mock("@/core", () => ({
   },
 }))
 
-vi.mock("@/domains/system-integration", () => ({
+vi.mock("@/core/hooks", () => ({
   useNotifications: () => ({
     showError: mockShowError,
     showSuccess: mockShowSuccess,

--- a/src/features/export/types/export-types.ts
+++ b/src/features/export/types/export-types.ts
@@ -1,4 +1,4 @@
-import { OutputFormat } from "@/features/video-compiler/types/render"
+import type { OutputFormat } from "@/core/types"
 
 export interface OAuthToken {
   accessToken: string

--- a/src/features/media/__tests__/components/media-item.test.tsx
+++ b/src/features/media/__tests__/components/media-item.test.tsx
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { useFavorites } from "@/core/hooks"
 import { MediaType } from "@/domains/media-management"
-import { useFavorites } from "@/domains/project-management/hooks"
 import { fireEvent, renderWithProviders, screen } from "@/test/test-utils"
 
 import { MediaItem } from "../../components/media-item"
@@ -35,7 +35,7 @@ vi.mock("../../components/file-metadata", () => ({
 }))
 
 // Мокаем useFavorites
-vi.mock("@/domains/project-management/hooks", async (importOriginal) => {
+vi.mock("@/core/hooks", async (importOriginal) => {
   const actual: any = await importOriginal()
   return {
     ...actual,

--- a/src/features/person-identification/hooks/use-advanced-person-identification.ts
+++ b/src/features/person-identification/hooks/use-advanced-person-identification.ts
@@ -4,6 +4,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from "react"
+import { useNotifications } from "@/core/hooks"
 import {
   type AdvancedFaceDetection,
   AdvancedFaceDetectionService,
@@ -11,7 +12,6 @@ import {
   PersonDatabaseService,
   type TrackedPerson,
 } from "@/domains/ai-services/services/person-identification"
-import { useNotifications } from "@/domains/system-integration"
 import { createLogger } from "@/lib/tauri-logger"
 import type { DetectedFace, PersonProfile, PersonSearchResult } from "../types/person"
 

--- a/src/features/transcription/components/enhanced-transcription-panel.tsx
+++ b/src/features/transcription/components/enhanced-transcription-panel.tsx
@@ -33,7 +33,7 @@ import { Separator } from "@/components/ui/separator"
 import { Switch } from "@/components/ui/switch"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { container } from "@/core"
-import { useNotifications } from "@/domains/system-integration"
+import { useNotifications } from "@/core/hooks"
 import { type EnhancedSubtitleOptions, useEnhancedSubtitleAutomation } from "../hooks/use-enhanced-subtitle-automation"
 // Импортируем существующие компоненты и хуки
 import { useTranscription } from "../hooks/use-transcription"

--- a/src/features/transcription/hooks/use-enhanced-subtitle-automation.ts
+++ b/src/features/transcription/hooks/use-enhanced-subtitle-automation.ts
@@ -5,6 +5,7 @@
 
 import { useCallback, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
+import { useNotifications } from "@/core/hooks"
 // Импортируем новый enhanced инструмент
 import {
   autoGenerateSubtitlesFromVideo,
@@ -14,7 +15,6 @@ import {
   extractSubtitlesFromScreenText,
   generateMultilingualSubtitles,
 } from "@/domains/ai-tools/tools/automation/enhanced-subtitle-automation"
-import { useNotifications } from "@/domains/system-integration"
 import { logError, logInfo } from "@/lib/tauri-logger"
 
 // Базовые типы из транскрипции

--- a/src/features/video-compiler/__tests__/hooks/use-video-compiler.test.ts
+++ b/src/features/video-compiler/__tests__/hooks/use-video-compiler.test.ts
@@ -12,7 +12,7 @@ const mockShowSuccess = vi.fn()
 const mockShowError = vi.fn()
 const mockShowInfo = vi.fn()
 
-vi.mock("@/domains/system-integration", () => ({
+vi.mock("@/core/hooks", () => ({
   useNotifications: () => ({
     showSuccess: mockShowSuccess,
     showError: mockShowError,

--- a/src/features/video-compiler/hooks/use-frame-extraction.ts
+++ b/src/features/video-compiler/hooks/use-frame-extraction.ts
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 
 import { useTranslation } from "react-i18next"
+import { useNotifications } from "@/core/hooks"
 import { useFramePreview } from "@/domains/media-management"
-import { useNotifications } from "@/domains/system-integration"
 import {
   type ExtractionPurpose,
   frameExtractionService,

--- a/src/features/video-compiler/hooks/use-gpu-capabilities.ts
+++ b/src/features/video-compiler/hooks/use-gpu-capabilities.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { useNotifications } from "@/domains/system-integration"
+import { useNotifications } from "@/core/hooks"
 import {
   CompilerSettings,
   FfmpegCapabilities,

--- a/src/features/video-compiler/hooks/use-prerender.ts
+++ b/src/features/video-compiler/hooks/use-prerender.ts
@@ -5,7 +5,7 @@
 import { useCallback, useEffect, useState } from "react"
 
 import { useTranslation } from "react-i18next"
-import { useNotifications } from "@/domains/system-integration"
+import { useNotifications } from "@/core/hooks"
 import {
   clearPrerenderCache as clearCache,
   getPrerenderCacheInfo,

--- a/src/features/video-compiler/hooks/use-video-compiler.ts
+++ b/src/features/video-compiler/hooks/use-video-compiler.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { useNotifications } from "@/domains/system-integration"
+import { useNotifications } from "@/core/hooks"
 import { renderProject, trackRenderProgress } from "@/domains/video-editing/services/compiler"
 import { videoCompilerRenderService } from "@/domains/video-editing/services/video-compiler-render-service"
 import { ProjectSchema } from "@/domains/video-editing/types/video-compiler"

--- a/src/features/video-player/components/__tests__/prerender-controls.test.tsx
+++ b/src/features/video-player/components/__tests__/prerender-controls.test.tsx
@@ -16,7 +16,7 @@ const mockShowError = vi.fn()
 const mockShowInfo = vi.fn()
 const mockShowWarning = vi.fn()
 
-vi.mock("@/domains/system-integration", () => ({
+vi.mock("@/core/hooks", () => ({
   useNotifications: () => ({
     showSuccess: mockShowSuccess,
     showError: mockShowError,


### PR DESCRIPTION
## Summary
- replace legacy core hook re-exports with core-owned hooks backed by container ports/state
- route render queue and project loader through core platform/video services
- move a first set of UI notification imports from domains to @/core/hooks
- update tests to mock the new core hook bridge

Refs #150
Refs #156

## Boundary baseline
- total violations: 506 -> 492
- core -> domains: 6 -> 0
- ui -> domains: 467 -> 459

## Verification
- bun install --frozen-lockfile --ignore-scripts
- bun run check:boundaries --max-details=8
- bun run check:type
- bunx biome check <changed src/test files>
- git diff --check
- bun run test src/features/export/__tests__/hooks/use-render-queue.test.ts src/features/browser/__tests__/components/layout/favorite-button.test.tsx src/features/browser/__tests__/adapters/media-adapter.test.tsx src/features/media/__tests__/components/media-item.test.tsx src/features/subtitles/__tests__/hooks/use-subtitles-import.test.ts src/features/export/__tests__/hooks/use-social-export.test.ts src/features/video-player/components/__tests__/prerender-controls.test.tsx src/features/person-identification/__tests__/hooks/use-advanced-person-identification.test.tsx src/features/transcription/__tests__/hooks/use-enhanced-subtitle-automation.test.ts src/features/video-compiler/__tests__/hooks/use-frame-extraction.test.ts src/features/video-compiler/__tests__/hooks/use-frame-extraction-simple.test.ts src/features/video-compiler/__tests__/hooks/use-prerender.test.tsx src/features/video-compiler/__tests__/hooks/use-gpu-capabilities.test.ts src/features/video-compiler/__tests__/hooks/use-video-compiler.test.ts