### PR TITLE
Phase F8: bridge options media type through core

### DIFF
--- a/config/package-boundaries-baseline.json
+++ b/config/package-boundaries-baseline.json
@@ -1,11 +1,11 @@
 {
   "updated": "2026-06-08",
-  "source": "Phase F7 language core bridge",
-  "violations": 419,
+  "source": "Phase F8 options media type bridge",
+  "violations": 417,
   "bySeverity": {
-    "warn": 419
+    "warn": 417
   },
   "byEdge": {
-    "ui -> domains": 419
+    "ui -> domains": 417
   }
 }

--- a/docs/08_tasks/planned/monorepo-packages-migration.md
+++ b/docs/08_tasks/planned/monorepo-packages-migration.md
@@ -128,7 +128,8 @@ adapters -> core
 **Цель:** постепенно снижать warning-only `ui -> domains` baseline маленькими UI slices.
 
 - [x] `language`: добавить core language port/service и перевести `features/language` с `@/domains/system-integration` на core service.
-- [ ] Следующие маленькие кандидаты: `options`, `color-scheme`, `keyboard-shortcuts`, `color-grading`.
+- [x] `options`: добавить core-facing `MediaFile` type bridge и убрать type-only imports из `@/domains/media-management`.
+- [ ] Следующие маленькие кандидаты: `color-scheme`, `keyboard-shortcuts`, `color-grading`.
 
 ## Проверка каждого PR
 
@@ -152,11 +153,11 @@ CI использует `bun run check:boundaries:baseline`, который ср
 
 Baseline на 2026-06-08:
 
-- Scanned files: 1586
-- Violations: 419
+- Scanned files: 1587
+- Violations: 417
 - `error`: 0
-- `warn`: 419
-- Edges: `ui -> domains` 419
+- `warn`: 417
+- Edges: `ui -> domains` 417
 
 Следующие PR должны уменьшать этот отчет и не добавлять новые нарушения без явного follow-up.
 

--- a/docs/engineering/package-boundaries.md
+++ b/docs/engineering/package-boundaries.md
@@ -63,3 +63,4 @@ This gate fails if total violations, severity counts or edge counts increase abo
 5. **F5 workspace split:** create package/app `package.json` files, update build/test scripts, lockfiles and CI cache.
 6. **F6 boundary error burn-down:** remove hard `domains -> ui/app-shell` violations and keep the remaining `ui -> domains` coupling as warning-only follow-up work.
 7. **F7 warning burn-down:** reduce `ui -> domains` warnings through small core ports and UI bridge slices.
+8. **F8 options type bridge:** move `features/options` off type-only media-management imports through core-facing media types.

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -41,6 +41,7 @@ export type {
   Clip,
   CommandResult,
   EventEnvelope,
+  MediaFile,
   MediaItem,
   Project,
   ProjectCommand,

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -29,5 +29,6 @@ export type {
   ViewMode,
 } from "@/types/generated/tauri-bindings"
 
-// Re-export commonly used domain types for features
+// Re-export core-facing compatibility types for features
+export * from "./media"
 export * from "./video-editing"

--- a/src/core/types/media.ts
+++ b/src/core/types/media.ts
@@ -1,0 +1,43 @@
+/**
+ * Core-facing media types used by UI slices.
+ * Keep this file independent from domain packages so type-only UI props can
+ * move off domain re-exports before media-management is extracted.
+ */
+
+export interface MediaFile {
+  id: string
+  name: string
+  path: string
+  type: string
+  duration?: number
+  size?: number
+  createdAt?: Date
+  updatedAt?: Date
+  width?: number
+  height?: number
+  fps?: number
+  bitrate?: number
+  thumbnailPath?: string
+  metadata?: {
+    type?: string
+    bitrate?: number
+    codec?: string
+    width?: number
+    height?: number
+    fps?: number
+    duration?: number
+    channels?: number
+    sample_rate?: number
+    [key: string]: unknown
+  }
+  isVideo?: boolean
+  isImage?: boolean
+  isAudio?: boolean
+  isAddedToTimeline?: boolean
+  isIncluded?: boolean
+  isUnavailable?: boolean
+  lastCheckedAt?: number
+  isLoadingMetadata?: boolean
+  source?: string
+  [key: string]: unknown
+}

--- a/src/features/options/components/info-settings.tsx
+++ b/src/features/options/components/info-settings.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next"
 
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
 import { Label } from "@/components/ui/label"
-import type { MediaFile } from "@/domains/media-management"
+import type { MediaFile } from "@/core/types"
 import { useTimeline } from "@/features/timeline"
 
 interface InfoSettingsState {

--- a/src/features/options/components/options.tsx
+++ b/src/features/options/components/options.tsx
@@ -3,7 +3,7 @@ import { type JSX, useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import type { MediaFile } from "@/domains/media-management"
+import type { MediaFile } from "@/core/types"
 import { TAB_BUTTON_STYLES } from "@/features/browser"
 import { ColorSettings } from "@/features/color-grading"
 import { cn } from "@/lib/utils"


### PR DESCRIPTION
## Summary
- add a core-facing `MediaFile` type bridge independent from domain packages
- switch `features/options` type-only imports from `@/domains/media-management` to `@/core/types`
- update package-boundary baseline/docs from 419 to 417 `ui -> domains` warnings

Part of #165.

## Verification
- `bun run check:boundaries`
- `bun run check:boundaries:baseline`
- `bun run check:workspaces`
- `bun run check:type`
- `bun run test -- src/features/options/__tests__/components/audio-settings.test.tsx src/features/options/__tests__/components/speed-settings.test.tsx`
- `bunx biome ci` on changed files
- `git diff --cached --check`