### PR TITLE
Phase F7: bridge language through core port

### DIFF
--- a/config/package-boundaries-baseline.json
+++ b/config/package-boundaries-baseline.json
@@ -1,11 +1,11 @@
 {
   "updated": "2026-06-08",
-  "source": "Phase F6 boundary error burn-down",
-  "violations": 420,
+  "source": "Phase F7 language core bridge",
+  "violations": 419,
   "bySeverity": {
-    "warn": 420
+    "warn": 419
   },
   "byEdge": {
-    "ui -> domains": 420
+    "ui -> domains": 419
   }
 }

--- a/docs/08_tasks/planned/monorepo-packages-migration.md
+++ b/docs/08_tasks/planned/monorepo-packages-migration.md
@@ -123,6 +123,13 @@ adapters -> core
 - [x] Убрать provider re-exports из `src/domains/video-editing`.
 - [x] Обновить committed baseline до warning-only отчета.
 
+### F7: UI-to-domains warning burn-down
+
+**Цель:** постепенно снижать warning-only `ui -> domains` baseline маленькими UI slices.
+
+- [x] `language`: добавить core language port/service и перевести `features/language` с `@/domains/system-integration` на core service.
+- [ ] Следующие маленькие кандидаты: `options`, `color-scheme`, `keyboard-shortcuts`, `color-grading`.
+
 ## Проверка каждого PR
 
 Минимальный набор для каждого Phase F slice:
@@ -145,11 +152,11 @@ CI использует `bun run check:boundaries:baseline`, который ср
 
 Baseline на 2026-06-08:
 
-- Scanned files: 1580
-- Violations: 420
+- Scanned files: 1586
+- Violations: 419
 - `error`: 0
-- `warn`: 420
-- Edges: `ui -> domains` 420
+- `warn`: 419
+- Edges: `ui -> domains` 419
 
 Следующие PR должны уменьшать этот отчет и не добавлять новые нарушения без явного follow-up.
 

--- a/docs/engineering/package-boundaries.md
+++ b/docs/engineering/package-boundaries.md
@@ -62,3 +62,4 @@ This gate fails if total violations, severity counts or edge counts increase abo
 4. **F4 UI pilot package:** extract one feature vertical into the future `@timeline-studio/ui` shape without moving the whole app.
 5. **F5 workspace split:** create package/app `package.json` files, update build/test scripts, lockfiles and CI cache.
 6. **F6 boundary error burn-down:** remove hard `domains -> ui/app-shell` violations and keep the remaining `ui -> domains` coupling as warning-only follow-up work.
+7. **F7 warning burn-down:** reduce `ui -> domains` warnings through small core ports and UI bridge slices.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,6 +22,10 @@
       "types": "./src/ports/index.ts",
       "default": "./src/ports/index.ts"
     },
