### PR TITLE
refactor(core): route adapter access through ports

### DIFF
--- a/src/adapters/http/index.ts
+++ b/src/adapters/http/index.ts
@@ -19,11 +19,12 @@
 
 import { MockPlatformService, MockStorageService } from "@/adapters/mock"
 import { container } from "@/core/container"
-
+import { NodeBackendBridgeService } from "../node/node-backend-bridge"
 import { type HttpBackendOptions, HttpBackendService } from "./backend"
 import { HttpClient } from "./client"
 import { HttpMediaService } from "./media"
 
+export { NodeBackendBridgeService } from "../node/node-backend-bridge"
 // Re-exports
 export { type HttpBackendOptions, HttpBackendService } from "./backend"
 export { HttpClient, type HttpClientOptions } from "./client"
@@ -41,6 +42,7 @@ export interface HttpAppOptions {
 export interface HttpAppServices {
   backend: HttpBackendService
   media: HttpMediaService
+  nodeBackend: NodeBackendBridgeService
   client: HttpClient
 }
 
@@ -54,9 +56,11 @@ export async function initHttpApp(options: HttpAppOptions = {}): Promise<HttpApp
   const client = new HttpClient({ baseUrl: serverUrl })
   const backend = new HttpBackendService({ serverUrl, ...options.backend })
   const media = new HttpMediaService()
+  const nodeBackend = new NodeBackendBridgeService({ serverUrl })
 
   container.registerBackend(backend)
   container.registerMedia(media)
+  container.registerNodeBackend(nodeBackend)
   // src-node doesn't provide storage/platform — use in-memory mocks so the container is complete
   if (!container.hasStorage()) container.registerStorage(new MockStorageService(true))
   if (!container.hasPlatform()) container.registerPlatform(new MockPlatformService())
@@ -70,7 +74,7 @@ export async function initHttpApp(options: HttpAppOptions = {}): Promise<HttpApp
     }
   }
 
-  return { backend, media, client }
+  return { backend, media, nodeBackend, client }
 }
 
 /**
@@ -82,6 +86,7 @@ export function createHttpServices(options: HttpAppOptions = {}): HttpAppService
   return {
     backend: new HttpBackendService({ serverUrl, ...options.backend }),
     media: new HttpMediaService(),
+    nodeBackend: new NodeBackendBridgeService({ serverUrl }),
     client: new HttpClient({ baseUrl: serverUrl }),
   }
 }

--- a/src/adapters/mock/index.ts
+++ b/src/adapters/mock/index.ts
@@ -11,6 +11,7 @@ import { MockAIService } from "./ai"
 import { MockBackendService } from "./backend"
 import { MockEventService } from "./event"
 import { MockMediaService } from "./media"
+import { MockNodeBackendService } from "./node-backend"
 import { MockPlatformService } from "./platform"
 import { MockStorageService } from "./storage"
 import { MockVideoService } from "./video"
@@ -19,6 +20,7 @@ export { MockAIService } from "./ai"
 export { MockBackendService } from "./backend"
 export { MockEventService } from "./event"
 export { MockMediaService } from "./media"
+export { MockNodeBackendService } from "./node-backend"
 export { MockPlatformService } from "./platform"
 export { MockStorageService } from "./storage"
 export { MockVideoService } from "./video"
@@ -37,6 +39,7 @@ export function initMockApp(options: { useLocalStorage?: boolean } = {}): {
   storage: MockStorageService
   event: MockEventService
   media: MockMediaService
+  nodeBackend: MockNodeBackendService
   video: MockVideoService
   ai: MockAIService
 } {
@@ -48,6 +51,7 @@ export function initMockApp(options: { useLocalStorage?: boolean } = {}): {
   const storage = new MockStorageService(useLocalStorage)
   const event = new MockEventService()
   const media = new MockMediaService()
+  const nodeBackend = new MockNodeBackendService()
   const video = new MockVideoService()
   const ai = new MockAIService()
 
@@ -57,11 +61,12 @@ export function initMockApp(options: { useLocalStorage?: boolean } = {}): {
   container.registerStorage(storage)
   container.registerEvent(event)
   container.registerMedia(media)
+  container.registerNodeBackend(nodeBackend)
   container.registerVideo(video)
   container.registerAI(ai)
 
   // Return services for test manipulation
-  return { backend, platform, storage, event, media, video, ai }
+  return { backend, platform, storage, event, media, nodeBackend, video, ai }
 }
 
 /**
@@ -74,6 +79,7 @@ export function createMockServices(options: { useLocalStorage?: boolean } = {}):
   storage: MockStorageService
   event: MockEventService
   media: MockMediaService
+  nodeBackend: MockNodeBackendService
   video: MockVideoService
   ai: MockAIService
 } {
@@ -85,6 +91,7 @@ export function createMockServices(options: { useLocalStorage?: boolean } = {}):
     storage: new MockStorageService(useLocalStorage),
     event: new MockEventService(),
     media: new MockMediaService(),
+    nodeBackend: new MockNodeBackendService(),
     video: new MockVideoService(),
     ai: new MockAIService(),
   }

--- a/src/adapters/mock/node-backend.ts
+++ b/src/adapters/mock/node-backend.ts
@@ -1,0 +1,74 @@
+/**
+ * Mock Node Backend Adapter
+ *
+ * Represents an unavailable optional src-node backend in tests/browser fallback.
+ */
+
+import type {
+  INodeBackendService,
+  MediaMetadata,
+  NodeBackendCacheStats,
+  NodeBackendClearCacheResult,
+  NodeBackendHealth,
+  NodeBackendThumbnailSize,
+  ScanFolderOptions,
+  ScannedMediaFile,
+  ThumbnailOptions,
+} from "@/core/ports"
+
+export class MockNodeBackendService implements INodeBackendService {
+  async checkHealth(): Promise<NodeBackendHealth> {
+    return {
+      available: false,
+      ffmpegAvailable: false,
+      timestamp: Date.now(),
+    }
+  }
+
+  async scanFolderWithThumbnails(_folderPath: string, _options: NodeBackendThumbnailSize): Promise<ScannedMediaFile[]> {
+    throw new Error("Node backend is not available in mock mode")
+  }
+
+  async scanFolder(_folderPath: string, _options?: ScanFolderOptions): Promise<ScannedMediaFile[]> {
+    throw new Error("Node backend is not available in mock mode")
+  }
+
+  async getMetadata(_filePath: string): Promise<MediaMetadata> {
+    throw new Error("Node backend is not available in mock mode")
+  }
+
+  async processFiles(_filePaths: string[]): Promise<ScannedMediaFile[]> {
+    throw new Error("Node backend is not available in mock mode")
+  }
+
+  async generateThumbnail(_fileId: string, _filePath: string, _options?: ThumbnailOptions): Promise<string> {
+    throw new Error("Node backend is not available in mock mode")
+  }
+
+  async generateWaveform(_filePath: string): Promise<number[]> {
+    throw new Error("Node backend is not available in mock mode")
+  }
+
+  async getCacheStats(): Promise<NodeBackendCacheStats> {
+    return {
+      cache: {
+        memorySize: 0,
+        dbSize: 0,
+      },
+      queue: {
+        pending: 0,
+        processing: 0,
+        completed: 0,
+        failed: 0,
+      },
+      timestamp: Date.now(),
+    }
+  }
+
+  async clearCache(): Promise<NodeBackendClearCacheResult> {
+    return {
+      success: true,
+      cleared: 0,
+    }
+  }
+}

