### PR TITLE
refactor(ui): pilot version-control bridge alias

### DIFF
--- a/docs/08_tasks/planned/monorepo-packages-migration.md
+++ b/docs/08_tasks/planned/monorepo-packages-migration.md
@@ -73,29 +73,36 @@ adapters -> core
 
 **Цель:** убрать зависимость core от domains и начать снимать `ui -> domains` coupling.
 
-- [ ] Найти `core -> domains` импорты через `bun run check:boundaries`.
-- [ ] Вынести UI-facing контракты в `src/core/ports`.
-- [ ] Добавить bridge API в `src/core/container` или соседний composition module.
-- [ ] Перевести первый набор hooks/features с прямых domain imports на core API.
-- [ ] Оставить desktop поведение неизменным.
+- [x] Найти `core -> domains` импорты через `bun run check:boundaries`.
+- [x] Вынести UI-facing контракты в `src/core/ports`.
+- [x] Добавить bridge API в `src/core/container` или соседний composition module.
+- [x] Перевести первый набор hooks/features с прямых domain imports на core API.
+- [x] Оставить desktop поведение неизменным.
 
 ### F3: Adapter contracts
 
 **Цель:** закрыть прямые импорты adapters из UI.
 
-- [ ] Найти `ui -> adapters` импорты через `bun run check:boundaries`.
-- [ ] Перенести нужные операции за core ports.
-- [ ] Инициализировать Tauri/Node/Mock implementations только в app-shell/adapters.
-- [ ] Подготовить mock adapter path для UI tests.
+- [x] Найти `ui -> adapters` импорты через `bun run check:boundaries`.
+- [x] Перенести нужные операции за core ports.
+- [x] Инициализировать Tauri/Node/Mock implementations только в app-shell/adapters.
+- [x] Подготовить mock adapter path для UI tests.
 
 ### F4: UI pilot package
 
 **Цель:** проверить форму `@timeline-studio/ui` на одном вертикальном feature slice.
 
-- [ ] Выбрать feature с небольшим числом domain imports.
-- [ ] Перевести его public API на `@timeline-studio/ui/features/*`.
-- [ ] Убедиться, что feature не импортирует adapters и новые domain imports не добавляются.
-- [ ] Обновить relevant tests.
+- [x] Выбрать feature с небольшим числом domain imports: pilot slice - `src/features/version-control`.
+- [x] Перевести его public API на `@timeline-studio/ui/features/version-control`.
+- [x] Убедиться, что feature не импортирует adapters и новые domain imports не добавляются.
+- [x] Обновить relevant tests.
+
+Следующие UI slices после pilot:
+
+1. `developer-tools` - самый маленький feature slice без domain/adapter imports.
+2. `drag-drop` - небольшой UI-only slice для проверки non-modal feature shape.
+3. `language` - небольшой slice с одним domain import; хороший кандидат для следующего core bridge.
+4. `color-scheme` и `options` - следующие после burn-down оставшихся settings/domain связей.
 
 ### F5: Workspace split и CI
 
@@ -125,11 +132,11 @@ bun run check:type
 
 Baseline на 2026-06-07:
 
-- Scanned files: 1569
-- Violations: 506
-- `error`: 39
-- `warn`: 467
-- Edges: `core -> domains` 6, `domains -> app-shell` 3, `domains -> ui` 28, `ui -> adapters` 2, `ui -> domains` 467
+- Scanned files: 1573
+- Violations: 490
+- `error`: 31
+- `warn`: 459
+- Edges: `domains -> app-shell` 3, `domains -> ui` 28, `ui -> domains` 459
 
 Следующие PR должны уменьшать этот отчет и не добавлять новые нарушения без явного follow-up.
 

--- a/src/features/timeline/hooks/integration/use-integrated-version-control.ts
+++ b/src/features/timeline/hooks/integration/use-integrated-version-control.ts
@@ -2,8 +2,8 @@
  * Интегрированный hook для Timeline Undo/Redo + Project Version Control
  */
 
+import { useVersionControl } from "@timeline-studio/ui/features/version-control"
 import { useCallback, useEffect, useState } from "react"
