### PR TITLE
feat: add bot-first render job foundation

### DIFF
--- a/docs/08_tasks/planned/bot-first-workflow.md
+++ b/docs/08_tasks/planned/bot-first-workflow.md
@@ -1,0 +1,75 @@
+# Bot-first workflow
+
+**Статус:** Active, tracked in [#171](https://github.com/chatman-media/timeline-studio/issues/171)
+**Приоритет:** High
+**Создано:** 2026-06-08
+**Ответственный:** Architecture Team
+
+## Контекст
+
+Целевая модель Timeline Studio - пользователь управляет созданием ролика через бота. Desktop UI остается полезным для просмотра, настройки и ручного редактирования, но основной happy path должен работать без открытия приложения: бот принимает материалы и параметры, запускает сборку проекта, рендерит видео и возвращает результат или публикует его в выбранный канал.
+
+Это меняет приоритет архитектурной миграции: вместо отдельных UI/export slices нужно в первую очередь выделять headless contracts и worker-friendly services, которыми сможет пользоваться бот, CLI, desktop и будущий backend.
+
+## Цели
+
+1. Бот может создать render job из JSON-контракта без React/Tauri состояния.
+2. Render job возвращает машинно-читаемый статус, прогресс, ошибки и артефакт.
+3. Desktop/CLI используют тот же core port, что и будущий bot worker.
+4. Публикация в соцсети подключается как destination после стабильного render job pipeline, а не как UI-first export flow.
+5. Все новые slices сохраняют работоспособность desktop app и не ломают Phase F package boundaries.
+
+## First workflow
+
+```text
+bot message
+  -> parse media/template/params
+  -> create BotRenderJobRequest
+  -> run IRenderJobService
+  -> track BotRenderJobEvent stream
+  -> return file artifact or publish destination
+```
+
+## PR slices
+
+### B1: Render job foundation
+
+**Цель:** создать общий headless контракт и первый Node/CLI вход для bot worker.
+
+- [x] Добавить `BotRenderJobRequest`, `BotRenderJob`, `BotRenderJobEvent` и `BotRenderJobResult` в core types.
+- [x] Добавить `IRenderJobService` core port.
+- [x] Добавить `NodeRenderJobService`, который запускает render через существующий `IVideoService`.
+- [x] Добавить CLI-команду `render-job <job.json>` с JSON output/status file.
+- [x] Покрыть Node service и CLI contract unit tests.
+
+### B2: Bot intake contract
+
+**Цель:** описать вход бота до создания render job.
+
+- [ ] Добавить типы `BotWorkflowRequest`, `BotMediaAttachment`, `BotTemplateSelection`.
+- [ ] Добавить parser/normalizer для входа из Telegram-like payload в `BotRenderJobRequest`.
+- [ ] Добавить validation errors, пригодные для ответа пользователю в чате.
+
+### B3: Worker event stream
+
+**Цель:** дать боту live-статусы без UI.
+
+- [ ] Добавить event sink abstraction для отправки progress updates.
+- [ ] Поддержать status snapshots для reconnect/retry.
+- [ ] Покрыть cancel/retry сценарии.
+
+### B4: Publishing destinations
+
+**Цель:** подключать Telegram/YouTube/TikTok как destination после готового render artifact.
+
+- [ ] Добавить `IPublishService` core port.
+- [ ] Добавить destination-specific publishing adapters.
+- [ ] Связать publish phase с `BotRenderJobStatus = "publishing"`.
+
+## Связанные задачи
+
+- [#150](https://github.com/chatman-media/timeline-studio/issues/150) - Phase F / package boundaries
+- [#171](https://github.com/chatman-media/timeline-studio/issues/171) - Epic: Bot-first workflow
+- [telegram-mini-app.md](./telegram-mini-app.md)
+- [cloud-rendering.md](./cloud-rendering.md)
+- [export-architecture-refactoring.md](./export-architecture-refactoring.md)

--- a/docs/08_tasks/planned/monorepo-packages-migration.md
+++ b/docs/08_tasks/planned/monorepo-packages-migration.md
@@ -57,6 +57,10 @@ adapters -> core
 
 `app-shell` - это композиционный слой (`src/app`, `src/cli`, `src/config`), где допустимо связывать UI, domains и adapters. Все остальные слои должны двигаться к зависимостям через `core`.
 
+## Bot-first priority
+
+С 2026-06-08 следующий верхнеуровневый вектор - [Bot-first workflow](./bot-first-workflow.md). Phase F остается обязательной инженерной базой и quality gate, но новые slices должны в первую очередь приближать headless bot workflow: render job contracts, worker/event stream, intake contract и publishing destinations.
+
 ## Phase F PR slices
 
 ### F1: Package boundaries baseline

--- a/src/adapters/node/__tests__/render-job.test.ts
+++ b/src/adapters/node/__tests__/render-job.test.ts
@@ -1,0 +1,155 @@
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type { IVideoService, RenderJob as VideoRenderJob } from "@/core/ports"
+import { NodeRenderJobService } from "../render-job"
+
+function createVideoService(videoJob: VideoRenderJob): IVideoService {
+  return {
+    renderProject: vi.fn().mockResolvedValue(videoJob.id),
+    getRenderJob: vi.fn().mockResolvedValue(videoJob),
+    getActiveJobs: vi.fn().mockResolvedValue([videoJob]),
+    cancelRender: vi.fn().mockResolvedValue(true),
+  } as unknown as IVideoService
+}
+
+describe("NodeRenderJobService", () => {
+  let tempDir: string
+  let nowTick = 0
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "render-job-service-"))
+    nowTick = 0
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  it("runs an inline render job and returns a machine-readable artifact", async () => {
+    const videoJob: VideoRenderJob = {
+      id: "video-job-1",
+      status: "completed",
+      progress: 100,
+      outputPath: path.join(tempDir, "out.mp4"),
+    }
+    const video = createVideoService(videoJob)
+    const service = new NodeRenderJobService(video, {
+      outputDir: tempDir,
+      idFactory: () => "bot-job-1",
+      now: () => `2026-06-08T00:00:0${nowTick++}.000Z`,
+    })
+
+    const result = await service.run(
+      {
+        source: "bot",
+        project: { type: "inline", schema: { clips: [{ path: "/video.mp4" }] } },
+        output: { format: "mp4", path: path.join(tempDir, "out.mp4"), destination: "file" },
+      },
+      { pollIntervalMs: 1, timeoutMs: 100 },
+    )
+
+    expect(result.job.id).toBe("bot-job-1")
+    expect(result.job.providerJobId).toBe("video-job-1")
+    expect(result.job.status).toBe("done")
+    expect(result.job.progress).toBe(100)
+    expect(result.job.artifact).toEqual({
+      type: "file",
+      path: path.join(tempDir, "out.mp4"),
+      destination: "file",
+      mimeType: "video/mp4",
+    })
+    expect(video.renderProject).toHaveBeenCalledWith({ clips: [{ path: "/video.mp4" }] }, path.join(tempDir, "out.mp4"))
+  })
+
+  it("loads a project schema from a job file reference", async () => {
+    const projectPath = path.join(tempDir, "project.json")
+    await fs.writeFile(projectPath, JSON.stringify({ clips: [{ path: "/clip.mov" }] }))
+
+    const videoJob: VideoRenderJob = {
+      id: "video-job-2",
+      status: "completed",
+      progress: 100,
+    }
+    const video = createVideoService(videoJob)
+    const service = new NodeRenderJobService(video, {
+      outputDir: tempDir,
+      idFactory: () => "bot-job-2",
+    })
+
+    const result = await service.run(
+      {
+        source: "cli",
+        project: { type: "file", path: projectPath },
+        output: { format: "mp4", destination: "telegram" },
+      },
+      { pollIntervalMs: 1, timeoutMs: 100 },
+    )
+
+    expect(result.job.status).toBe("done")
+    expect(result.job.artifact?.path).toBe(path.join(tempDir, "bot-job-2.mp4"))
+    expect(result.job.artifact?.destination).toBe("telegram")
+    expect(video.renderProject).toHaveBeenCalledWith(
+      { clips: [{ path: "/clip.mov" }] },
+      path.join(tempDir, "bot-job-2.mp4"),
+    )
+  })
+
+  it("returns a failed job when the video render fails", async () => {
+    const videoJob: VideoRenderJob = {
+      id: "video-job-3",
+      status: "failed",
+      progress: 20,
+      error: "Encoding error",
+    }
+    const video = createVideoService(videoJob)
+    const service = new NodeRenderJobService(video, {
+      outputDir: tempDir,
+      idFactory: () => "bot-job-3",
+    })
+
+    const result = await service.run(
+      {
+        source: "bot",
+        project: { type: "inline", schema: { clips: [{ path: "/video.mp4" }] } },
+        output: { format: "mp4", path: path.join(tempDir, "failed.mp4") },
+      },
+      { pollIntervalMs: 1, timeoutMs: 100 },
+    )
+
+    expect(result.job.status).toBe("failed")
+    expect(result.job.error).toBe("Encoding error")
+    expect(result.events.at(-1)?.status).toBe("failed")
+  })
+
+  it("can cancel a provider render job", async () => {
+    const videoJob: VideoRenderJob = {
+      id: "video-job-4",
+      status: "running",
+      progress: 50,
+    }
+    const video = createVideoService(videoJob)
+    const service = new NodeRenderJobService(video, {
+      outputDir: tempDir,
+      idFactory: () => "bot-job-4",
+    })
+
+    const runPromise = service.run(
+      {
+        source: "bot",
+        project: { type: "inline", schema: { clips: [{ path: "/video.mp4" }] } },
+        output: { format: "mp4" },
+      },
+      { pollIntervalMs: 10, timeoutMs: 20 },
+    )
+
+    await vi.waitFor(async () => {
+      await expect(service.getJob("bot-job-4")).resolves.toMatchObject({ providerJobId: "video-job-4" })
+    })
+    await expect(service.cancelJob("bot-job-4")).resolves.toBe(true)
+    expect(video.cancelRender).toHaveBeenCalledWith("video-job-4")
+    const result = await runPromise
+    expect(result.job.status).toBe("cancelled")
+  })
+})

--- a/src/adapters/node/index.ts
+++ b/src/adapters/node/index.ts
@@ -14,6 +14,7 @@ import { type NodeLanguageOptions, NodeLanguageService } from "./language"
 import { type NodeMediaOptions, NodeMediaService } from "./media"
 import { NodeBackendBridgeService } from "./node-backend-bridge"
 import { type NodePlatformOptions, NodePlatformService } from "./platform"
+import { NodeRenderJobService, type NodeRenderJobServiceOptions } from "./render-job"
 import { type NodeStorageOptions, NodeStorageService } from "./storage"
 import { type NodeVideoOptions, NodeVideoService } from "./video"
 
@@ -25,6 +26,7 @@ export { type NodeLanguageOptions, NodeLanguageService } from "./language"
 export { type NodeMediaOptions, NodeMediaService } from "./media"
 export { NodeBackendBridgeService } from "./node-backend-bridge"
 export { type NodePlatformOptions, NodePlatformService } from "./platform"
+export { NodeRenderJobService, type NodeRenderJobServiceOptions } from "./render-job"
 export { type NodeStorageOptions, NodeStorageService } from "./storage"
 export { type NodeVideoOptions, NodeVideoService } from "./video"
 
@@ -43,6 +45,8 @@ export interface NodeAppOptions {
   backend?: NodeBackendOptions
   /** Опции для Language сервиса */
   language?: NodeLanguageOptions
+  /** Опции для bot-first RenderJob сервиса */
+  renderJob?: NodeRenderJobServiceOptions
   /** Автоматически подключаться к бэкенду */
   autoConnect?: boolean
 }
@@ -57,6 +61,7 @@ export interface NodeAppServices {
   video: NodeVideoService
   ai: NodeAIService
   language: NodeLanguageService
+  renderJob: NodeRenderJobService
 }
 
 /**
@@ -92,6 +97,7 @@ export async function initNodeApp(options: NodeAppOptions = {}): Promise<NodeApp
   const video = new NodeVideoService(options.video)
   const ai = new NodeAIService(options.ai)
   const language = new NodeLanguageService(options.language)
+  const renderJob = new NodeRenderJobService(video, options.renderJob)
 
   // Register in container
   container.registerBackend(backend)
@@ -119,6 +125,7 @@ export async function initNodeApp(options: NodeAppOptions = {}): Promise<NodeApp
     video,
     ai,
     language,
+    renderJob,
   }
 }
 
@@ -130,6 +137,8 @@ export async function initNodeApp(options: NodeAppOptions = {}): Promise<NodeApp
  * @returns Объект со всеми сервисами
  */
 export function createNodeServices(options: NodeAppOptions = {}): NodeAppServices {
+  const video = new NodeVideoService(options.video)
+
   return {
     backend: new NodeBackendService(options.backend),
     platform: new NodePlatformService(options.platform),
@@ -137,8 +146,9 @@ export function createNodeServices(options: NodeAppOptions = {}): NodeAppService
     event: new NodeEventService(),
     media: new NodeMediaService(options.media),
     nodeBackend: new NodeBackendBridgeService(),
-    video: new NodeVideoService(options.video),
+    video,
     ai: new NodeAIService(options.ai),
     language: new NodeLanguageService(options.language),
+    renderJob: new NodeRenderJobService(video, options.renderJob),
   }
 }

--- a/src/adapters/node/render-job.ts
+++ b/src/adapters/node/render-job.ts
@@ -1,0 +1,247 @@
+import crypto from "node:crypto"
+import fs from "node:fs/promises"
+import path from "node:path"
+
+import type { IRenderJobService, IVideoService, RenderJob as VideoRenderJob } from "@/core/ports"
+import type {
+  BotRenderJob,
+  BotRenderJobEvent,
+  BotRenderJobRequest,
+  BotRenderJobResult,
+  BotRenderJobRunOptions,
+  BotRenderJobStatus,
+} from "@/core/types"
+
+export interface NodeRenderJobServiceOptions {
+  outputDir?: string
+  idFactory?: () => string
+  now?: () => string
+}
+
+const DEFAULT_POLL_INTERVAL_MS = 1000
+const DEFAULT_TIMEOUT_MS = 60 * 60 * 1000
+
+function normalizeVideoStatus(status?: string): BotRenderJobStatus {
+  switch (status) {
+    case "pending":
+      return "queued"
+    case "running":
+      return "rendering"
+    case "completed":
+      return "done"
+    case "failed":
+      return "failed"
+    case "cancelled":
+      return "cancelled"
+    default:
+      return "rendering"
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function isCancelled(job: BotRenderJob): boolean {
+  return job.status === "cancelled"
+}
+
+export class NodeRenderJobService implements IRenderJobService {
+  private jobs = new Map<string, BotRenderJob>()
+  private outputDir: string
+  private idFactory: () => string
+  private now: () => string
+
+  constructor(
+    private readonly video: IVideoService,
+    options: NodeRenderJobServiceOptions = {},
+  ) {
+    this.outputDir = options.outputDir ?? process.cwd()
+    this.idFactory = options.idFactory ?? (() => crypto.randomUUID())
+    this.now = options.now ?? (() => new Date().toISOString())
+  }
+
+  async run(request: BotRenderJobRequest, options: BotRenderJobRunOptions = {}): Promise<BotRenderJobResult> {
+    const job = this.createJob(request)
+
+    try {
+      await this.emit(job, "preparing", 5, "Preparing render job", options)
+      const projectSchema = await this.resolveProjectSchema(request)
+      const outputPath = this.resolveOutputPath(request, job.id)
+
+      if (isCancelled(job)) {
+        return { job, events: [...job.events] }
+      }
+
+      await this.emit(job, "rendering", 10, "Starting video render", options)
+      const providerJobId = await this.video.renderProject(projectSchema, outputPath)
+      job.providerJobId = providerJobId
+
+      if (isCancelled(job)) {
+        await this.video.cancelRender(providerJobId)
+        return { job, events: [...job.events] }
+      }
+
+      await this.waitForVideoJob(job, providerJobId, options)
+
+      if (job.status === "done") {
+        job.artifact = {
+          type: "file",
+          path: outputPath,
+          destination: request.output.destination ?? "file",
+          mimeType: "video/mp4",
+        }
+      }
+    } catch (error) {
+      job.error = errorMessage(error)
+      await this.emit(job, "failed", job.progress, job.error, options)
+    }
+
+    return {
+      job,
+      events: [...job.events],
+    }
+  }
+
+  async getJob(jobId: string): Promise<BotRenderJob | null> {
+    return this.jobs.get(jobId) ?? null
+  }
+
+  async cancelJob(jobId: string): Promise<boolean> {
+    const job = this.jobs.get(jobId)
+    if (!job) return false
+
+    const cancelled = job.providerJobId ? await this.video.cancelRender(job.providerJobId) : true
+    if (cancelled) {
+      const timestamp = this.now()
+      job.status = "cancelled"
+      job.updatedAt = timestamp
+      job.progress = Math.min(job.progress, 99)
+      job.events.push({
+        jobId: job.id,
+        status: "cancelled",
+        progress: job.progress,
+        message: "Render job cancelled",
+        timestamp,
+      })
+    }
+    return cancelled
+  }
+
+  private createJob(request: BotRenderJobRequest): BotRenderJob {
+    const now = this.now()
+    const job: BotRenderJob = {
+      id: this.idFactory(),
+      status: "queued",
+      progress: 0,
+      request,
+      createdAt: now,
+      updatedAt: now,
+      events: [],
+    }
+
+    this.jobs.set(job.id, job)
+    job.events.push({
+      jobId: job.id,
+      status: "queued",
+      progress: 0,
+      message: "Render job queued",
+      timestamp: now,
+    })
+
+    return job
+  }
+
+  private async resolveProjectSchema(request: BotRenderJobRequest): Promise<unknown> {
+    if (request.project?.type === "inline") {
+      return request.project.schema
+    }
+
+    if (request.project?.type === "file") {
+      const projectContent = await fs.readFile(path.resolve(request.project.path), "utf-8")
+      return JSON.parse(projectContent)
+    }
+
+    throw new Error("Render job requires project.type=file or project.type=inline")
+  }
+
+  private resolveOutputPath(request: BotRenderJobRequest, jobId: string): string {
+    if (request.output.destination && request.output.destination !== "file" && !request.output.path) {
+      return path.resolve(this.outputDir, `${jobId}.${request.output.format}`)
+    }
+
+    return path.resolve(request.output.path ?? path.join(this.outputDir, `${jobId}.${request.output.format}`))
+  }
+
+  private async waitForVideoJob(
+    job: BotRenderJob,
+    providerJobId: string,
+    options: BotRenderJobRunOptions,
+  ): Promise<void> {
+    const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS
+    const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+    const startedAt = Date.now()
+
+    while (Date.now() - startedAt <= timeoutMs) {
+      if (isCancelled(job)) return
+
+      const videoJob = await this.readVideoJob(providerJobId)
+
+      if (!videoJob) {
+        await this.emit(job, "done", 100, "Render job completed", options)
+        return
+      }
+
+      const status = normalizeVideoStatus(videoJob.status)
+      const progress = typeof videoJob.progress === "number" ? videoJob.progress : job.progress
+      await this.emit(job, status, status === "done" ? 100 : progress, `Render status: ${status}`, options)
+
+      if (status === "done") return
+      if (status === "cancelled") return
+      if (status === "failed") {
+        throw new Error(videoJob.error ?? "Render job failed")
+      }
+
+      await delay(pollIntervalMs)
+    }
+
+    throw new Error(`Render job timed out after ${timeoutMs}ms`)
+  }
+
+  private async readVideoJob(providerJobId: string): Promise<VideoRenderJob | null> {
+    try {
+      return await this.video.getRenderJob(providerJobId)
+    } catch {
+      const activeJobs = await this.video.getActiveJobs()
+      return activeJobs.find((job) => job.id === providerJobId) ?? null
+    }
+  }
+
+  private async emit(
+    job: BotRenderJob,
+    status: BotRenderJobStatus,
+    progress: number,
+    message: string,
+    options: BotRenderJobRunOptions,
+  ): Promise<void> {
+    const timestamp = this.now()
+    job.status = status
+    job.progress = Math.max(0, Math.min(100, progress))
+    job.updatedAt = timestamp
+
+    const event: BotRenderJobEvent = {
+      jobId: job.id,
+      status,
+      progress: job.progress,
+      message,
+      timestamp,
+    }
+    job.events.push(event)
+
+    await options.onEvent?.(event, job)
+  }
+}

--- a/src/cli/commands/__tests__/render-job.test.ts
+++ b/src/cli/commands/__tests__/render-job.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for bot-first render-job command.
+ */
+
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { readRenderJobRequest, renderJobCommand, serializeRenderJobResult } from "../render-job"
+
+describe("render-job command", () => {
+  let tempDir: string
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "render-job-command-"))
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  it("should have correct command shape", () => {
+    expect(renderJobCommand.name()).toBe("render-job")
+    expect(renderJobCommand.description()).toBe("Run a bot-first render job from JSON")
+    expect(renderJobCommand.registeredArguments[0].name()).toBe("job")
+    expect(renderJobCommand.options.some((option) => option.long === "--status-file")).toBe(true)
+    expect(renderJobCommand.options.some((option) => option.long === "--pretty")).toBe(true)
+  })
+
+  it("reads render job JSON and defaults source to cli", async () => {
+    const jobPath = path.join(tempDir, "job.json")
+    await fs.writeFile(
+      jobPath,
+      JSON.stringify({
+        project: { type: "inline", schema: { clips: [] } },
+        output: { format: "mp4" },
+      }),
+    )
+
+    const request = await readRenderJobRequest(jobPath)
+
+    expect(request.source).toBe("cli")
+    expect(request.output.format).toBe("mp4")
+  })
+
+  it("rejects render job JSON without output format", async () => {
+    const jobPath = path.join(tempDir, "job.json")
+    await fs.writeFile(jobPath, JSON.stringify({ source: "bot" }))
+
+    await expect(readRenderJobRequest(jobPath)).rejects.toThrow("Render job JSON must include output.format")
+  })
+
+  it("serializes compact and pretty JSON results", () => {
+    const result = {
+      job: {
+        id: "job-1",
+        status: "done" as const,
+        progress: 100,
+        request: { source: "bot" as const, output: { format: "mp4" as const } },
+        createdAt: "2026-06-08T00:00:00.000Z",
+        updatedAt: "2026-06-08T00:00:01.000Z",
+        events: [],
+      },
+      events: [],
+    }
+
+    expect(serializeRenderJobResult(result)).not.toContain("\n")
+    expect(serializeRenderJobResult(result, true)).toContain("\n")
+  })
+})

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -4,4 +4,5 @@
 
 export { infoCommand } from "./info"
 export { renderCommand } from "./render"
+export { renderJobCommand } from "./render-job"
 export { transcribeCommand } from "./transcribe"

--- a/src/cli/commands/render-job.ts
+++ b/src/cli/commands/render-job.ts
@@ -1,0 +1,104 @@
+/**
+ * Bot-first render job command.
+ *
+ * Reads a machine-readable job JSON file, runs it through the headless Node
+ * render job service, and writes a machine-readable result for bot/worker use.
+ */
+
+import fs from "node:fs/promises"
+import path from "node:path"
+import { Command } from "commander"
+
+import { initNodeApp } from "@/adapters/node"
+import type { BotRenderJobRequest, BotRenderJobResult } from "@/core/types"
+
+export interface RenderJobCommandOptions {
+  statusFile?: string
+  pretty?: boolean
+  pollInterval?: string
+  timeout?: string
+}
+
+export const renderJobCommand = new Command("render-job")
+  .description("Run a bot-first render job from JSON")
+  .argument("<job>", "Path to render job JSON")
+  .option("--status-file <path>", "Write final job result JSON to a file")
+  .option("--pretty", "Pretty-print JSON output")
+  .option("--poll-interval <ms>", "Render polling interval in milliseconds", "1000")
+  .option("--timeout <ms>", "Render timeout in milliseconds", "3600000")
+  .action(async (jobFile: string, options: RenderJobCommandOptions) => {
+    try {
+      const result = await runRenderJobFile(jobFile, options)
+      const serialized = serializeRenderJobResult(result, options.pretty)
+
+      if (options.statusFile) {
+        await fs.writeFile(path.resolve(options.statusFile), `${serialized}\n`)
+      }
+
+      process.stdout.write(`${serialized}\n`)
+      if (result.job.status === "failed" || result.job.status === "cancelled") {
+        process.exit(1)
+      }
+    } catch (error) {
+      const failed = serializeRenderJobResult(
+        {
+          job: {
+            id: "unavailable",
+            status: "failed",
+            progress: 0,
+            request: {
+              source: "cli",
+              output: { format: "mp4", destination: "file" },
+            },
+            error: error instanceof Error ? error.message : String(error),
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            events: [],
+          },
+          events: [],
+        },
+        options.pretty,
+      )
+      process.stderr.write(`${failed}\n`)
+      process.exit(1)
+    }
+  })
+
+export async function runRenderJobFile(
+  jobFile: string,
+  options: RenderJobCommandOptions = {},
+): Promise<BotRenderJobResult> {
+  const request = await readRenderJobRequest(jobFile)
+  const services = await initNodeApp({ autoConnect: false })
+
+  return services.renderJob.run(request, {
+    pollIntervalMs: parsePositiveInteger(options.pollInterval, 1000),
+    timeoutMs: parsePositiveInteger(options.timeout, 3600000),
+  })
+}
+
+export async function readRenderJobRequest(jobFile: string): Promise<BotRenderJobRequest> {
+  const jobPath = path.resolve(jobFile)
+  const content = await fs.readFile(jobPath, "utf-8")
+  const parsed = JSON.parse(content) as BotRenderJobRequest
+
+  if (!parsed.output?.format) {
+    throw new Error("Render job JSON must include output.format")
+  }
+
+  if (!parsed.source) {
+    parsed.source = "cli"
+  }
+
+  return parsed
+}
+
+export function serializeRenderJobResult(result: BotRenderJobResult, pretty = false): string {
+  return JSON.stringify(result, null, pretty ? 2 : 0)
+}
+
+function parsePositiveInteger(value: string | undefined, fallback: number): number {
+  if (!value) return fallback
+  const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -22,6 +22,7 @@ import { Command } from "commander"
 
 import { infoCommand } from "./commands/info"
 import { renderCommand } from "./commands/render"
+import { renderJobCommand } from "./commands/render-job"
 import { transcribeCommand } from "./commands/transcribe"
 
 const program = new Command()
@@ -32,6 +33,7 @@ program.name("timeline-studio").description("Timeline Studio CLI - инстру�
 program.addCommand(infoCommand)
 program.addCommand(transcribeCommand)
 program.addCommand(renderCommand)
+program.addCommand(renderJobCommand)
 
 // Запуск
 program.parse(process.argv)

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -24,6 +24,7 @@ export type {
   ILanguageService,
   INodeBackendService,
   IPlatformService,
+  IRenderJobService,
   IStorageService,
   NodeBackendHealth,
   NotificationOptions,
@@ -36,6 +37,17 @@ export { getAppLanguage, setAppLanguage } from "./services"
 
 // Types (re-exported from generated bindings for now)
 export type {
+  BotRenderJob,
+  BotRenderJobArtifact,
+  BotRenderJobDestination,
+  BotRenderJobEvent,
+  BotRenderJobMediaInput,
+  BotRenderJobProjectInput,
+  BotRenderJobRequest,
+  BotRenderJobResult,
+  BotRenderJobRunOptions,
+  BotRenderJobSource,
+  BotRenderJobStatus,
   BrowserState,
   BrowserTab,
   Clip,

--- a/src/core/ports/index.ts
+++ b/src/core/ports/index.ts
@@ -70,6 +70,7 @@ export type {
   OpenDialogOptions,
   SaveDialogOptions,
 } from "./platform.port"
+export type { IRenderJobService } from "./render-job.port"
 export type { IStorageService } from "./storage.port"
 export type {
   CacheConfig,

--- a/src/core/ports/render-job.port.ts
+++ b/src/core/ports/render-job.port.ts
@@ -1,0 +1,7 @@
+import type { BotRenderJob, BotRenderJobRequest, BotRenderJobResult, BotRenderJobRunOptions } from "../types"
+
+export interface IRenderJobService {
+  run(request: BotRenderJobRequest, options?: BotRenderJobRunOptions): Promise<BotRenderJobResult>
+  getJob(jobId: string): Promise<BotRenderJob | null>
+  cancelJob(jobId: string): Promise<boolean>
+}

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -31,4 +31,5 @@ export type {
 
 // Re-export core-facing compatibility types for features
 export * from "./media"
+export * from "./render-job"
 export * from "./video-editing"

--- a/src/core/types/render-job.ts
+++ b/src/core/types/render-job.ts
@@ -1,0 +1,87 @@
+/**
+ * Bot-first render job contracts.
+ *
+ * These types describe a headless workflow that can be called by a bot, CLI,
+ * desktop UI, or future API worker without depending on React/Tauri UI state.
+ */
+
+export type BotRenderJobSource = "bot" | "desktop" | "cli"
+
+export type BotRenderJobStatus = "queued" | "preparing" | "rendering" | "publishing" | "done" | "failed" | "cancelled"
+
+export type BotRenderJobDestination = "file" | "telegram" | "youtube" | "tiktok" | "vimeo"
+
+export interface BotRenderJobMediaInput {
+  type: "file" | "url"
+  value: string
+  name?: string
+  mimeType?: string
+  metadata?: Record<string, unknown>
+}
+
+export type BotRenderJobProjectInput =
+  | {
+      type: "file"
+      path: string
+    }
+  | {
+      type: "inline"
+      schema: unknown
+    }
+
+export interface BotRenderJobOutput {
+  format: "mp4"
+  path?: string
+  resolution?: "720p" | "1080p" | "4k"
+  destination?: BotRenderJobDestination
+}
+
+export interface BotRenderJobRequest {
+  source: BotRenderJobSource
+  templateId?: string
+  projectId?: string
+  project?: BotRenderJobProjectInput
+  media?: BotRenderJobMediaInput[]
+  params?: Record<string, unknown>
+  output: BotRenderJobOutput
+}
+
+export interface BotRenderJobArtifact {
+  type: "file" | "url"
+  path?: string
+  url?: string
+  destination: BotRenderJobDestination
+  mimeType?: string
+}
+
+export interface BotRenderJobEvent {
+  jobId: string
+  status: BotRenderJobStatus
+  progress: number
+  message?: string
+  timestamp: string
+}
+
+export interface BotRenderJob {
+  id: string
+  providerJobId?: string
+  status: BotRenderJobStatus
+  progress: number
+  request: BotRenderJobRequest
+  artifact?: BotRenderJobArtifact
+  error?: string
+  createdAt: string
+  updatedAt: string
+  events: BotRenderJobEvent[]
+}
+
+export interface BotRenderJobRunOptions {
+  pollIntervalMs?: number
+  timeoutMs?: number
+  onEvent?: (event: BotRenderJobEvent, job: BotRenderJob) => void | Promise<void>
+}
+
+export interface BotRenderJobResult {
+  job: BotRenderJob
+  events: BotRenderJobEvent[]
+}


### PR DESCRIPTION
## Summary

- add bot-first render job core contracts and `IRenderJobService` port
- add `NodeRenderJobService` plus machine-readable `render-job <job.json>` CLI entrypoint
- document the bot-first workflow roadmap and track it in #171
- add unit coverage for the Node service and CLI contract

## Verification

- `bun run check:type`
- `bun run check:workspaces`
- `bun run check:boundaries`
- `bun run check:boundaries:baseline`
- `bun run test -- src/adapters/node/__tests__/render-job.test.ts src/cli/commands/__tests__/render-job.test.ts src/cli/commands/__tests__/render.test.ts src/core/__tests__/container.test.ts`
- `bunx biome ci` on changed files
- `git diff --check`

Refs #171