--- a/src/adapters/node/index.ts
+++ b/src/adapters/node/index.ts
@@ -11,6 +11,7 @@ import { type NodeAIOptions, NodeAIService } from "./ai"
 import { type NodeBackendOptions, NodeBackendService } from "./backend"
 import { NodeEventService } from "./event"
 import { type NodeMediaOptions, NodeMediaService } from "./media"
+import { NodeBackendBridgeService } from "./node-backend-bridge"
 import { type NodePlatformOptions, NodePlatformService } from "./platform"
 import { type NodeStorageOptions, NodeStorageService } from "./storage"
 import { type NodeVideoOptions, NodeVideoService } from "./video"
@@ -20,6 +21,7 @@ export { type NodeAIOptions, NodeAIService } from "./ai"
 export { type NodeBackendOptions, NodeBackendService } from "./backend"
 export { NodeEventService } from "./event"
 export { type NodeMediaOptions, NodeMediaService } from "./media"
+export { NodeBackendBridgeService } from "./node-backend-bridge"
 export { type NodePlatformOptions, NodePlatformService } from "./platform"
 export { type NodeStorageOptions, NodeStorageService } from "./storage"
 export { type NodeVideoOptions, NodeVideoService } from "./video"
@@ -47,6 +49,7 @@ export interface NodeAppServices {
   storage: NodeStorageService
   event: NodeEventService
   media: NodeMediaService
+  nodeBackend: NodeBackendBridgeService
   video: NodeVideoService
   ai: NodeAIService
 }
@@ -80,6 +83,7 @@ export async function initNodeApp(options: NodeAppOptions = {}): Promise<NodeApp
   const storage = new NodeStorageService(options.storage)
   const event = new NodeEventService()
   const media = new NodeMediaService(options.media)
+  const nodeBackend = new NodeBackendBridgeService()
   const video = new NodeVideoService(options.video)
   const ai = new NodeAIService(options.ai)
 
@@ -89,6 +93,7 @@ export async function initNodeApp(options: NodeAppOptions = {}): Promise<NodeApp
   container.registerStorage(storage)
   container.registerEvent(event)
   container.registerMedia(media)
+  container.registerNodeBackend(nodeBackend)
   container.registerVideo(video)
   container.registerAI(ai)
 
@@ -103,6 +108,7 @@ export async function initNodeApp(options: NodeAppOptions = {}): Promise<NodeApp
     storage,
     event,
     media,
+    nodeBackend,
     video,
     ai,
   }
@@ -122,6 +128,7 @@ export function createNodeServices(options: NodeAppOptions = {}): NodeAppService
     storage: new NodeStorageService(options.storage),
     event: new NodeEventService(),
     media: new NodeMediaService(options.media),
+    nodeBackend: new NodeBackendBridgeService(),
     video: new NodeVideoService(options.video),
     ai: new NodeAIService(options.ai),
   }

