### PR TITLE
Phase F10: bridge color scheme settings imports

### DIFF
--- a/config/package-boundaries-baseline.json
+++ b/config/package-boundaries-baseline.json
@@ -1,11 +1,11 @@
 {
   "updated": "2026-06-08",
-  "source": "Phase F9 keyboard shortcuts modal bridge",
-  "violations": 415,
+  "source": "Phase F10 color scheme settings bridge",
+  "violations": 412,
   "bySeverity": {
-    "warn": 415
+    "warn": 412
   },
   "byEdge": {
-    "ui -> domains": 415
+    "ui -> domains": 412
   }
 }

--- a/docs/08_tasks/planned/monorepo-packages-migration.md
+++ b/docs/08_tasks/planned/monorepo-packages-migration.md
@@ -130,7 +130,8 @@ adapters -> core
 - [x] `language`: добавить core language port/service и перевести `features/language` с `@/domains/system-integration` на core service.
 - [x] `options`: добавить core-facing `MediaFile` type bridge и убрать type-only imports из `@/domains/media-management`.
 - [x] `keyboard-shortcuts`: перевести modal hook imports на feature-facing compatibility layer `@/features/modals/services`.
-- [ ] Следующие маленькие кандидаты: `color-scheme`, `color-grading`.
+- [x] `color-scheme`: расширить feature-facing `user-settings` adapter и убрать прямые imports из `project-management`/`system-integration`.
+- [ ] Следующие маленькие кандидаты: `color-grading`.
 
 ## Проверка каждого PR
 
@@ -155,10 +156,10 @@ CI использует `bun run check:boundaries:baseline`, который ср
 Baseline на 2026-06-08:
 
 - Scanned files: 1587
-- Violations: 415
+- Violations: 412
 - `error`: 0
-- `warn`: 415
-- Edges: `ui -> domains` 415
+- `warn`: 412
+- Edges: `ui -> domains` 412
 
 Следующие PR должны уменьшать этот отчет и не добавлять новые нарушения без явного follow-up.
 

--- a/docs/engineering/package-boundaries.md
+++ b/docs/engineering/package-boundaries.md
@@ -65,3 +65,4 @@ This gate fails if total violations, severity counts or edge counts increase abo
 7. **F7 warning burn-down:** reduce `ui -> domains` warnings through small core ports and UI bridge slices.
 8. **F8 options type bridge:** move `features/options` off type-only media-management imports through core-facing media types.
 9. **F9 keyboard shortcuts modal bridge:** move `features/keyboard-shortcuts` off direct system-integration modal imports through the existing modals compatibility layer.
+10. **F10 color scheme settings bridge:** move `features/color-scheme` off direct project-management and system-integration imports through feature-facing adapters.

--- a/src/features/color-scheme/components/color-scheme-dropdown.tsx
+++ b/src/features/color-scheme/components/color-scheme-dropdown.tsx
@@ -14,7 +14,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { useModals } from "@/domains/system-integration"
+import { useModals } from "@/features/modals/services"
 import { useColorScheme } from "../hooks/use-color-scheme"
 import { schemePreviewColor } from "../lib"
 import type { ColorScheme } from "../types"

--- a/src/features/color-scheme/components/color-scheme-provider.tsx
+++ b/src/features/color-scheme/components/color-scheme-provider.tsx
@@ -11,7 +11,7 @@
 import { useTheme } from "next-themes"
 import { type ReactNode, useEffect } from "react"
 
-import { useUserSettings } from "@/domains/project-management/hooks"
+import { useUserSettings } from "@/features/user-settings"
 import { useColorScheme } from "../hooks/use-color-scheme"
 import { applyColorScheme } from "../lib"
 

--- a/src/features/color-scheme/hooks/use-color-scheme.ts
+++ b/src/features/color-scheme/hooks/use-color-scheme.ts
@@ -10,7 +10,7 @@
 import { useTheme } from "next-themes"
 import { useCallback, useMemo } from "react"
 
-import { useUserSettings } from "@/domains/project-management/hooks"
+import { useUserSettings } from "@/features/user-settings"
 import { BUILTIN_COLOR_SCHEMES, BUILTIN_SCHEMES_BY_ID, DEFAULT_COLOR_SCHEME_ID } from "../constants"
 import type { ColorScheme, ThemeMode } from "../types"
 