-import { useVersionControl } from "@/features/version-control/hooks"
 import {
   type VersionControlIntegrationConfig,
   versionControlIntegration,

--- a/src/features/timeline/services/version-control-integration.ts
+++ b/src/features/timeline/services/version-control-integration.ts
@@ -3,8 +3,8 @@
  * Объединяет краткосрочные операции отмены с долгосрочным управлением версиями
  */
 
+import type { VersionInfo } from "@timeline-studio/ui/features/version-control"
 import { isServiceEnabled } from "@/config/service-config"
-import type { VersionInfo } from "@/features/version-control/types"
 import { createLogger } from "@/lib/tauri-logger"
 import type { UndoRedoService } from "./undo-redo-service"
 

--- a/src/features/user-settings/__tests__/components/tabs/version-control-tab.test.tsx
+++ b/src/features/user-settings/__tests__/components/tabs/version-control-tab.test.tsx
@@ -7,7 +7,7 @@ import { describe, expect, it, vi } from "vitest"
 
 import { VersionControlTab } from "../../../components/tabs/version-control-tab"
 
-vi.mock("@/features/version-control/components/version-control-manager", () => ({
+vi.mock("@timeline-studio/ui/features/version-control", () => ({
   VersionControlManager: () => (
     <div data-testid="version-control-manager" data-oid="7baoz3p">
       Version Control Manager

--- a/src/features/user-settings/components/tabs/version-control-tab.tsx
+++ b/src/features/user-settings/components/tabs/version-control-tab.tsx
@@ -3,7 +3,7 @@
  * Provides access to project version control functionality
  */
 
-import { VersionControlManager } from "@/features/version-control/components/version-control-manager"
+import { VersionControlManager } from "@timeline-studio/ui/features/version-control"
 
 /**
  * Version Control tab component

--- a/src/features/version-control/README.md
+++ b/src/features/version-control/README.md
@@ -45,7 +45,7 @@ version-control/
 
 ## Usage
 ```typescript
-import { useVersionControl } from '@/features/version-control'
+import { useVersionControl } from '@timeline-studio/ui/features/version-control'
 
 function ProjectHeader() {
   const {

--- a/src/features/version-control/README.ru.md
+++ b/src/features/version-control/README.ru.md
@@ -45,7 +45,7 @@ version-control/
 
 ## Использование
 ```typescript
-import { useVersionControl } from '@/features/version-control'
+import { useVersionControl } from '@timeline-studio/ui/features/version-control'
 
 function ProjectHeader() {
   const {

--- a/src/features/version-control/__tests__/components/version-control-manager.test.tsx
+++ b/src/features/version-control/__tests__/components/version-control-manager.test.tsx
@@ -12,7 +12,7 @@ import { BranchManager, VersionControlManager, VersionControlSettings } from "..
 
 // Mock the useVersionControl hook
 const mockUseVersionControl = vi.fn()
-vi.mock("@/features/version-control/hooks", () => ({
+vi.mock("../../hooks", () => ({
   useVersionControl: () => mockUseVersionControl(),
 }))
 

--- a/src/features/version-control/__tests__/components/version-history-panel.test.tsx
+++ b/src/features/version-control/__tests__/components/version-history-panel.test.tsx
@@ -13,7 +13,7 @@ import type { VersionInfo } from "../../types"
 
 // Mock the useVersionControl hook
 const mockUseVersionControl = vi.fn()
-vi.mock("@/features/version-control/hooks", () => ({
+vi.mock("../../hooks", () => ({
   useVersionControl: () => mockUseVersionControl(),
 }))
 

--- a/src/features/version-control/components/version-control-manager.tsx
+++ b/src/features/version-control/components/version-control-manager.tsx
@@ -3,16 +3,15 @@
  * Main interface for version control functionality
  */
 
+import { Badge } from "@timeline-studio/ui/components/badge"
+import { Button } from "@timeline-studio/ui/components/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@timeline-studio/ui/components/card"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@timeline-studio/ui/components/tabs"
 import { AlertCircle, Clock, GitBranch, GitCommit, GitMerge, History, Settings } from "lucide-react"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 
-import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { useVersionControl } from "@/features/version-control/hooks"
-
+import { useVersionControl } from "../hooks"
 import { VersionHistoryPanel } from "./version-history-panel"
 
 interface VersionControlManagerProps {

--- a/src/features/version-control/components/version-history-panel.tsx
+++ b/src/features/version-control/components/version-history-panel.tsx
@@ -3,17 +3,16 @@
  * Provides UI for viewing and managing project versions
  */
 
+import { Badge } from "@timeline-studio/ui/components/badge"
+import { Button } from "@timeline-studio/ui/components/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@timeline-studio/ui/components/card"
+import { ScrollArea } from "@timeline-studio/ui/components/scroll-area"
+import { Separator } from "@timeline-studio/ui/components/separator"
 import { Clock, GitBranch, History, MessageCircle, Plus, RotateCcw, Settings, User } from "lucide-react"
 import { useCallback, useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 
-import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { ScrollArea } from "@/components/ui/scroll-area"
-import { Separator } from "@/components/ui/separator"
-import { useVersionControl } from "@/features/version-control/hooks"
-
+import { useVersionControl } from "../hooks"
 import type { VersionInfo } from "../types"
 
 // Time formatting function with i18n support

--- a/src/features/version-control/hooks/use-version-control.ts
+++ b/src/features/version-control/hooks/use-version-control.ts
@@ -7,9 +7,9 @@ import { useCallback, useEffect, useMemo, useState } from "react"
 
 import { getBackend } from "@/core/container"
 import type { CommandResult, ProjectCommand, ProjectEvent } from "@/core/types"
-import type { VersionInfo } from "@/features/version-control/types"
 import { useToast } from "@/hooks/use-toast"
 import { createLogger } from "@/lib/tauri-logger"
+import type { VersionInfo } from "../types"
 
 const logger = createLogger("UseVersionControl")
 

--- a/src/features/version-control/index.ts
+++ b/src/features/version-control/index.ts
@@ -2,6 +2,12 @@
  * Version control feature exports
  */
 
-export { VersionControlManager } from "./components/version-control-manager"
+export {
+  BranchManager,
+  VersionControlManager,
+  VersionControlSettings,
+} from "./components/version-control-manager"
 export { VersionHistoryPanel } from "./components/version-history-panel"
 export * from "./hooks"
+export type { VersionControlActions, VersionControlHookState } from "./hooks/use-version-control"
+export type { VersionControlState, VersionInfo } from "./types"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,6 +31,11 @@ export default defineConfig({
     alias: {
       "@": path.resolve(__dirname, "./src"),
       "@features": path.resolve(__dirname, "./src/features"),
+      "@timeline-studio/core": path.resolve(__dirname, "./src/core"),
+      "@timeline-studio/domains": path.resolve(__dirname, "./src/domains"),
+      "@timeline-studio/adapters": path.resolve(__dirname, "./src/adapters"),
+      "@timeline-studio/ui/features": path.resolve(__dirname, "./src/features"),
+      "@timeline-studio/ui/components": path.resolve(__dirname, "./src/components/ui"),
     },
   },
   build: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -78,6 +78,11 @@ export default defineConfig({
     alias: {
       "@": path.resolve(__dirname, "./src"),
       "@features": path.resolve(__dirname, "./src/features"),
+      "@timeline-studio/core": path.resolve(__dirname, "./src/core"),
+      "@timeline-studio/domains": path.resolve(__dirname, "./src/domains"),
+      "@timeline-studio/adapters": path.resolve(__dirname, "./src/adapters"),
+      "@timeline-studio/ui/features": path.resolve(__dirname, "./src/features"),
+      "@timeline-studio/ui/components": path.resolve(__dirname, "./src/components/ui"),
       // Mock Tauri dependencies during testing
       "@tauri-apps/plugin-os": path.resolve(__dirname, "./src/test/mocks/tauri/plugins/os.ts"),
       "@tauri-apps/plugin-notification": path.resolve(__dirname, "./src/test/mocks/tauri/plugins/notification.ts"),


### PR DESCRIPTION
## Summary
- promote `version-control` to the pilot `@timeline-studio/ui/features/version-control` public API
- switch external consumers and tests to the bridge alias while keeping slice internals relative
- add Vite/Vitest bridge aliases for `@timeline-studio/*` so runtime tests match `tsconfig` paths
- update Phase F migration docs with the pilot slice and next UI slice order

## Verification
- `bun install --frozen-lockfile --ignore-scripts`
- `bunx biome check --write vite.config.ts vitest.config.ts src/features/version-control/index.ts src/features/version-control/hooks/use-version-control.ts src/features/version-control/components/version-control-manager.tsx src/features/version-control/components/version-history-panel.tsx src/features/version-control/__tests__/components/version-control-manager.test.tsx src/features/version-control/__tests__/components/version-history-panel.test.tsx src/features/user-settings/components/tabs/version-control-tab.tsx src/features/user-settings/__tests__/components/tabs/version-control-tab.test.tsx src/features/timeline/hooks/integration/use-integrated-version-control.ts src/features/timeline/services/version-control-integration.ts`
- `bun run check:type`
- `bun run check:boundaries --max-details=80` -> 490 total violations, no `ui -> adapters`
- `bun run test -- src/features/version-control/__tests__/components/version-history-panel.test.tsx src/features/version-control/__tests__/components/version-control-manager.test.tsx src/features/user-settings/__tests__/components/tabs/version-control-tab.test.tsx`
- `git diff --check`

Closes #158