--- a/src/adapters/node/node-backend-bridge.ts
+++ b/src/adapters/node/node-backend-bridge.ts
@@ -1,0 +1,90 @@
+/**
+ * Node Backend Bridge Adapter
+ *
+ * Thin adapter around the src-node tRPC client.
+ */
+
+import type {
+  INodeBackendService,
+  MediaMetadata,
+  NodeBackendCacheStats,
+  NodeBackendClearCacheResult,
+  NodeBackendHealth,
+  NodeBackendThumbnailSize,
+  ScanFolderOptions,
+  ScannedMediaFile,
+  ThumbnailOptions,
+} from "@/core/ports"
+
+import { createNodeBackendClient, type NodeBackendClient, nodeBackendClient } from "./node-backend-client"
+
+export interface NodeBackendBridgeOptions {
+  client?: NodeBackendClient
+  serverUrl?: string
+}
+
+export class NodeBackendBridgeService implements INodeBackendService {
+  private readonly client: NodeBackendClient
+
+  constructor(options: NodeBackendBridgeOptions = {}) {
+    this.client = options.client ?? (options.serverUrl ? createNodeBackendClient(options.serverUrl) : nodeBackendClient)
+  }
+
+  async checkHealth(): Promise<NodeBackendHealth> {
+    const [health, ffmpeg] = await Promise.all([
+      this.client.health.check.query(),
+      this.client.health.ffmpegCheck.query(),
+    ])
+
+    return {
+      available: health.status === "ok",
+      ffmpegAvailable: ffmpeg.available,
+      timestamp: Date.now(),
+    }
+  }
+
+  async scanFolderWithThumbnails(folderPath: string, options: NodeBackendThumbnailSize): Promise<ScannedMediaFile[]> {
+    return this.client.media.scanWithThumbnails.mutate({
+      folderPath,
+      width: options.width,
+      height: options.height,
+    })
+  }
+
+  async scanFolder(folderPath: string, options?: ScanFolderOptions): Promise<ScannedMediaFile[]> {
+    return this.client.media.scanFolder.mutate({
+      folderPath,
+      recursive: options?.recursive,
+    })
+  }
+
+  async getMetadata(filePath: string): Promise<MediaMetadata> {
+    return this.client.media.getMetadata.query({ filePath })
+  }
+
+  async processFiles(filePaths: string[]): Promise<ScannedMediaFile[]> {
+    return this.client.media.processFiles.mutate({ filePaths })
+  }
+
+  async generateThumbnail(fileId: string, filePath: string, options?: ThumbnailOptions): Promise<string> {
+    return this.client.thumbnail.generate.mutate({
+      fileId,
+      filePath,
+      width: options?.width,
+      height: options?.height,
+      timestamp: options?.timestamp,
+    })
+  }
+
+  async generateWaveform(filePath: string): Promise<number[]> {
+    return this.client.waveform.generateData.query({ filePath })
+  }
+
+  async getCacheStats(): Promise<NodeBackendCacheStats> {
+    return this.client.cache.getStats.query()
+  }
+
+  async clearCache(): Promise<NodeBackendClearCacheResult> {
+    return this.client.cache.clear.mutate()
+  }
+}