--- a/src/features/user-settings/__tests__/hooks/use-user-settings.test.ts
+++ b/src/features/user-settings/__tests__/hooks/use-user-settings.test.ts
@@ -19,6 +19,13 @@ const mockDomain = {
   isBrowserVisible: true,
   isTimelineVisible: true,
   isOptionsVisible: false,
+  isLoaded: true,
+
+  // Appearance
+  themeMode: "system" as const,
+  colorScheme: "teal",
+  customColorSchemes: [],
+  quickAccessSchemeIds: ["teal"],
 
   // GPU/Perf
   gpuAccelerationEnabled: false,
@@ -77,6 +84,8 @@ describe("useUserSettings (adapter)", () => {
     expect(result.current.layoutMode).toBe("default")
     expect(result.current.isBrowserVisible).toBe(true)
     expect(result.current.playerVolume).toBe(50)
+    expect(result.current.themeMode).toBe("system")
+    expect(result.current.colorScheme).toBe("teal")
   })
 
   it("проксирует toggle*-методы", () => {
@@ -106,6 +115,14 @@ describe("useUserSettings (adapter)", () => {
 
     result.current.handleAiApiKeyChange("k1")
     expect(mockDomain.updateOpenAiApiKey).toHaveBeenCalledWith("k1")
+  })
+
+  it("проксирует пакетное обновление настроек", () => {
+    const { result } = renderHook(() => useUserSettings())
+
+    result.current.updateSettings({ colorScheme: "amber", themeMode: "dark" })
+
+    expect(mockDomain.updateSettings).toHaveBeenCalledWith({ colorScheme: "amber", themeMode: "dark" })
   })
 
   it("валидирует вкладки браузера в handleTabChange", () => {

--- a/src/features/user-settings/__tests__/test-utils.ts
+++ b/src/features/user-settings/__tests__/test-utils.ts
@@ -40,9 +40,16 @@ export function createMockUserSettings(overrides?: Partial<UserSettingsContextVa
     isBrowserVisible: true,
     isTimelineVisible: true,
     isOptionsVisible: true,
+    isLoaded: true,
     activeTab: "media",
     layoutMode: "default",
     playerVolume: 100,
+
+    // Внешний вид
+    themeMode: "system",
+    colorScheme: "teal",
+    customColorSchemes: [],
+    quickAccessSchemeIds: ["teal"],
 
     // GPU и производительность
     gpuAccelerationEnabled: false,
@@ -80,6 +87,7 @@ export function createMockUserSettings(overrides?: Partial<UserSettingsContextVa
     handlePlayerVolumeChange: vi.fn(),
     toggleTimelineVisibility: vi.fn(),
     toggleOptionsVisibility: vi.fn(),
+    updateSettings: vi.fn(),
 
     // Методы GPU и производительности
     handleGpuAccelerationChange: vi.fn(),

--- a/src/features/user-settings/hooks/use-user-settings.ts
+++ b/src/features/user-settings/hooks/use-user-settings.ts
@@ -67,6 +67,13 @@ export function useUserSettings(): UserSettingsContextValue {
     isBrowserVisible: d.isBrowserVisible,
     isTimelineVisible: d.isTimelineVisible,
     isOptionsVisible: d.isOptionsVisible,
+    isLoaded: d.isLoaded,
+
+    // Внешний вид
+    themeMode: d.themeMode,
+    colorScheme: d.colorScheme,
+    customColorSchemes: d.customColorSchemes ?? [],
+    quickAccessSchemeIds: d.quickAccessSchemeIds ?? [],
 
     // GPU/Perf
     gpuAccelerationEnabled: d.gpuAccelerationEnabled,
@@ -104,6 +111,7 @@ export function useUserSettings(): UserSettingsContextValue {
     toggleBrowserVisibility: d.toggleBrowserVisibility,
     toggleTimelineVisibility: d.toggleTimelineVisibility,
     toggleOptionsVisibility: d.toggleOptionsVisibility,
+    updateSettings: (updates: Record<string, unknown>) => d.updateSettings(updates as any),
 
     // GPU/Perf
     handleGpuAccelerationChange,

--- a/src/features/user-settings/services/user-settings-provider.tsx
+++ b/src/features/user-settings/services/user-settings-provider.tsx
@@ -6,6 +6,22 @@ import type { UserSettingsContextType } from "@/domains/project-management/machi
 import { type LayoutMode } from "@/domains/project-management/machines/user-settings-machine"
 import { getProjectManagementOrchestrator } from "@/domains/project-management/services/project-management-orchestrator"
 
+export type UserSettingsThemeMode = "light" | "dark" | "system"
+
+export type UserSettingsColorSchemeVars = {
+  teal: string
+  "teal-light": string
+  "teal-dark": string
+}
+
+export interface UserSettingsColorScheme {
+  id: string
+  name: string
+  isBuiltin?: boolean
+  light: UserSettingsColorSchemeVars
+  dark: UserSettingsColorSchemeVars
+}
+
 /**
  * Интерфейс значения контекста пользовательских настроек
  * Определяет данные и методы, доступные через хук useUserSettings
@@ -24,6 +40,13 @@ export interface UserSettingsContextValue {
   isBrowserVisible: boolean // Флаг видимости браузера
   isTimelineVisible: boolean // Флаг видимости временной шкалы
   isOptionsVisible: boolean // Флаг видимости опций
+  isLoaded: boolean // Флаг загрузки настроек
+
+  // Внешний вид
+  themeMode: UserSettingsThemeMode
+  colorScheme: string
+  customColorSchemes: UserSettingsColorScheme[]
+  quickAccessSchemeIds: string[]
 
   // GPU и производительность
   gpuAccelerationEnabled: boolean
@@ -61,6 +84,7 @@ export interface UserSettingsContextValue {
   toggleBrowserVisibility: () => void // Переключение видимости браузера
   toggleTimelineVisibility: () => void // Переключение видимости временной шкалы
   toggleOptionsVisibility: () => void // Переключение видимости опций
+  updateSettings: (updates: Record<string, unknown>) => void // Пакетное обновление настроек
 
   // Методы для GPU и производительности
   handleGpuAccelerationChange: (value: boolean) => void
@@ -283,6 +307,11 @@ export function UserSettingsProvider({
     [orchestrator],
   )
 
+  const updateSettings = useCallback(
+    (updates: Record<string, unknown>) => orchestrator.updateUserSettings(updates as Partial<UserSettingsContextType>),
+    [orchestrator],
+  )
+
   // Мемоизированное значение контекста
   const value: UserSettingsContextValue = useMemo(
     () => ({
@@ -297,6 +326,13 @@ export function UserSettingsProvider({
       isBrowserVisible: settings?.isBrowserVisible ?? true,
       isTimelineVisible: settings?.isTimelineVisible ?? true,
       isOptionsVisible: settings?.isOptionsVisible ?? false,
+      isLoaded: settings?.isLoaded ?? false,
+
+      // Внешний вид
+      themeMode: settings?.themeMode ?? "system",
+      colorScheme: settings?.colorScheme ?? "teal",
+      customColorSchemes: settings?.customColorSchemes ?? [],
+      quickAccessSchemeIds: settings?.quickAccessSchemeIds ?? [],
 
       // GPU и производительность
       gpuAccelerationEnabled: settings?.gpuAccelerationEnabled ?? false,
@@ -334,6 +370,7 @@ export function UserSettingsProvider({
       toggleBrowserVisibility,
       toggleTimelineVisibility,
       toggleOptionsVisibility,
+      updateSettings,
       handleGpuAccelerationChange,
       handlePreferredGpuEncoderChange,
       handleMaxConcurrentJobsChange,
@@ -364,6 +401,7 @@ export function UserSettingsProvider({
       toggleBrowserVisibility,
       toggleTimelineVisibility,
       toggleOptionsVisibility,
+      updateSettings,
       handleGpuAccelerationChange,
       handlePreferredGpuEncoderChange,
       handleMaxConcurrentJobsChange,


### PR DESCRIPTION
## Summary
- extend the feature-facing `user-settings` adapter with color scheme settings and `updateSettings`
- switch `features/color-scheme` off direct `project-management` and `system-integration` imports
- update package-boundary baseline/docs from 415 to 412 `ui -> domains` warnings

Part of #165.

## Verification
- `bun run check:boundaries`
- `bun run check:boundaries:baseline`
- `bun run check:workspaces`
- `bun run check:type`
- `bun run test -- src/features/user-settings/__tests__/hooks/use-user-settings.test.ts src/features/user-settings/__tests__/components/user-settings-modal-tabs.test.tsx src/features/user-settings/__tests__/components/user-settings-modal.test.tsx`
- `bunx biome ci` on changed files
- `git diff --cached --check`