### PR TITLE
feat: add bot-first intake contract

### DIFF
--- a/docs/08_tasks/planned/bot-first-workflow.md
+++ b/docs/08_tasks/planned/bot-first-workflow.md
@@ -42,13 +42,13 @@ bot message
 - [x] Добавить CLI-команду `render-job <job.json>` с JSON output/status file.
 - [x] Покрыть Node service и CLI contract unit tests.
 
-### B2: Bot intake contract
+### B2: Bot intake contract ([#173](https://github.com/chatman-media/timeline-studio/issues/173))
 
 **Цель:** описать вход бота до создания render job.
 
-- [ ] Добавить типы `BotWorkflowRequest`, `BotMediaAttachment`, `BotTemplateSelection`.
-- [ ] Добавить parser/normalizer для входа из Telegram-like payload в `BotRenderJobRequest`.
-- [ ] Добавить validation errors, пригодные для ответа пользователю в чате.
+- [x] Добавить типы `BotWorkflowRequest`, `BotMediaAttachment`, `BotTemplateSelection`.
+- [x] Добавить parser/normalizer для входа из Telegram-like payload в `BotRenderJobRequest`.
+- [x] Добавить validation errors, пригодные для ответа пользователю в чате.
 
 ### B3: Worker event stream
 
@@ -70,6 +70,7 @@ bot message
 
 - [#150](https://github.com/chatman-media/timeline-studio/issues/150) - Phase F / package boundaries
 - [#171](https://github.com/chatman-media/timeline-studio/issues/171) - Epic: Bot-first workflow
+- [#173](https://github.com/chatman-media/timeline-studio/issues/173) - B2: Bot intake contract
 - [telegram-mini-app.md](./telegram-mini-app.md)
 - [cloud-rendering.md](./cloud-rendering.md)
 - [export-architecture-refactoring.md](./export-architecture-refactoring.md)

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -32,11 +32,19 @@ export type {
   SaveDialogOptions,
   Unsubscribe,
 } from "./ports"
-export type { LanguageResponse } from "./services"
-export { getAppLanguage, setAppLanguage } from "./services"
+export type { LanguageResponse, ParsedBotWorkflowText } from "./services"
+export {
+  createBotRenderJobRequest,
+  createBotWorkflowRequestFromTelegramLikePayload,
+  getAppLanguage,
+  parseBotWorkflowText,
+  setAppLanguage,
+} from "./services"
 
 // Types (re-exported from generated bindings for now)
 export type {
+  BotMediaAttachment,
+  BotMediaAttachmentType,
   BotRenderJob,
   BotRenderJobArtifact,
   BotRenderJobDestination,
@@ -48,6 +56,14 @@ export type {
   BotRenderJobRunOptions,
   BotRenderJobSource,
   BotRenderJobStatus,
+  BotTemplateSelection,
+  BotWorkflowIntakeOptions,
+  BotWorkflowIntakeResult,
+  BotWorkflowOutput,
+  BotWorkflowRequest,
+  BotWorkflowSource,
+  BotWorkflowValidationCode,
+  BotWorkflowValidationError,
   BrowserState,
   BrowserTab,
   Clip,
@@ -61,6 +77,8 @@ export type {
   ProjectSettings,
   ProjectState,
   TabSettings,
+  TelegramLikeBotFile,
+  TelegramLikeBotPayload,
   Timeline,
   Track,
   ViewMode,

--- a/src/core/services/__tests__/bot-workflow-intake.test.ts
+++ b/src/core/services/__tests__/bot-workflow-intake.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest"
+import {
+  createBotRenderJobRequest,
+  createBotWorkflowRequestFromTelegramLikePayload,
+  parseBotWorkflowText,
+} from "../bot-workflow-intake"
+
+describe("bot workflow intake", () => {
+  it("parses render hints from bot text", () => {
+    const parsed = parseBotWorkflowText(
+      '/render template=shorts project="./project.json" destination=telegram resolution=1080p tone=fast https://cdn.example.com/input.mov',
+    )
+
+    expect(parsed).toEqual({
+      templateId: "shorts",
+      projectPath: "./project.json",
+      output: {
+        destination: "telegram",
+        resolution: "1080p",
+      },
+      params: {
+        tone: "fast",
+      },
+    })
+  })
+
+  it("normalizes a telegram-like payload into a bot workflow request", () => {
+    const workflow = createBotWorkflowRequestFromTelegramLikePayload({
+      chat: { id: 42 },
+      from: { id: "user-1" },
+      message_id: 7,
+      caption: "template=promo destination=telegram",
+      video: {
+        file_id: "telegram-file-1",
+        file_unique_id: "unique-video-1",
+        file_name: "clip.mp4",
+        mime_type: "video/mp4",
+      },
+    })
+
+    expect(workflow).toMatchObject({
+      source: "telegram",
+      chatId: "42",
+      userId: "user-1",
+      messageId: "7",
+      text: "template=promo destination=telegram",
+      media: [
+        {
+          id: "unique-video-1",
+          type: "file",
+          value: "telegram-file-1",
+          name: "clip.mp4",
+          mimeType: "video/mp4",
+          metadata: {
+            telegramFileId: "telegram-file-1",
+            telegramFileUniqueId: "unique-video-1",
+          },
+        },
+      ],
+    })
+  })
+
+  it("creates a render job request from template, media, params, and output hints", () => {
+    const workflow = createBotWorkflowRequestFromTelegramLikePayload({
+      caption: "template=promo destination=telegram audience=founders",
+      document: {
+        url: "https://cdn.example.com/input.mov",
+        file_name: "input.mov",
+        mime_type: "video/quicktime",
+      },
+    })
+
+    const result = createBotRenderJobRequest(workflow)
+
+    expect(result).toEqual({
+      ok: true,
+      warnings: [],
+      renderJob: {
+        source: "bot",
+        templateId: "promo",
+        media: [
+          {
+            type: "url",
+            value: "https://cdn.example.com/input.mov",
+            name: "input.mov",
+            mimeType: "video/quicktime",
+          },
+        ],
+        params: {
+          audience: "founders",
+        },
+        output: {
+          format: "mp4",
+          destination: "telegram",
+        },
+      },
+    })
+  })
+
+  it("prefers structured workflow fields over text hints", () => {
+    const result = createBotRenderJobRequest({
+      source: "telegram",
+      text: "template=text-template destination=file tone=calm",
+      template: {
+        id: "structured-template",
+        params: {
+          tone: "bold",
+          ratio: "9:16",
+        },
+      },
+      params: {
+        tone: "urgent",
+      },
+      output: {
+        destination: "youtube",
+        resolution: "4k",
+      },
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      renderJob: {
+        source: "bot",
+        templateId: "structured-template",
+        params: {
+          tone: "urgent",
+          ratio: "9:16",
+        },
+        output: {
+          format: "mp4",
+          destination: "youtube",
+          resolution: "4k",
+        },
+      },
+    })
+  })
+
+  it("returns chat-ready validation errors", () => {
+    const result = createBotRenderJobRequest({
+      source: "telegram",
+      media: [{ type: "file", value: "" }],
+      output: { format: "mp4" },
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      errors: [
+        {
+          code: "invalid_media",
+          field: "media.0.value",
+          message: "Media attachment value cannot be empty",
+          userMessage: "One of the attached files is empty or unavailable. Send it again.",
+        },
+        {
+          code: "missing_input",
+          field: "workflow",
+          message: "Workflow requires a template, project, or media attachment",
+          userMessage: "Send a video file, link, project, or choose a template.",
+        },
+      ],
+    })
+  })
+
+  it("validates unsupported output values from text hints", () => {
+    const result = createBotRenderJobRequest({
+      source: "telegram",
+      text: "template=promo destination=instagram resolution=8k format=mov",
+    })
+
+    expect(result).toMatchObject({
+      ok: false,
+      errors: [
+        { code: "invalid_output", field: "output.format" },
+        { code: "unsupported_destination", field: "output.destination" },
+        { code: "unsupported_resolution", field: "output.resolution" },
+      ],
+    })
+  })
+})

--- a/src/core/services/bot-workflow-intake.ts
+++ b/src/core/services/bot-workflow-intake.ts
@@ -1,0 +1,335 @@
+import type {
+  BotMediaAttachment,
+  BotWorkflowIntakeOptions,
+  BotWorkflowIntakeResult,
+  BotWorkflowOutput,
+  BotWorkflowRequest,
+  BotWorkflowValidationError,
+  TelegramLikeBotFile,
+  TelegramLikeBotPayload,
+} from "../types"
+import type { BotRenderJobDestination, BotRenderJobMediaInput, BotRenderJobRequest } from "../types/render-job"
+
+const DESTINATIONS = new Set(["file", "telegram", "youtube", "tiktok", "vimeo"])
+const RESOLUTIONS = new Set(["720p", "1080p", "4k"])
+
+export interface ParsedBotWorkflowText {
+  templateId?: string
+  projectPath?: string
+  output: BotWorkflowOutput
+  params: Record<string, string>
+}
+
+export function createBotRenderJobRequest(
+  workflow: BotWorkflowRequest,
+  options: BotWorkflowIntakeOptions = {},
+): BotWorkflowIntakeResult {
+  const textHints = parseBotWorkflowText(workflow.text)
+  const errors: BotWorkflowValidationError[] = []
+  const warnings: BotWorkflowValidationError[] = []
+  const templateId = firstNonEmpty(workflow.template?.id, textHints.templateId, options.defaultTemplateId)
+  const project = workflow.project ?? workflow.template?.project ?? projectFromText(textHints.projectPath)
+  const media = normalizeMedia(workflow.media ?? [], errors)
+  const params = mergeParams(textHints.params, workflow.template?.params, workflow.params)
+  const output = normalizeOutput(workflow, textHints.output, options, errors)
+
+  if (workflow.template && !workflow.template.id.trim()) {
+    errors.push(
+      validationError(
+        "invalid_template",
+        "template.id",
+        "Template id cannot be empty",
+        "Choose a template before starting the render.",
+      ),
+    )
+  }
+
+  if (!templateId && !project && media.length === 0) {
+    errors.push(
+      validationError(
+        "missing_input",
+        "workflow",
+        "Workflow requires a template, project, or media attachment",
+        "Send a video file, link, project, or choose a template.",
+      ),
+    )
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors }
+  }
+
+  const renderJob: BotRenderJobRequest = {
+    source: "bot",
+    ...(templateId ? { templateId } : {}),
+    ...(project ? { project } : {}),
+    ...(media.length > 0 ? { media } : {}),
+    ...(Object.keys(params).length > 0 ? { params } : {}),
+    output,
+  }
+
+  return { ok: true, renderJob, warnings }
+}
+
+export function createBotWorkflowRequestFromTelegramLikePayload(payload: TelegramLikeBotPayload): BotWorkflowRequest {
+  const media: BotMediaAttachment[] = [...(payload.attachments ?? [])]
+  const appendFile = (file: TelegramLikeBotFile | undefined, fallbackName: string) => {
+    const attachment = telegramFileToAttachment(file, fallbackName)
+    if (attachment) media.push(attachment)
+  }
+
+  appendFile(payload.document, "document")
+  appendFile(payload.video, "video")
+  appendFile(payload.audio, "audio")
+  appendFile(payload.animation, "animation")
+
+  if (Array.isArray(payload.photo)) {
+    appendFile(payload.photo.at(-1), "photo")
+  } else {
+    appendFile(payload.photo, "photo")
+  }
+
+  for (const file of payload.media ?? []) {
+    appendFile(file, "media")
+  }
+
+  return {
+    source: "telegram",
+    chatId: stringifyId(payload.chat?.id),
+    userId: stringifyId(payload.from?.id),
+    messageId: stringifyId(payload.message_id),
+    text: payload.text ?? payload.caption,
+    media,
+    raw: payload,
+  }
+}
+
+export function parseBotWorkflowText(text = ""): ParsedBotWorkflowText {
+  const parsed: ParsedBotWorkflowText = {
+    output: {},
+    params: {},
+  }
+
+  for (const token of tokenizeText(text)) {
+    if (token.startsWith("/")) continue
+
+    const separatorIndex = findKeyValueSeparator(token)
+    if (separatorIndex <= 0) continue
+
+    const key = normalizeKey(token.slice(0, separatorIndex))
+    const value = trimCommandValue(token.slice(separatorIndex + 1))
+    if (!value) continue
+
+    switch (key) {
+      case "template":
+      case "templateid":
+        parsed.templateId = value
+        break
+      case "project":
+      case "projectpath":
+        parsed.projectPath = value
+        break
+      case "destination":
+      case "dest":
+        parsed.output.destination = value as BotRenderJobDestination
+        break
+      case "format":
+        parsed.output.format = value as BotWorkflowOutput["format"]
+        break
+      case "output":
+      case "outputpath":
+        parsed.output.path = value
+        break
+      case "resolution":
+        parsed.output.resolution = value as BotWorkflowOutput["resolution"]
+        break
+      default:
+        parsed.params[key] = value
+    }
+  }
+
+  return parsed
+}
+
+function normalizeMedia(
+  attachments: BotMediaAttachment[],
+  errors: BotWorkflowValidationError[],
+): BotRenderJobMediaInput[] {
+  return attachments
+    .map((attachment, index) => {
+      const value = attachment.value.trim()
+      if (!value) {
+        errors.push(
+          validationError(
+            "invalid_media",
+            `media.${index}.value`,
+            "Media attachment value cannot be empty",
+            "One of the attached files is empty or unavailable. Send it again.",
+          ),
+        )
+      }
+
+      if (attachment.type !== "file" && attachment.type !== "url") {
+        errors.push(
+          validationError(
+            "invalid_media",
+            `media.${index}.type`,
+            `Unsupported media attachment type: ${attachment.type}`,
+            "One of the attached files has an unsupported type.",
+          ),
+        )
+      }
+
+      return {
+        type: attachment.type,
+        value,
+        ...(attachment.name ? { name: attachment.name } : {}),
+        ...(attachment.mimeType ? { mimeType: attachment.mimeType } : {}),
+        ...(attachment.metadata ? { metadata: attachment.metadata } : {}),
+      }
+    })
+    .filter((attachment) => attachment.value.length > 0)
+}
+
+function normalizeOutput(
+  workflow: BotWorkflowRequest,
+  textOutput: BotWorkflowOutput,
+  options: BotWorkflowIntakeOptions,
+  errors: BotWorkflowValidationError[],
+): BotRenderJobRequest["output"] {
+  const output: BotWorkflowOutput = {
+    format: workflow.output?.format ?? textOutput.format ?? "mp4",
+    path: workflow.output?.path ?? textOutput.path ?? options.defaultOutputPath,
+    resolution: workflow.output?.resolution ?? textOutput.resolution ?? options.defaultResolution,
+    destination:
+      workflow.output?.destination ??
+      textOutput.destination ??
+      options.defaultDestination ??
+      defaultDestination(workflow),
+  }
+
+  if (output.format !== "mp4") {
+    errors.push(
+      validationError(
+        "invalid_output",
+        "output.format",
+        `Unsupported render output format: ${String(output.format)}`,
+        "Only MP4 export is available right now.",
+      ),
+    )
+  }
+
+  if (output.destination && !DESTINATIONS.has(output.destination)) {
+    errors.push(
+      validationError(
+        "unsupported_destination",
+        "output.destination",
+        `Unsupported render destination: ${String(output.destination)}`,
+        "This publishing destination is not available yet.",
+      ),
+    )
+  }
+
+  if (output.resolution && !RESOLUTIONS.has(output.resolution)) {
+    errors.push(
+      validationError(
+        "unsupported_resolution",
+        "output.resolution",
+        `Unsupported render resolution: ${String(output.resolution)}`,
+        "Choose 720p, 1080p, or 4k.",
+      ),
+    )
+  }
+
+  return {
+    format: "mp4",
+    ...(output.path ? { path: output.path } : {}),
+    ...(output.resolution ? { resolution: output.resolution } : {}),
+    ...(output.destination ? { destination: output.destination } : {}),
+  }
+}
+
+function telegramFileToAttachment(
+  file: TelegramLikeBotFile | undefined,
+  fallbackName: string,
+): BotMediaAttachment | null {
+  if (!file) return null
+
+  const value = firstNonEmpty(file.url, file.file_path, file.file_id) ?? ""
+  const metadata: Record<string, unknown> = {}
+
+  if (file.file_id) metadata.telegramFileId = file.file_id
+  if (file.file_unique_id) metadata.telegramFileUniqueId = file.file_unique_id
+
+  return {
+    id: file.file_unique_id ?? file.file_id,
+    type: isUrl(value) ? "url" : "file",
+    value,
+    name: file.file_name ?? fallbackName,
+    mimeType: file.mime_type,
+    caption: file.caption,
+    ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+  }
+}
+
+function projectFromText(projectPath?: string): BotRenderJobRequest["project"] {
+  return projectPath ? { type: "file", path: projectPath } : undefined
+}
+
+function mergeParams(...records: Array<Record<string, unknown> | undefined>): Record<string, unknown> {
+  return Object.assign({}, ...records.filter(Boolean))
+}
+
+function validationError(
+  code: BotWorkflowValidationError["code"],
+  field: string,
+  message: string,
+  userMessage: string,
+): BotWorkflowValidationError {
+  return { code, field, message, userMessage }
+}
+
+function defaultDestination(workflow: BotWorkflowRequest): BotRenderJobDestination {
+  return workflow.source === "telegram" ? "telegram" : "file"
+}
+
+function stringifyId(value: string | number | undefined): string | undefined {
+  return value === undefined ? undefined : String(value)
+}
+
+function firstNonEmpty(...values: Array<string | undefined>): string | undefined {
+  return values.find((value) => value !== undefined && value.trim().length > 0)?.trim()
+}
+
+function tokenizeText(text: string): string[] {
+  return text.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) ?? []
+}
+
+function findKeyValueSeparator(token: string): number {
+  if (isUrl(token)) return -1
+
+  const equalsIndex = token.indexOf("=")
+  const colonIndex = token.indexOf(":")
+  if (equalsIndex === -1) return colonIndex
+  if (colonIndex === -1) return equalsIndex
+  return Math.min(equalsIndex, colonIndex)
+}
+
+function normalizeKey(key: string): string {
+  return key.trim().toLowerCase().replace(/[_-]/g, "")
+}
+
+function trimCommandValue(value: string): string {
+  const trimmed = value.trim()
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"') && trimmed.length >= 2) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'") && trimmed.length >= 2)
+  ) {
+    return trimmed.slice(1, -1).trim()
+  }
+  return trimmed
+}
+
+function isUrl(value: string): boolean {
+  return value.startsWith("http://") || value.startsWith("https://")
+}

--- a/src/core/services/index.ts
+++ b/src/core/services/index.ts
@@ -1,1 +1,2 @@
+export * from "./bot-workflow-intake"
 export * from "./language"

--- a/src/core/types/bot-workflow.ts
+++ b/src/core/types/bot-workflow.ts
@@ -1,0 +1,117 @@
+/**
+ * Bot-first intake contracts.
+ *
+ * These types describe the payload after a chat/bot adapter has collected
+ * message text, attachments, template hints, and output preferences.
+ */
+
+import type {
+  BotRenderJobDestination,
+  BotRenderJobOutput,
+  BotRenderJobProjectInput,
+  BotRenderJobRequest,
+} from "./render-job"
+
+export type BotWorkflowSource = "telegram" | "api" | "cli" | "desktop"
+
+export type BotMediaAttachmentType = "file" | "url"
+
+export type BotWorkflowValidationCode =
+  | "missing_input"
+  | "invalid_media"
+  | "invalid_template"
+  | "invalid_output"
+  | "unsupported_destination"
+  | "unsupported_resolution"
+
+export interface BotMediaAttachment {
+  id?: string
+  type: BotMediaAttachmentType
+  value: string
+  name?: string
+  mimeType?: string
+  caption?: string
+  metadata?: Record<string, unknown>
+}
+
+export interface BotTemplateSelection {
+  id: string
+  version?: string
+  params?: Record<string, unknown>
+  project?: BotRenderJobProjectInput
+}
+
+export interface BotWorkflowOutput {
+  format?: BotRenderJobOutput["format"]
+  path?: string
+  resolution?: BotRenderJobOutput["resolution"]
+  destination?: BotRenderJobDestination
+}
+
+export interface BotWorkflowRequest {
+  source: BotWorkflowSource
+  chatId?: string
+  userId?: string
+  messageId?: string
+  text?: string
+  template?: BotTemplateSelection
+  project?: BotRenderJobProjectInput
+  media?: BotMediaAttachment[]
+  params?: Record<string, unknown>
+  output?: BotWorkflowOutput
+  raw?: unknown
+}
+
+export interface BotWorkflowValidationError {
+  code: BotWorkflowValidationCode
+  field: string
+  message: string
+  userMessage: string
+}
+
+export type BotWorkflowIntakeResult =
+  | {
+      ok: true
+      renderJob: BotRenderJobRequest
+      warnings: BotWorkflowValidationError[]
+    }
+  | {
+      ok: false
+      errors: BotWorkflowValidationError[]
+    }
+
+export interface BotWorkflowIntakeOptions {
+  defaultDestination?: BotRenderJobDestination
+  defaultOutputPath?: string
+  defaultResolution?: BotRenderJobOutput["resolution"]
+  defaultTemplateId?: string
+}
+
+export interface TelegramLikeBotFile {
+  file_id?: string
+  file_unique_id?: string
+  file_name?: string
+  mime_type?: string
+  file_path?: string
+  url?: string
+  caption?: string
+}
+
+export interface TelegramLikeBotPayload {
+  chat?: {
+    id?: string | number
+  }
+  from?: {
+    id?: string | number
+  }
+  message_id?: string | number
+  text?: string
+  caption?: string
+  document?: TelegramLikeBotFile
+  video?: TelegramLikeBotFile
+  audio?: TelegramLikeBotFile
+  animation?: TelegramLikeBotFile
+  photo?: TelegramLikeBotFile | TelegramLikeBotFile[]
+  media?: TelegramLikeBotFile[]
+  attachments?: BotMediaAttachment[]
+}

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -30,6 +30,7 @@ export type {
 } from "@/types/generated/tauri-bindings"
 
 // Re-export core-facing compatibility types for features
+export * from "./bot-workflow"
 export * from "./media"
 export * from "./render-job"
 export * from "./video-editing"


### PR DESCRIPTION
## Summary

- add bot workflow intake types for chat source, media attachments, template selection, output preferences, and validation errors
- add pure core normalizers for Telegram-like payloads and render text hints
- convert validated workflow requests into `BotRenderJobRequest` with chat-ready error messages
- update the bot-first roadmap and add focused unit coverage

## Verification

- `bun run check:type`
- `bun run check:workspaces`
- `bun run check:boundaries`
- `bun run check:boundaries:baseline`
- `bun run test -- src/core/services/__tests__/bot-workflow-intake.test.ts src/adapters/node/__tests__/render-job.test.ts src/cli/commands/__tests__/render-job.test.ts`
- `bunx biome ci` on changed files
- `git diff --check`

Refs #171
Closes #173