+    "./services": {
+      "types": "./src/services/index.ts",
+      "default": "./src/services/index.ts"
+    },
     "./types": {
       "types": "./src/types/index.ts",
       "default": "./src/types/index.ts"

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -1,0 +1,1 @@
+export * from "../../../../src/core/services/index"

--- a/src/adapters/http/index.ts
+++ b/src/adapters/http/index.ts
@@ -17,7 +17,7 @@
  * ```
  */
 
-import { MockPlatformService, MockStorageService } from "@/adapters/mock"
+import { MockLanguageService, MockPlatformService, MockStorageService } from "@/adapters/mock"
 import { container } from "@/core/container"
 import { NodeBackendBridgeService } from "../node/node-backend-bridge"
 import { type HttpBackendOptions, HttpBackendService } from "./backend"
@@ -43,6 +43,7 @@ export interface HttpAppServices {
   backend: HttpBackendService
   media: HttpMediaService
   nodeBackend: NodeBackendBridgeService
+  language: MockLanguageService
   client: HttpClient
 }
 
@@ -57,10 +58,12 @@ export async function initHttpApp(options: HttpAppOptions = {}): Promise<HttpApp
   const backend = new HttpBackendService({ serverUrl, ...options.backend })
   const media = new HttpMediaService()
   const nodeBackend = new NodeBackendBridgeService({ serverUrl })
+  const language = new MockLanguageService()
 
   container.registerBackend(backend)
   container.registerMedia(media)
   container.registerNodeBackend(nodeBackend)
+  container.registerLanguage(language)
   // src-node doesn't provide storage/platform — use in-memory mocks so the container is complete
   if (!container.hasStorage()) container.registerStorage(new MockStorageService(true))
   if (!container.hasPlatform()) container.registerPlatform(new MockPlatformService())
@@ -74,7 +77,7 @@ export async function initHttpApp(options: HttpAppOptions = {}): Promise<HttpApp
     }
   }
 
-  return { backend, media, nodeBackend, client }
+  return { backend, media, nodeBackend, language, client }
 }
 
 /**
@@ -87,6 +90,7 @@ export function createHttpServices(options: HttpAppOptions = {}): HttpAppService
     backend: new HttpBackendService({ serverUrl, ...options.backend }),
     media: new HttpMediaService(),
     nodeBackend: new NodeBackendBridgeService({ serverUrl }),
+    language: new MockLanguageService(),
     client: new HttpClient({ baseUrl: serverUrl }),
   }
 }

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -41,6 +41,7 @@ export {
   createMockServices,
   initMockApp,
   MockBackendService,
+  MockLanguageService,
   MockMediaService,
   MockPlatformService,
   MockStorageService,
@@ -53,6 +54,7 @@ export { AppInitProvider, useAppInit, useAppReady } from "./react"
 export {
   initTauriApp,
   TauriBackendService,
+  TauriLanguageService,
   TauriMediaService,
   TauriPlatformService,
   TauriStorageService,

--- a/src/adapters/mock/__tests__/language.test.ts
+++ b/src/adapters/mock/__tests__/language.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { MockLanguageService } from "../language"
+
+describe("MockLanguageService", () => {
+  let service: MockLanguageService
+
+  beforeEach(() => {
+    service = new MockLanguageService()
+  })
+
+  it("returns default language response", async () => {
+    await expect(service.getAppLanguage()).resolves.toEqual({
+      language: "en",
+      system_language: "en-US",
+    })
+  })
+
+  it("updates app language", async () => {
+    const result = await service.setAppLanguage("ru")
+
+    expect(result).toEqual({
+      language: "ru",
+      system_language: "en-US",
+    })
+    await expect(service.getAppLanguage()).resolves.toEqual(result)
+  })
+
+  it("supports custom language response for tests", async () => {
+    service.setLanguageResponse({ language: "fr", system_language: "fr-FR" })
+
+    await expect(service.getAppLanguage()).resolves.toEqual({
+      language: "fr",
+      system_language: "fr-FR",
+    })
+  })
+})

--- a/src/adapters/mock/index.ts
+++ b/src/adapters/mock/index.ts
@@ -10,6 +10,7 @@ import { container } from "@/core/container"
 import { MockAIService } from "./ai"
 import { MockBackendService } from "./backend"
 import { MockEventService } from "./event"
+import { MockLanguageService } from "./language"
 import { MockMediaService } from "./media"
 import { MockNodeBackendService } from "./node-backend"
 import { MockPlatformService } from "./platform"
@@ -19,6 +20,7 @@ import { MockVideoService } from "./video"
 export { MockAIService } from "./ai"
 export { MockBackendService } from "./backend"
 export { MockEventService } from "./event"
+export { MockLanguageService } from "./language"
 export { MockMediaService } from "./media"
 export { MockNodeBackendService } from "./node-backend"
 export { MockPlatformService } from "./platform"
@@ -42,6 +44,7 @@ export function initMockApp(options: { useLocalStorage?: boolean } = {}): {
   nodeBackend: MockNodeBackendService
   video: MockVideoService
   ai: MockAIService
+  language: MockLanguageService
 } {
   const { useLocalStorage = false } = options
 
@@ -54,6 +57,7 @@ export function initMockApp(options: { useLocalStorage?: boolean } = {}): {
   const nodeBackend = new MockNodeBackendService()
   const video = new MockVideoService()
   const ai = new MockAIService()
+  const language = new MockLanguageService()
 
   // Register in container
   container.registerBackend(backend)
@@ -64,9 +68,10 @@ export function initMockApp(options: { useLocalStorage?: boolean } = {}): {
   container.registerNodeBackend(nodeBackend)
   container.registerVideo(video)
   container.registerAI(ai)
+  container.registerLanguage(language)
 
   // Return services for test manipulation
-  return { backend, platform, storage, event, media, nodeBackend, video, ai }
+  return { backend, platform, storage, event, media, nodeBackend, video, ai, language }
 }
 
 /**
@@ -82,6 +87,7 @@ export function createMockServices(options: { useLocalStorage?: boolean } = {}):
   nodeBackend: MockNodeBackendService
   video: MockVideoService
   ai: MockAIService
+  language: MockLanguageService
 } {
   const { useLocalStorage = false } = options
 
@@ -94,5 +100,6 @@ export function createMockServices(options: { useLocalStorage?: boolean } = {}):
     nodeBackend: new MockNodeBackendService(),
     video: new MockVideoService(),
     ai: new MockAIService(),
+    language: new MockLanguageService(),
   }
 }

--- a/src/adapters/mock/language.ts
+++ b/src/adapters/mock/language.ts
@@ -1,0 +1,25 @@
+import type { ILanguageService, LanguageResponse } from "@/core/ports"
+
+export class MockLanguageService implements ILanguageService {
+  private languageResponse: LanguageResponse
+
+  constructor(initialResponse: LanguageResponse = { language: "en", system_language: "en-US" }) {
+    this.languageResponse = initialResponse
+  }
+
+  async getAppLanguage(): Promise<LanguageResponse> {
+    return { ...this.languageResponse }
+  }
+
+  async setAppLanguage(lang: string): Promise<LanguageResponse> {
+    this.languageResponse = {
+      ...this.languageResponse,
+      language: lang,
+    }
+    return { ...this.languageResponse }
+  }
+
+  setLanguageResponse(response: LanguageResponse): void {
+    this.languageResponse = response
+  }
+}

--- a/src/adapters/node/__tests__/language.test.ts
+++ b/src/adapters/node/__tests__/language.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest"
+import { NodeLanguageService } from "../language"
+
+describe("NodeLanguageService", () => {
+  it("uses provided language options", async () => {
+    const service = new NodeLanguageService({ language: "ru", systemLanguage: "ru-RU" })
+
+    await expect(service.getAppLanguage()).resolves.toEqual({
+      language: "ru",
+      system_language: "ru-RU",
+    })
+  })
+
+  it("derives app language from system language", async () => {
+    const service = new NodeLanguageService({ systemLanguage: "fr-FR" })
+
+    await expect(service.getAppLanguage()).resolves.toEqual({
+      language: "fr",
+      system_language: "fr-FR",
+    })
+  })
+
+  it("updates app language in memory", async () => {
+    const service = new NodeLanguageService({ systemLanguage: "en-US" })
+
+    const result = await service.setAppLanguage("es")
+
+    expect(result).toEqual({
+      language: "es",
+      system_language: "en-US",
+    })
+    await expect(service.getAppLanguage()).resolves.toEqual(result)
+  })
+})

--- a/src/adapters/node/index.ts
+++ b/src/adapters/node/index.ts
@@ -10,6 +10,7 @@ import { container } from "@/core/container"
 import { type NodeAIOptions, NodeAIService } from "./ai"
 import { type NodeBackendOptions, NodeBackendService } from "./backend"
 import { NodeEventService } from "./event"
+import { type NodeLanguageOptions, NodeLanguageService } from "./language"
 import { type NodeMediaOptions, NodeMediaService } from "./media"
 import { NodeBackendBridgeService } from "./node-backend-bridge"
 import { type NodePlatformOptions, NodePlatformService } from "./platform"
@@ -20,6 +21,7 @@ import { type NodeVideoOptions, NodeVideoService } from "./video"
 export { type NodeAIOptions, NodeAIService } from "./ai"
 export { type NodeBackendOptions, NodeBackendService } from "./backend"
 export { NodeEventService } from "./event"
+export { type NodeLanguageOptions, NodeLanguageService } from "./language"
 export { type NodeMediaOptions, NodeMediaService } from "./media"
 export { NodeBackendBridgeService } from "./node-backend-bridge"
 export { type NodePlatformOptions, NodePlatformService } from "./platform"
@@ -39,6 +41,8 @@ export interface NodeAppOptions {
   ai?: NodeAIOptions
   /** Опции для Backend сервиса */
   backend?: NodeBackendOptions
+  /** Опции для Language сервиса */
+  language?: NodeLanguageOptions
   /** Автоматически подключаться к бэкенду */
   autoConnect?: boolean
 }
@@ -52,6 +56,7 @@ export interface NodeAppServices {
   nodeBackend: NodeBackendBridgeService
   video: NodeVideoService
   ai: NodeAIService
+  language: NodeLanguageService
 }
 
 /**
@@ -86,6 +91,7 @@ export async function initNodeApp(options: NodeAppOptions = {}): Promise<NodeApp
   const nodeBackend = new NodeBackendBridgeService()
   const video = new NodeVideoService(options.video)
   const ai = new NodeAIService(options.ai)
+  const language = new NodeLanguageService(options.language)
 
   // Register in container
   container.registerBackend(backend)
@@ -96,6 +102,7 @@ export async function initNodeApp(options: NodeAppOptions = {}): Promise<NodeApp
   container.registerNodeBackend(nodeBackend)
   container.registerVideo(video)
   container.registerAI(ai)
+  container.registerLanguage(language)
 
   // Auto-connect if requested
   if (autoConnect) {
@@ -111,6 +118,7 @@ export async function initNodeApp(options: NodeAppOptions = {}): Promise<NodeApp
     nodeBackend,
     video,
     ai,
+    language,
   }
 }
 
@@ -131,5 +139,6 @@ export function createNodeServices(options: NodeAppOptions = {}): NodeAppService
     nodeBackend: new NodeBackendBridgeService(),
     video: new NodeVideoService(options.video),
     ai: new NodeAIService(options.ai),
+    language: new NodeLanguageService(options.language),
   }
 }

--- a/src/adapters/node/language.ts
+++ b/src/adapters/node/language.ts
@@ -1,0 +1,38 @@
+import type { ILanguageService, LanguageResponse } from "@/core/ports"
+
+export interface NodeLanguageOptions {
+  language?: string
+  systemLanguage?: string
+}
+
+function getSystemLanguage(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().locale || "en"
+  } catch {
+    return "en"
+  }
+}
+
+export class NodeLanguageService implements ILanguageService {
+  private languageResponse: LanguageResponse
+
+  constructor(options: NodeLanguageOptions = {}) {
+    const systemLanguage = options.systemLanguage ?? getSystemLanguage()
+    this.languageResponse = {
+      language: options.language ?? systemLanguage.split("-")[0] ?? "en",
+      system_language: systemLanguage,
+    }
+  }
+
+  async getAppLanguage(): Promise<LanguageResponse> {
+    return { ...this.languageResponse }
+  }
+
+  async setAppLanguage(lang: string): Promise<LanguageResponse> {
+    this.languageResponse = {
+      ...this.languageResponse,
+      language: lang,
+    }
+    return { ...this.languageResponse }
+  }
+}

--- a/src/adapters/tauri/__tests__/language.test.ts
+++ b/src/adapters/tauri/__tests__/language.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { TauriLanguageService } from "../language"
+
+const mockInvoke = vi.fn()
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: any[]) => mockInvoke(...args),
+}))
+
+vi.mock("@/lib/tauri-logger", () => ({
+  createLogger: () => ({
+    debugSync: vi.fn(),
+    infoSync: vi.fn(),
+    errorSync: vi.fn(),
+  }),
+}))
+
+describe("TauriLanguageService", () => {
+  let service: TauriLanguageService
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    service = new TauriLanguageService()
+  })
+
+  it("gets app language through Tauri command", async () => {
+    const response = { language: "en", system_language: "en-US" }
+    mockInvoke.mockResolvedValueOnce(response)
+
+    const result = await service.getAppLanguage()
+
+    expect(mockInvoke).toHaveBeenCalledWith("get_app_language_tauri")
+    expect(result).toEqual(response)
+  })
+
+  it("sets app language through Tauri command", async () => {
+    const response = { language: "ru", system_language: "en-US" }
+    mockInvoke.mockResolvedValueOnce(response)
+
+    const result = await service.setAppLanguage("ru")
+
+    expect(mockInvoke).toHaveBeenCalledWith("set_app_language_tauri", { lang: "ru" })
+    expect(result).toEqual(response)
+  })
+
+  it("propagates Tauri command errors", async () => {
+    mockInvoke.mockRejectedValueOnce(new Error("Backend error"))
+
+    await expect(service.getAppLanguage()).rejects.toThrow("Backend error")
+  })
+})

--- a/src/adapters/tauri/index.ts
+++ b/src/adapters/tauri/index.ts
@@ -10,6 +10,7 @@ import { container } from "@/core/container"
 import { TauriAIService } from "./ai"
 import { TauriBackendService } from "./backend"
 import { TauriEventService } from "./event"
+import { TauriLanguageService } from "./language"
 import { TauriMediaService } from "./media"
 import { TauriNodeBackendService } from "./node-backend"
 import { TauriPlatformService } from "./platform"
@@ -22,6 +23,7 @@ export type { EventHandler, StateChangeHandler } from "./backend-sync"
 // Re-export BackendSync for backwards compatibility
 export { BackendSync, getBackendSync } from "./backend-sync"
 export { TauriEventService } from "./event"
+export { TauriLanguageService } from "./language"
 export { TauriMediaService } from "./media"
 export { TauriNodeBackendService } from "./node-backend"
 export { TauriPlatformService } from "./platform"
@@ -48,6 +50,7 @@ export async function initTauriApp(options: { storeName?: string; autoConnect?: 
   const nodeBackend = new TauriNodeBackendService()
   const video = new TauriVideoService()
   const ai = new TauriAIService()
+  const language = new TauriLanguageService()
 
   container.registerBackend(backend)
   container.registerPlatform(platform)
@@ -57,6 +60,7 @@ export async function initTauriApp(options: { storeName?: string; autoConnect?: 
   container.registerNodeBackend(nodeBackend)
   container.registerVideo(video)
   container.registerAI(ai)
+  container.registerLanguage(language)
 
   // Auto-connect to backend if requested
   if (autoConnect) {

--- a/src/adapters/tauri/language.ts
+++ b/src/adapters/tauri/language.ts
@@ -1,0 +1,31 @@
+import { invoke } from "@tauri-apps/api/core"
+import type { ILanguageService, LanguageResponse } from "@/core/ports"
+import { createLogger } from "@/lib/tauri-logger"
+
+const logger = createLogger("TauriLanguageService")
+
+export class TauriLanguageService implements ILanguageService {
+  async getAppLanguage(): Promise<LanguageResponse> {
+    logger.debugSync("Getting app language from backend")
+    try {
+      const result = await invoke<LanguageResponse>("get_app_language_tauri")
+      logger.debugSync("App language retrieved", { language: result.language })
+      return result
+    } catch (error) {
+      logger.errorSync("Failed to get app language", { error })
+      throw error
+    }
+  }
+
+  async setAppLanguage(lang: string): Promise<LanguageResponse> {
+    logger.infoSync("Setting app language", { lang })
+    try {
+      const result = await invoke<LanguageResponse>("set_app_language_tauri", { lang })
+      logger.infoSync("App language set successfully", { lang })
+      return result
+    } catch (error) {
+      logger.errorSync("Failed to set app language", { lang, error })
+      throw error
+    }
+  }
+}

--- a/src/core/__tests__/container.test.ts
+++ b/src/core/__tests__/container.test.ts
@@ -1,6 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { container, getBackend, getEvent, getNodeBackend, getPlatform, getStorage, resetContainer } from "../container"
-import type { IBackendService, IEventService, INodeBackendService, IPlatformService, IStorageService } from "../ports"
+import {
+  container,
+  getBackend,
+  getEvent,
+  getLanguage,
+  getNodeBackend,
+  getPlatform,
+  getStorage,
+  resetContainer,
+} from "../container"
+import type {
+  IBackendService,
+  IEventService,
+  ILanguageService,
+  INodeBackendService,
+  IPlatformService,
+  IStorageService,
+} from "../ports"
 
 // Mock implementations
 const createMockBackend = (): IBackendService => ({
@@ -62,6 +78,11 @@ const createMockNodeBackend = (): INodeBackendService => ({
   generateWaveform: vi.fn(),
   getCacheStats: vi.fn(),
   clearCache: vi.fn(),
+})
+
+const createMockLanguage = (): ILanguageService => ({
+  getAppLanguage: vi.fn(),
+  setAppLanguage: vi.fn(),
 })
 
 describe("ServiceContainer", () => {
@@ -171,6 +192,27 @@ describe("ServiceContainer", () => {
       container.registerNodeBackend(mockNodeBackend)
 
       expect(getNodeBackend()).toBe(mockNodeBackend)
+    })
+  })
+
+  describe("Language Service", () => {
+    it("throws error when language service not registered", () => {
+      expect(() => container.getLanguage()).toThrow("[ServiceContainer] Language service not registered")
+    })
+
+    it("registers and retrieves language service", () => {
+      const mockLanguage = createMockLanguage()
+      container.registerLanguage(mockLanguage)
+
+      expect(container.hasLanguage()).toBe(true)
+      expect(container.getLanguage()).toBe(mockLanguage)
+    })
+
+    it("getLanguage helper works", () => {
+      const mockLanguage = createMockLanguage()
+      container.registerLanguage(mockLanguage)
+
+      expect(getLanguage()).toBe(mockLanguage)
     })
   })
 

--- a/src/core/container.ts
+++ b/src/core/container.ts
@@ -9,6 +9,7 @@ import type {
   IAIService,
   IBackendService,
   IEventService,
+  ILanguageService,
   IMediaService,
   INodeBackendService,
   IPlatformService,
@@ -27,6 +28,7 @@ class ServiceContainer {
   private _nodeBackend: INodeBackendService | null = null
   private _video: IVideoService | null = null
   private _ai: IAIService | null = null
+  private _language: ILanguageService | null = null
 
   private constructor() {}
 
@@ -50,6 +52,7 @@ class ServiceContainer {
       ServiceContainer.instance._nodeBackend = null
       ServiceContainer.instance._video = null
       ServiceContainer.instance._ai = null
+      ServiceContainer.instance._language = null
     }
   }
 
@@ -204,6 +207,25 @@ class ServiceContainer {
   hasAI(): boolean {
     return this._ai !== null
   }
+
+  // === Language Service ===
+
+  registerLanguage(language: ILanguageService): void {
+    this._language = language
+  }
+
+  getLanguage(): ILanguageService {
+    if (!this._language) {
+      throw new Error(
+        "[ServiceContainer] Language service not registered. Call registerLanguage() first or use initTauriApp()/initMockApp().",
+      )
+    }
+    return this._language
+  }
+
+  hasLanguage(): boolean {
+    return this._language !== null
+  }
 }
 
 // Singleton instance
@@ -218,6 +240,7 @@ export const getMedia = (): IMediaService => container.getMedia()
 export const getNodeBackend = (): INodeBackendService => container.getNodeBackend()
 export const getVideo = (): IVideoService => container.getVideo()
 export const getAI = (): IAIService => container.getAI()
+export const getLanguage = (): ILanguageService => container.getLanguage()
 
 // For testing
 export const resetContainer = (): void => ServiceContainer.reset()

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -12,6 +12,7 @@
 export {
   container,
   getBackend,
+  getLanguage,
   getNodeBackend,
   getPlatform,
   getStorage,
@@ -20,6 +21,7 @@ export {
 // Ports (Interfaces)
 export type {
   IBackendService,
+  ILanguageService,
   INodeBackendService,
   IPlatformService,
   IStorageService,
@@ -29,6 +31,8 @@ export type {
   SaveDialogOptions,
   Unsubscribe,
 } from "./ports"
+export type { LanguageResponse } from "./services"
+export { getAppLanguage, setAppLanguage } from "./services"
 
 // Types (re-exported from generated bindings for now)
 export type {

--- a/src/core/ports/index.ts
+++ b/src/core/ports/index.ts
@@ -38,6 +38,7 @@ export type {
 } from "./ai.port"
 export type { IBackendService, Unsubscribe } from "./backend.port"
 export type { EventCallback, IEventService, UnlistenFn } from "./event.port"
+export type { ILanguageService, LanguageResponse } from "./language.port"
 export type {
   IMediaService,
   MediaImportOptions,

--- a/src/core/ports/language.port.ts
+++ b/src/core/ports/language.port.ts
@@ -1,0 +1,9 @@
+export interface LanguageResponse {
+  language: string
+  system_language: string
+}
+
+export interface ILanguageService {
+  getAppLanguage(): Promise<LanguageResponse>
+  setAppLanguage(lang: string): Promise<LanguageResponse>
+}

--- a/src/core/services/index.ts
+++ b/src/core/services/index.ts
@@ -1,0 +1,1 @@
+export * from "./language"

--- a/src/core/services/language.ts
+++ b/src/core/services/language.ts
@@ -1,0 +1,12 @@
+import { container } from "../container"
+import type { LanguageResponse } from "../ports"
+
+export type { LanguageResponse } from "../ports"
+
+export async function getAppLanguage(): Promise<LanguageResponse> {
+  return container.getLanguage().getAppLanguage()
+}
+
+export async function setAppLanguage(lang: string): Promise<LanguageResponse> {
+  return container.getLanguage().setAppLanguage(lang)
+}

--- a/src/features/language/hooks/__tests__/use-language.test.tsx
+++ b/src/features/language/hooks/__tests__/use-language.test.tsx
@@ -14,7 +14,7 @@ vi.mock("react-i18next", () => ({
   useTranslation: vi.fn(),
 }))
 
-vi.mock("@/domains/system-integration", () => ({
+vi.mock("@/core/services/language", () => ({
   getAppLanguage: vi.fn(),
   setAppLanguage: vi.fn(),
 }))
@@ -61,7 +61,7 @@ describe("useLanguage", () => {
 
   describe("initialization", () => {
     it("should initialize with loading state", async () => {
-      const { getAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockImplementation(() => new Promise(() => {})) // Never resolves
 
       const { result } = renderHook(() => useLanguage())
@@ -71,7 +71,7 @@ describe("useLanguage", () => {
     })
 
     it("should fetch language from backend on mount", async () => {
-      const { getAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockResolvedValue({
         language: "en",
         system_language: "en-US",
@@ -90,7 +90,7 @@ describe("useLanguage", () => {
     })
 
     it("should set system language from backend response", async () => {
-      const { getAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockResolvedValue({
         language: "ru",
         system_language: "ru", // Use language code, not locale
@@ -104,7 +104,7 @@ describe("useLanguage", () => {
     })
 
     it("should change i18n language if different from backend", async () => {
-      const { getAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockResolvedValue({
         language: "ru",
         system_language: "ru-RU",
@@ -120,7 +120,7 @@ describe("useLanguage", () => {
     })
 
     it("should not change i18n language if same as backend", async () => {
-      const { getAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockResolvedValue({
         language: "en",
         system_language: "en-US",
@@ -138,7 +138,7 @@ describe("useLanguage", () => {
     })
 
     it("should save language to localStorage", async () => {
-      const { getAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockResolvedValue({
         language: "ru",
         system_language: "ru-RU",
@@ -154,7 +154,7 @@ describe("useLanguage", () => {
 
   describe("supported language validation", () => {
     it("should use default language if backend returns unsupported language", async () => {
-      const { getAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockResolvedValue({
         language: "unsupported",
         system_language: "en-US",
@@ -173,7 +173,7 @@ describe("useLanguage", () => {
     })
 
     it("should use default system language if backend returns unsupported system language", async () => {
-      const { getAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockResolvedValue({
         language: "en",
         system_language: "invalid-INVALID",
@@ -187,7 +187,7 @@ describe("useLanguage", () => {
     })
 
     it("should handle all supported languages", async () => {
-      const { getAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage } = vi.mocked(await import("@/core/services/language"))
 
       const languages = ["en", "ru", "es", "fr", "de", "pt", "zh", "ja", "ko", "tr", "it", "th", "hi", "ar", "fa"]
 
@@ -214,7 +214,7 @@ describe("useLanguage", () => {
 
   describe("error handling", () => {
     it("should handle backend error", async () => {
-      const { getAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockRejectedValue(new Error("Backend not available"))
 
       const { result } = renderHook(() => useLanguage())
@@ -227,7 +227,7 @@ describe("useLanguage", () => {
     })
 
     it("should fallback to localStorage on backend error", async () => {
-      const { getAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockRejectedValue(new Error("Backend error"))
 
       localStorage.setItem("app-language", "ru")
@@ -240,7 +240,7 @@ describe("useLanguage", () => {
     })
 
     it("should validate localStorage language before using", async () => {
-      const { getAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockRejectedValue(new Error("Backend error"))
 
       localStorage.setItem("app-language", "invalid")
@@ -256,7 +256,7 @@ describe("useLanguage", () => {
     })
 
     it("should handle localStorage read error", async () => {
-      const { getAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockRejectedValue(new Error("Backend error"))
 
       // Mock localStorage.getItem to throw
@@ -278,7 +278,7 @@ describe("useLanguage", () => {
     })
 
     it("should handle non-Error objects in catch blocks", async () => {
-      const { getAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockRejectedValue("String error")
 
       const { result } = renderHook(() => useLanguage())
@@ -293,7 +293,7 @@ describe("useLanguage", () => {
 
   describe("changeLanguage function", () => {
     it("should change language via i18n and backend", async () => {
-      const { getAppLanguage, setAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage, setAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockResolvedValue({
         language: "en",
         system_language: "en-US",
@@ -318,7 +318,7 @@ describe("useLanguage", () => {
     })
 
     it("should set loading state during language change", async () => {
-      const { getAppLanguage, setAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage, setAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockResolvedValue({
         language: "en",
         system_language: "en-US",
@@ -361,7 +361,7 @@ describe("useLanguage", () => {
     })
 
     it("should clear error state on successful language change", async () => {
-      const { getAppLanguage, setAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage, setAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockRejectedValueOnce(new Error("Initial error"))
       setAppLanguage.mockResolvedValue({
         language: "ru",
@@ -383,7 +383,7 @@ describe("useLanguage", () => {
     })
 
     it("should handle error during language change", async () => {
-      const { getAppLanguage, setAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage, setAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockResolvedValue({
         language: "en",
         system_language: "en-US",
@@ -404,7 +404,7 @@ describe("useLanguage", () => {
     })
 
     it("should still save to localStorage even if backend fails", async () => {
-      const { getAppLanguage, setAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage, setAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockResolvedValue({
         language: "en",
         system_language: "en-US",
@@ -424,7 +424,7 @@ describe("useLanguage", () => {
     })
 
     it("should change i18n language even if backend fails", async () => {
-      const { getAppLanguage, setAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage, setAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockResolvedValue({
         language: "en",
         system_language: "en-US",
@@ -446,7 +446,7 @@ describe("useLanguage", () => {
 
   describe("refreshLanguage function", () => {
     it("should refetch language from backend", async () => {
-      const { getAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockResolvedValueOnce({
         language: "en",
         system_language: "en-US",
@@ -479,7 +479,7 @@ describe("useLanguage", () => {
     })
 
     it("should set loading state during refresh", async () => {
-      const { getAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockResolvedValue({
         language: "en",
         system_language: "en-US",
@@ -523,7 +523,7 @@ describe("useLanguage", () => {
 
   describe("currentLanguage getter", () => {
     it("should return i18n language if available", async () => {
-      const { getAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockResolvedValue({
         language: "ru",
         system_language: "ru-RU",
@@ -541,7 +541,7 @@ describe("useLanguage", () => {
     })
 
     it("should return default language if i18n not available", async () => {
-      const { getAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockResolvedValue({
         language: "en",
         system_language: "en-US",
@@ -560,7 +560,7 @@ describe("useLanguage", () => {
     })
 
     it("should return default language if i18n.language is empty", async () => {
-      const { getAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockResolvedValue({
         language: "en",
         system_language: "en-US",
@@ -578,7 +578,7 @@ describe("useLanguage", () => {
 
   describe("RTL languages", () => {
     it("should handle Arabic language (RTL)", async () => {
-      const { getAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockResolvedValue({
         language: "ar",
         system_language: "ar", // Use language code, not locale
@@ -594,7 +594,7 @@ describe("useLanguage", () => {
     })
 
     it("should handle Persian language (RTL)", async () => {
-      const { getAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockResolvedValue({
         language: "fa",
         system_language: "fa", // Use language code, not locale
@@ -612,7 +612,7 @@ describe("useLanguage", () => {
 
   describe("memoization", () => {
     it("should memoize fetchLanguage callback", async () => {
-      const { getAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockResolvedValue({
         language: "en",
         system_language: "en-US",
@@ -635,7 +635,7 @@ describe("useLanguage", () => {
     })
 
     it("should memoize changeLanguage callback", async () => {
-      const { getAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockResolvedValue({
         language: "en",
         system_language: "en-US",
@@ -658,7 +658,7 @@ describe("useLanguage", () => {
     })
 
     it("should recreate callbacks when i18n changes", async () => {
-      const { getAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockResolvedValue({
         language: "en",
         system_language: "en-US",
@@ -695,7 +695,7 @@ describe("useLanguage", () => {
 
   describe("concurrent operations", () => {
     it("should handle concurrent language changes", async () => {
-      const { getAppLanguage, setAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage, setAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockResolvedValue({
         language: "en",
         system_language: "en-US",
@@ -725,7 +725,7 @@ describe("useLanguage", () => {
     })
 
     it("should handle concurrent refresh calls", async () => {
-      const { getAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockResolvedValue({
         language: "en",
         system_language: "en-US",
@@ -753,7 +753,7 @@ describe("useLanguage", () => {
 
   describe("edge cases", () => {
     it("should handle missing i18n object", async () => {
-      const { getAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockResolvedValue({
         language: "en",
         system_language: "en-US",
@@ -775,7 +775,7 @@ describe("useLanguage", () => {
     })
 
     it("should handle empty string in backend response", async () => {
-      const { getAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockResolvedValue({
         language: "",
         system_language: "",
@@ -795,7 +795,7 @@ describe("useLanguage", () => {
     })
 
     it("should handle null values in backend response", async () => {
-      const { getAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockResolvedValue({
         language: null as any,
         system_language: null as any,
@@ -812,7 +812,7 @@ describe("useLanguage", () => {
     })
 
     it("should handle changeLanguage with empty string", async () => {
-      const { getAppLanguage, setAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage, setAppLanguage } = vi.mocked(await import("@/core/services/language"))
       getAppLanguage.mockResolvedValue({
         language: "en",
         system_language: "en-US",
@@ -836,7 +836,7 @@ describe("useLanguage", () => {
 
   describe("integration scenarios", () => {
     it("should handle language switching flow (en -> ru -> es)", async () => {
-      const { getAppLanguage, setAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage, setAppLanguage } = vi.mocked(await import("@/core/services/language"))
 
       // Initial: English
       getAppLanguage.mockResolvedValue({
@@ -883,7 +883,7 @@ describe("useLanguage", () => {
     })
 
     it("should handle app restart with saved language", async () => {
-      const { getAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage } = vi.mocked(await import("@/core/services/language"))
 
       // Simulate app restart with saved language
       localStorage.setItem("app-language", "ru")
@@ -903,7 +903,7 @@ describe("useLanguage", () => {
     })
 
     it("should handle backend recovery after error", async () => {
-      const { getAppLanguage } = vi.mocked(await import("@/domains/system-integration"))
+      const { getAppLanguage } = vi.mocked(await import("@/core/services/language"))
 
       // Initial error
       getAppLanguage.mockRejectedValueOnce(new Error("Backend unavailable"))

--- a/src/features/language/hooks/use-language.ts
+++ b/src/features/language/hooks/use-language.ts
@@ -6,7 +6,7 @@
 import { useCallback, useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 
-import { getAppLanguage, setAppLanguage } from "@/domains/system-integration"
+import { getAppLanguage, setAppLanguage } from "@/core/services/language"
 import { DEFAULT_LANGUAGE, isSupportedLanguage, type LanguageCode } from "@/i18n/constants"
 
 import { createLogger } from "@/lib/tauri-logger"


### PR DESCRIPTION
## Summary
- add a core language port/service facade and register language services in Tauri, mock, node, and HTTP adapters
- switch `features/language` from `@/domains/system-integration` to the core language service
- update package-boundary baseline/docs from 420 to 419 `ui -> domains` warnings
- add container and language adapter tests

Part of #165.

## Verification
- `bun run check:boundaries`
- `bun run check:boundaries:baseline`
- `bun run check:workspaces`
- `bun run check:type`
- `bun run test -- src/features/language/hooks/__tests__/use-language.test.tsx src/features/language/__tests__/index.test.ts src/core/__tests__/container.test.ts src/adapters/mock/__tests__/language.test.ts src/adapters/node/__tests__/language.test.ts src/adapters/tauri/__tests__/language.test.ts src/domains/system-integration/__tests__/services/language/language-service.test.ts src/domains/system-integration/__tests__/tauri/language-commands.test.ts`
- `bunx biome ci` on changed files
- `git diff --cached --check`