--- a/src/adapters/node/node-backend-client.ts
+++ b/src/adapters/node/node-backend-client.ts
@@ -43,15 +43,18 @@ const getBackendUrl = (): string => {
  * ```
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const nodeBackendClient: any = createTRPCProxyClient<AppRouter>({
-  links: [
-    httpBatchLink({
-      url: `${getBackendUrl()}/trpc`,
-      headers() {
-        return {}
-      },
-    }),
-  ],
-})
+export const createNodeBackendClient = (backendUrl = getBackendUrl()): any =>
+  createTRPCProxyClient<AppRouter>({
+    links: [
+      httpBatchLink({
+        url: `${backendUrl}/trpc`,
+        headers() {
+          return {}
+        },
+      }),
+    ],
+  })
+
+export const nodeBackendClient: any = createNodeBackendClient()
 
 export type NodeBackendClient = typeof nodeBackendClient

--- a/src/adapters/tauri/index.ts
+++ b/src/adapters/tauri/index.ts
@@ -11,6 +11,7 @@ import { TauriAIService } from "./ai"
 import { TauriBackendService } from "./backend"
 import { TauriEventService } from "./event"
 import { TauriMediaService } from "./media"
+import { TauriNodeBackendService } from "./node-backend"
 import { TauriPlatformService } from "./platform"
 import { TauriStorageService } from "./storage"
 import { TauriVideoService } from "./video"
@@ -22,6 +23,7 @@ export type { EventHandler, StateChangeHandler } from "./backend-sync"
 export { BackendSync, getBackendSync } from "./backend-sync"
 export { TauriEventService } from "./event"
 export { TauriMediaService } from "./media"
+export { TauriNodeBackendService } from "./node-backend"
 export { TauriPlatformService } from "./platform"
 export { TauriStorageService } from "./storage"
 export { TauriVideoService } from "./video"
@@ -43,6 +45,7 @@ export async function initTauriApp(options: { storeName?: string; autoConnect?: 
   const storage = new TauriStorageService(storeName)
   const event = new TauriEventService()
   const media = new TauriMediaService()
+  const nodeBackend = new TauriNodeBackendService()
   const video = new TauriVideoService()
   const ai = new TauriAIService()
 
@@ -51,6 +54,7 @@ export async function initTauriApp(options: { storeName?: string; autoConnect?: 
   container.registerStorage(storage)
   container.registerEvent(event)
   container.registerMedia(media)
+  container.registerNodeBackend(nodeBackend)
   container.registerVideo(video)
   container.registerAI(ai)
 

--- a/src/adapters/tauri/node-backend.ts
+++ b/src/adapters/tauri/node-backend.ts
@@ -1,0 +1,75 @@
+/**
+ * Tauri Node Backend Adapter
+ *
+ * Tauri uses Rust adapters directly. The optional src-node backend is unavailable
+ * unless the app is initialized through the HTTP adapter.
+ */
+
+import type {
+  INodeBackendService,
+  MediaMetadata,
+  NodeBackendCacheStats,
+  NodeBackendClearCacheResult,
+  NodeBackendHealth,
+  NodeBackendThumbnailSize,
+  ScanFolderOptions,
+  ScannedMediaFile,
+  ThumbnailOptions,
+} from "@/core/ports"
+
+export class TauriNodeBackendService implements INodeBackendService {
+  async checkHealth(): Promise<NodeBackendHealth> {
+    return {
+      available: false,
+      ffmpegAvailable: false,
+      timestamp: Date.now(),
+    }
+  }
+
+  async scanFolderWithThumbnails(_folderPath: string, _options: NodeBackendThumbnailSize): Promise<ScannedMediaFile[]> {
+    throw new Error("Node backend is not available in Tauri mode")
+  }
+
+  async scanFolder(_folderPath: string, _options?: ScanFolderOptions): Promise<ScannedMediaFile[]> {
+    throw new Error("Node backend is not available in Tauri mode")
+  }
+
+  async getMetadata(_filePath: string): Promise<MediaMetadata> {
+    throw new Error("Node backend is not available in Tauri mode")
+  }
+
+  async processFiles(_filePaths: string[]): Promise<ScannedMediaFile[]> {
+    throw new Error("Node backend is not available in Tauri mode")
+  }
+
+  async generateThumbnail(_fileId: string, _filePath: string, _options?: ThumbnailOptions): Promise<string> {
+    throw new Error("Node backend is not available in Tauri mode")
+  }
+
+  async generateWaveform(_filePath: string): Promise<number[]> {
+    throw new Error("Node backend is not available in Tauri mode")
+  }
+
+  async getCacheStats(): Promise<NodeBackendCacheStats> {
+    return {
+      cache: {
+        memorySize: 0,
+        dbSize: 0,
+      },
+      queue: {
+        pending: 0,
+        processing: 0,
+        completed: 0,
+        failed: 0,
+      },
+      timestamp: Date.now(),
+    }
+  }
+
+  async clearCache(): Promise<NodeBackendClearCacheResult> {
+    return {
+      success: true,
+      cleared: 0,
+    }
+  }
+}

--- a/src/core/__tests__/container.test.ts
+++ b/src/core/__tests__/container.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { container, getBackend, getEvent, getPlatform, getStorage, resetContainer } from "../container"
-import type { IBackendService, IEventService, IPlatformService, IStorageService } from "../ports"
+import { container, getBackend, getEvent, getNodeBackend, getPlatform, getStorage, resetContainer } from "../container"
+import type { IBackendService, IEventService, INodeBackendService, IPlatformService, IStorageService } from "../ports"
 
 // Mock implementations
 const createMockBackend = (): IBackendService => ({
@@ -50,6 +50,18 @@ const createMockStorage = (): IStorageService => ({
 const createMockEvent = (): IEventService => ({
   listen: vi.fn(),
   emit: vi.fn(),
+})
+
+const createMockNodeBackend = (): INodeBackendService => ({
+  checkHealth: vi.fn(),
+  scanFolderWithThumbnails: vi.fn(),
+  scanFolder: vi.fn(),
+  getMetadata: vi.fn(),
+  processFiles: vi.fn(),
+  generateThumbnail: vi.fn(),
+  generateWaveform: vi.fn(),
+  getCacheStats: vi.fn(),
+  clearCache: vi.fn(),
 })
 
 describe("ServiceContainer", () => {
@@ -141,10 +153,32 @@ describe("ServiceContainer", () => {
     })
   })
 
+  describe("Node Backend Service", () => {
+    it("throws error when node backend not registered", () => {
+      expect(() => container.getNodeBackend()).toThrow("[ServiceContainer] Node backend not registered")
+    })
+
+    it("registers and retrieves node backend service", () => {
+      const mockNodeBackend = createMockNodeBackend()
+      container.registerNodeBackend(mockNodeBackend)
+
+      expect(container.hasNodeBackend()).toBe(true)
+      expect(container.getNodeBackend()).toBe(mockNodeBackend)
+    })
+
+    it("getNodeBackend helper works", () => {
+      const mockNodeBackend = createMockNodeBackend()
+      container.registerNodeBackend(mockNodeBackend)
+
+      expect(getNodeBackend()).toBe(mockNodeBackend)
+    })
+  })
+
   describe("Container Reset", () => {
     it("resetContainer does not throw", () => {
       container.registerBackend(createMockBackend())
       container.registerPlatform(createMockPlatform())
+      container.registerNodeBackend(createMockNodeBackend())
 
       // Reset should not throw
       expect(() => resetContainer()).not.toThrow()
@@ -173,6 +207,17 @@ describe("ServiceContainer", () => {
 
       container.registerBackend(backend2)
       expect(container.getBackend()).toBe(backend2)
+    })
+
+    it("allows replacing registered node backend services", () => {
+      const nodeBackend1 = createMockNodeBackend()
+      const nodeBackend2 = createMockNodeBackend()
+
+      container.registerNodeBackend(nodeBackend1)
+      expect(container.getNodeBackend()).toBe(nodeBackend1)
+
+      container.registerNodeBackend(nodeBackend2)
+      expect(container.getNodeBackend()).toBe(nodeBackend2)
     })
   })
 })

--- a/src/core/container.ts
+++ b/src/core/container.ts
@@ -10,6 +10,7 @@ import type {
   IBackendService,
   IEventService,
   IMediaService,
+  INodeBackendService,
   IPlatformService,
   IStorageService,
   IVideoService,
@@ -23,6 +24,7 @@ class ServiceContainer {
   private _storage: IStorageService | null = null
   private _event: IEventService | null = null
   private _media: IMediaService | null = null
+  private _nodeBackend: INodeBackendService | null = null
   private _video: IVideoService | null = null
   private _ai: IAIService | null = null
 
@@ -45,6 +47,7 @@ class ServiceContainer {
       ServiceContainer.instance._storage = null
       ServiceContainer.instance._event = null
       ServiceContainer.instance._media = null
+      ServiceContainer.instance._nodeBackend = null
       ServiceContainer.instance._video = null
       ServiceContainer.instance._ai = null
     }
@@ -145,6 +148,25 @@ class ServiceContainer {
     return this._media !== null
   }
 
+  // === Node Backend Service ===
+
+  registerNodeBackend(nodeBackend: INodeBackendService): void {
+    this._nodeBackend = nodeBackend
+  }
+
+  getNodeBackend(): INodeBackendService {
+    if (!this._nodeBackend) {
+      throw new Error(
+        "[ServiceContainer] Node backend not registered. Call registerNodeBackend() first or use initHttpApp()/initMockApp().",
+      )
+    }
+    return this._nodeBackend
+  }
+
+  hasNodeBackend(): boolean {
+    return this._nodeBackend !== null
+  }
+
   // === Video Service ===
 
   registerVideo(video: IVideoService): void {
@@ -193,6 +215,7 @@ export const getPlatform = (): IPlatformService => container.getPlatform()
 export const getStorage = (): IStorageService => container.getStorage()
 export const getEvent = (): IEventService => container.getEvent()
 export const getMedia = (): IMediaService => container.getMedia()
+export const getNodeBackend = (): INodeBackendService => container.getNodeBackend()
 export const getVideo = (): IVideoService => container.getVideo()
 export const getAI = (): IAIService => container.getAI()
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -9,12 +9,21 @@
  */
 
 // Container (DI)
-export { container, getBackend, getPlatform, getStorage, resetContainer } from "./container"
+export {
+  container,
+  getBackend,
+  getNodeBackend,
+  getPlatform,
+  getStorage,
+  resetContainer,
+} from "./container"
 // Ports (Interfaces)
 export type {
   IBackendService,
+  INodeBackendService,
   IPlatformService,
   IStorageService,
+  NodeBackendHealth,
   NotificationOptions,
   OpenDialogOptions,
   SaveDialogOptions,

--- a/src/core/ports/index.ts
+++ b/src/core/ports/index.ts
@@ -56,6 +56,13 @@ export type {
   WaveformOptions,
 } from "./media.port"
 export type {
+  INodeBackendService,
+  NodeBackendCacheStats,
+  NodeBackendClearCacheResult,
+  NodeBackendHealth,
+  NodeBackendThumbnailSize,
+} from "./node-backend.port"
+export type {
   FileStats,
   IPlatformService,
   NotificationOptions,

--- a/src/core/ports/node-backend.port.ts
+++ b/src/core/ports/node-backend.port.ts
@@ -1,0 +1,51 @@
+/**
+ * Node Backend Port Interface
+ *
+ * Contract for optional src-node media processing backend access.
+ * Implementations live in adapters so UI code never imports node/trpc clients.
+ */
+
+import type { MediaMetadata, ScanFolderOptions, ScannedMediaFile, ThumbnailOptions } from "./media.port"
+
+export interface NodeBackendHealth {
+  available: boolean
+  ffmpegAvailable: boolean
+  timestamp: number
+}
+
+export interface NodeBackendThumbnailSize {
+  width: number
+  height: number
+}
+
+export interface NodeBackendCacheStats {
+  cache: {
+    memorySize: number
+    dbSize: number
+  }
+  queue: {
+    pending: number
+    processing: number
+    completed: number
+    failed: number
+  }
+  timestamp: number
+}
+
+export interface NodeBackendClearCacheResult {
+  success: boolean
+  timestamp?: number
+  cleared?: number
+}
+
+export interface INodeBackendService {
+  checkHealth(): Promise<NodeBackendHealth>
+  scanFolderWithThumbnails(folderPath: string, options: NodeBackendThumbnailSize): Promise<ScannedMediaFile[]>
+  scanFolder(folderPath: string, options?: ScanFolderOptions): Promise<ScannedMediaFile[]>
+  getMetadata(filePath: string): Promise<MediaMetadata>
+  processFiles(filePaths: string[]): Promise<ScannedMediaFile[]>
+  generateThumbnail(fileId: string, filePath: string, options?: ThumbnailOptions): Promise<string>
+  generateWaveform(filePath: string): Promise<number[]>
+  getCacheStats(): Promise<NodeBackendCacheStats>
+  clearCache(): Promise<NodeBackendClearCacheResult>
+}

--- a/src/features/browser/hooks/use-node-backend.ts
+++ b/src/features/browser/hooks/use-node-backend.ts
@@ -5,18 +5,13 @@
  */
 
 import { useCallback, useState } from "react"
-import { nodeBackendClient } from "@/adapters/node/node-backend-client"
+import { getNodeBackend } from "@/core/container"
+import type { NodeBackendHealth } from "@/core/ports"
 import type { ScannedMediaFile } from "@/core/ports/media.port"
 
 interface UseNodeBackendOptions {
   enabled?: boolean
   onError?: (error: Error) => void
-}
-
-interface BackendHealth {
-  available: boolean
-  ffmpegAvailable: boolean
-  timestamp: number
 }
 
 /**
@@ -48,6 +43,7 @@ interface BackendHealth {
 export function useNodeBackend(options: UseNodeBackendOptions = {}) {
   const { enabled = true, onError } = options
 
+  const [nodeBackend] = useState(() => getNodeBackend())
   const [isScanning, setIsScanning] = useState(false)
   const [isProcessing, setIsProcessing] = useState(false)
   const [error, setError] = useState<Error | null>(null)
@@ -55,25 +51,16 @@ export function useNodeBackend(options: UseNodeBackendOptions = {}) {
   /**
    * Check backend health and FFmpeg availability
    */
-  const checkHealth = useCallback(async (): Promise<BackendHealth> => {
+  const checkHealth = useCallback(async (): Promise<NodeBackendHealth> => {
     try {
-      const [health, ffmpeg] = await Promise.all([
-        nodeBackendClient.health.check.query(),
-        nodeBackendClient.health.ffmpegCheck.query(),
-      ])
-
-      return {
-        available: health.status === "ok",
-        ffmpegAvailable: ffmpeg.available,
-        timestamp: Date.now(),
-      }
+      return await nodeBackend.checkHealth()
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err))
       setError(error)
       onError?.(error)
       throw error
     }
-  }, [onError])
+  }, [nodeBackend, onError])
 
   /**
    * Scan folder for media files with thumbnail generation
@@ -88,13 +75,7 @@ export function useNodeBackend(options: UseNodeBackendOptions = {}) {
       setError(null)
 
       try {
-        const result = await nodeBackendClient.media.scanWithThumbnails.mutate({
-          folderPath,
-          width: options.width,
-          height: options.height,
-        })
-
-        return result
+        return await nodeBackend.scanFolderWithThumbnails(folderPath, options)
       } catch (err) {
         const error = err instanceof Error ? err : new Error(String(err))
         setError(error)
@@ -104,7 +85,7 @@ export function useNodeBackend(options: UseNodeBackendOptions = {}) {
         setIsScanning(false)
       }
     },
-    [enabled, onError],
+    [enabled, nodeBackend, onError],
   )
 
   /**
@@ -120,12 +101,7 @@ export function useNodeBackend(options: UseNodeBackendOptions = {}) {
       setError(null)
 
       try {
-        const result = await nodeBackendClient.media.scanFolder.mutate({
-          folderPath,
-          recursive: options?.recursive,
-        })
-
-        return result
+        return await nodeBackend.scanFolder(folderPath, options)
       } catch (err) {
         const error = err instanceof Error ? err : new Error(String(err))
         setError(error)
@@ -135,7 +111,7 @@ export function useNodeBackend(options: UseNodeBackendOptions = {}) {
         setIsScanning(false)
       }
     },
-    [enabled, onError],
+    [enabled, nodeBackend, onError],
   )
 
   /**
@@ -148,11 +124,7 @@ export function useNodeBackend(options: UseNodeBackendOptions = {}) {
       }
 
       try {
-        const result = await nodeBackendClient.media.getMetadata.query({
-          filePath,
-        })
-
-        return result
+        return await nodeBackend.getMetadata(filePath)
       } catch (err) {
         const error = err instanceof Error ? err : new Error(String(err))
         setError(error)
@@ -160,7 +132,7 @@ export function useNodeBackend(options: UseNodeBackendOptions = {}) {
         throw error
       }
     },
-    [enabled, onError],
+    [enabled, nodeBackend, onError],
   )
 
   /**
@@ -176,11 +148,7 @@ export function useNodeBackend(options: UseNodeBackendOptions = {}) {
       setError(null)
 
       try {
-        const result = await nodeBackendClient.media.processFiles.mutate({
-          filePaths,
-        })
-
-        return result
+        return await nodeBackend.processFiles(filePaths)
       } catch (err) {
         const error = err instanceof Error ? err : new Error(String(err))
         setError(error)
@@ -190,7 +158,7 @@ export function useNodeBackend(options: UseNodeBackendOptions = {}) {
         setIsProcessing(false)
       }
     },
-    [enabled, onError],
+    [enabled, nodeBackend, onError],
   )
 
   /**
@@ -207,15 +175,7 @@ export function useNodeBackend(options: UseNodeBackendOptions = {}) {
       }
 
       try {
-        const result = await nodeBackendClient.thumbnail.generate.mutate({
-          fileId,
-          filePath,
-          width: options?.width,
-          height: options?.height,
-          timestamp: options?.timestamp,
-        })
-
-        return result
+        return await nodeBackend.generateThumbnail(fileId, filePath, options)
       } catch (err) {
         const error = err instanceof Error ? err : new Error(String(err))
         setError(error)
@@ -223,7 +183,7 @@ export function useNodeBackend(options: UseNodeBackendOptions = {}) {
         throw error
       }
     },
-    [enabled, onError],
+    [enabled, nodeBackend, onError],
   )
 
   /**
@@ -236,11 +196,7 @@ export function useNodeBackend(options: UseNodeBackendOptions = {}) {
       }
 
       try {
-        const result = await nodeBackendClient.waveform.generateData.query({
-          filePath,
-        })
-
-        return result
+        return await nodeBackend.generateWaveform(filePath)
       } catch (err) {
         const error = err instanceof Error ? err : new Error(String(err))
         setError(error)
@@ -248,7 +204,7 @@ export function useNodeBackend(options: UseNodeBackendOptions = {}) {
         throw error
       }
     },
-    [enabled, onError],
+    [enabled, nodeBackend, onError],
   )
 
   /**
@@ -256,30 +212,28 @@ export function useNodeBackend(options: UseNodeBackendOptions = {}) {
    */
   const getCacheStats = useCallback(async () => {
     try {
-      const result = await nodeBackendClient.cache.getStats.query()
-      return result
+      return await nodeBackend.getCacheStats()
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err))
       setError(error)
       onError?.(error)
       throw error
     }
-  }, [onError])
+  }, [nodeBackend, onError])
 
   /**
    * Clear cache
    */
   const clearCache = useCallback(async () => {
     try {
-      const result = await nodeBackendClient.cache.clear.mutate()
-      return result
+      return await nodeBackend.clearCache()
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err))
       setError(error)
       onError?.(error)
       throw error
     }
-  }, [onError])
+  }, [nodeBackend, onError])
 
   return {
     // State
@@ -304,7 +258,7 @@ export function useNodeBackend(options: UseNodeBackendOptions = {}) {
     getCacheStats,
     clearCache,
 
-    // Direct client access (for advanced use)
-    client: nodeBackendClient,
+    // Core port access for advanced use
+    client: nodeBackend,
   }
 }

--- a/src/features/version-control/hooks/use-version-control.ts
+++ b/src/features/version-control/hooks/use-version-control.ts
@@ -5,11 +5,11 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react"
 
-import { getBackendSync } from "@/adapters/tauri/backend-sync"
+import { getBackend } from "@/core/container"
+import type { CommandResult, ProjectCommand, ProjectEvent } from "@/core/types"
 import type { VersionInfo } from "@/features/version-control/types"
 import { useToast } from "@/hooks/use-toast"
 import { createLogger } from "@/lib/tauri-logger"
-import type { CommandResult, ProjectEvent } from "@/types/generated/tauri-bindings"
 
 const logger = createLogger("UseVersionControl")
 
@@ -50,12 +50,12 @@ export function useVersionControl(): VersionControlHookState & VersionControlAct
   })
 
   const { toast } = useToast()
-  const [backendSync] = useState(() => getBackendSync())
+  const [backend] = useState(() => getBackend())
 
   // Update state from project state
   const updateFromProjectState = useCallback(async () => {
     try {
-      const projectState = await backendSync.getProjectState()
+      const projectState = await backend.getProjectState()
       if (projectState?.version_info) {
         const versionInfo = projectState.version_info
         setState((prev) => ({
@@ -75,7 +75,7 @@ export function useVersionControl(): VersionControlHookState & VersionControlAct
         error: error instanceof Error ? error.message : String(error),
       }))
     }
-  }, [backendSync])
+  }, [backend])
 
   // Handle version control events
   const handleVersionEvent = useCallback(
@@ -156,10 +156,10 @@ export function useVersionControl(): VersionControlHookState & VersionControlAct
     void updateFromProjectState()
 
     // Subscribe to events
-    const unsubscribe = backendSync.onEvent(handleVersionEvent)
+    const unsubscribe = backend.onEvent(handleVersionEvent)
 
     return unsubscribe
-  }, [backendSync, handleVersionEvent, updateFromProjectState])
+  }, [backend, handleVersionEvent, updateFromProjectState])
 
   // Helper function to handle command results
   const handleCommandResult = useCallback(
@@ -184,38 +184,52 @@ export function useVersionControl(): VersionControlHookState & VersionControlAct
     [toast],
   )
 
+  const executeVersionCommand = useCallback(
+    (command: ProjectCommand): Promise<CommandResult> => backend.executeCommand(command),
+    [backend],
+  )
+
   // Version control actions
   const createSnapshot = useCallback(
     async (message?: string): Promise<boolean> => {
       setState((prev) => ({ ...prev, isLoading: true, error: null }))
       try {
-        const result = await backendSync.createSnapshot(message)
+        const result = await executeVersionCommand({
+          type: "CreateSnapshot",
+          params: { message: message ?? null },
+        })
         return handleCommandResult(result, "Snapshot created successfully")
       } finally {
         setState((prev) => ({ ...prev, isLoading: false }))
       }
     },
-    [backendSync, handleCommandResult],
+    [executeVersionCommand, handleCommandResult],
   )
 
   const restoreVersion = useCallback(
     async (versionId: string): Promise<boolean> => {
       setState((prev) => ({ ...prev, isLoading: true, error: null }))
       try {
-        const result = await backendSync.restoreVersion(versionId)
+        const result = await executeVersionCommand({
+          type: "RestoreVersion",
+          params: { version_id: versionId },
+        })
         return handleCommandResult(result, `Version ${versionId} restored successfully`)
       } finally {
         setState((prev) => ({ ...prev, isLoading: false }))
       }
     },
-    [backendSync, handleCommandResult],
+    [executeVersionCommand, handleCommandResult],
   )
 
   const getVersionHistory = useCallback(
     async (limit?: number): Promise<VersionInfo[] | null> => {
       setState((prev) => ({ ...prev, isLoading: true, error: null }))
       try {
-        const result = await backendSync.getVersionHistory(limit)
+        const result = await executeVersionCommand({
+          type: "GetVersionHistory",
+          params: { limit: limit ?? null },
+        })
         if (result.success && result.data) {
           // Check if data has versions property and it's an array
           if (result.data && typeof result.data === "object" && "versions" in result.data) {
@@ -233,14 +247,17 @@ export function useVersionControl(): VersionControlHookState & VersionControlAct
         setState((prev) => ({ ...prev, isLoading: false }))
       }
     },
-    [backendSync],
+    [executeVersionCommand],
   )
 
   const compareVersions = useCallback(
     async (versionA: string, versionB: string) => {
       setState((prev) => ({ ...prev, isLoading: true, error: null }))
       try {
-        const result = await backendSync.compareVersions(versionA, versionB)
+        const result = await executeVersionCommand({
+          type: "CompareVersions",
+          params: { version_a: versionA, version_b: versionB },
+        })
         if (result.success) {
           return result.data
         }
@@ -250,72 +267,87 @@ export function useVersionControl(): VersionControlHookState & VersionControlAct
         setState((prev) => ({ ...prev, isLoading: false }))
       }
     },
-    [backendSync],
+    [executeVersionCommand],
   )
 
   const createBranch = useCallback(
     async (branchName: string, fromVersion?: string): Promise<boolean> => {
       setState((prev) => ({ ...prev, isLoading: true, error: null }))
       try {
-        const result = await backendSync.createBranch(branchName, fromVersion)
+        const result = await executeVersionCommand({
+          type: "CreateBranch",
+          params: { branch_name: branchName, from_version: fromVersion ?? null },
+        })
         return handleCommandResult(result, `Branch "${branchName}" created successfully`)
       } finally {
         setState((prev) => ({ ...prev, isLoading: false }))
       }
     },
-    [backendSync, handleCommandResult],
+    [executeVersionCommand, handleCommandResult],
   )
 
   const mergeBranch = useCallback(
     async (sourceBranch: string, targetBranch: string): Promise<boolean> => {
       setState((prev) => ({ ...prev, isLoading: true, error: null }))
       try {
-        const result = await backendSync.mergeBranch(sourceBranch, targetBranch)
+        const result = await executeVersionCommand({
+          type: "MergeBranch",
+          params: { source_branch: sourceBranch, target_branch: targetBranch },
+        })
         return handleCommandResult(result, `Branch "${sourceBranch}" merged into "${targetBranch}" successfully`)
       } finally {
         setState((prev) => ({ ...prev, isLoading: false }))
       }
     },
-    [backendSync, handleCommandResult],
+    [executeVersionCommand, handleCommandResult],
   )
 
   const switchBranch = useCallback(
     async (branchName: string): Promise<boolean> => {
       setState((prev) => ({ ...prev, isLoading: true, error: null }))
       try {
-        const result = await backendSync.switchBranch(branchName)
+        const result = await executeVersionCommand({
+          type: "SwitchBranch",
+          params: { branch_name: branchName },
+        })
         return handleCommandResult(result, `Switched to branch "${branchName}" successfully`)
       } finally {
         setState((prev) => ({ ...prev, isLoading: false }))
       }
     },
-    [backendSync, handleCommandResult],
+    [executeVersionCommand, handleCommandResult],
   )
 
   const setAutoSaveInterval = useCallback(
     async (seconds: number): Promise<boolean> => {
       setState((prev) => ({ ...prev, isLoading: true, error: null }))
       try {
-        const result = await backendSync.setAutoSaveInterval(seconds)
+        const result = await executeVersionCommand({
+          type: "SetAutoSaveInterval",
+          params: { seconds },
+        })
         return handleCommandResult(result, `Auto-save interval set to ${seconds} seconds`)
       } finally {
         setState((prev) => ({ ...prev, isLoading: false }))
       }
     },
-    [backendSync, handleCommandResult],
+    [executeVersionCommand, handleCommandResult],
   )
 
   const enableAutoSave = useCallback(
     async (enabled: boolean): Promise<boolean> => {
       setState((prev) => ({ ...prev, isLoading: true, error: null }))
       try {
-        const result = await backendSync.enableAutoSave(enabled)
+        const result = await executeVersionCommand({
+          type: "EnableAutoSave",
+          params: { enabled },
+        })
         return handleCommandResult(result, `Auto-save ${enabled ? "enabled" : "disabled"}`)
       } finally {
         setState((prev) => ({ ...prev, isLoading: false }))
       }
     },
-    [backendSync, handleCommandResult],
+    [executeVersionCommand, handleCommandResult],
   )
 
   return useMemo(


### PR DESCRIPTION
## Summary
- add a core `INodeBackendService` port and register node-backend implementations from node/http/mock/tauri adapters
- route `useNodeBackend` through the new core port instead of importing the node tRPC adapter directly
- route `useVersionControl` through the existing core backend port instead of importing Tauri `BackendSync`

## Verification
- `bun install --frozen-lockfile --ignore-scripts`
- `bunx biome check src/core/container.ts src/core/index.ts src/core/ports/index.ts src/core/ports/node-backend.port.ts src/core/__tests__/container.test.ts src/adapters/node/index.ts src/adapters/node/node-backend-client.ts src/adapters/node/node-backend-bridge.ts src/adapters/http/index.ts src/adapters/mock/index.ts src/adapters/mock/node-backend.ts src/adapters/tauri/index.ts src/adapters/tauri/node-backend.ts src/features/browser/hooks/use-node-backend.ts src/features/version-control/hooks/use-version-control.ts`
- `bun run check:type`
- `bun run check:boundaries --max-details=80` -> 490 total violations, `ui -> adapters` removed
- `bun run test -- src/core/__tests__/container.test.ts src/adapters/react/__tests__/app-init-provider.test.tsx src/adapters/react/__tests__/app-init-integration.test.tsx src/adapters/react/__tests__/app-init-edge-cases.test.tsx src/features/version-control/__tests__/components/version-history-panel.test.tsx src/features/version-control/__tests__/components/version-control-manager.test.tsx`
- `git diff --check`

Closes #157
