### PR TITLE
feat: add bot render job event stream

### DIFF
--- a/docs/08_tasks/planned/bot-first-workflow.md
+++ b/docs/08_tasks/planned/bot-first-workflow.md
@@ -50,13 +50,13 @@ bot message
 - [x] Добавить parser/normalizer для входа из Telegram-like payload в `BotRenderJobRequest`.
 - [x] Добавить validation errors, пригодные для ответа пользователю в чате.
 
-### B3: Worker event stream
+### B3: Worker event stream ([#175](https://github.com/chatman-media/timeline-studio/issues/175))
 
 **Цель:** дать боту live-статусы без UI.
 
-- [ ] Добавить event sink abstraction для отправки progress updates.
-- [ ] Поддержать status snapshots для reconnect/retry.
-- [ ] Покрыть cancel/retry сценарии.
+- [x] Добавить event sink abstraction для отправки progress updates.
+- [x] Поддержать status snapshots для reconnect/retry.
+- [x] Покрыть cancel/retry сценарии.
 
 ### B4: Publishing destinations
 
@@ -71,6 +71,7 @@ bot message
 - [#150](https://github.com/chatman-media/timeline-studio/issues/150) - Phase F / package boundaries
 - [#171](https://github.com/chatman-media/timeline-studio/issues/171) - Epic: Bot-first workflow
 - [#173](https://github.com/chatman-media/timeline-studio/issues/173) - B2: Bot intake contract
+- [#175](https://github.com/chatman-media/timeline-studio/issues/175) - B3: Worker event stream
 - [telegram-mini-app.md](./telegram-mini-app.md)
 - [cloud-rendering.md](./cloud-rendering.md)
 - [export-architecture-refactoring.md](./export-architecture-refactoring.md)

--- a/src/adapters/node/__tests__/render-job.test.ts
+++ b/src/adapters/node/__tests__/render-job.test.ts
@@ -3,6 +3,7 @@ import os from "node:os"
 import path from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { IVideoService, RenderJob as VideoRenderJob } from "@/core/ports"
+import { InMemoryBotRenderJobEventStream } from "@/core/services"
 import { NodeRenderJobService } from "../render-job"
 
 function createVideoService(videoJob: VideoRenderJob): IVideoService {
@@ -123,6 +124,53 @@ describe("NodeRenderJobService", () => {
     expect(result.events.at(-1)?.status).toBe("failed")
   })
 
+  it("publishes render progress to event sinks", async () => {
+    const videoJob: VideoRenderJob = {
+      id: "video-job-5",
+      status: "completed",
+      progress: 100,
+    }
+    const video = createVideoService(videoJob)
+    const stream = new InMemoryBotRenderJobEventStream()
+    const onEvent = vi.fn()
+    const service = new NodeRenderJobService(video, {
+      outputDir: tempDir,
+      idFactory: () => "bot-job-5",
+    })
+
+    const result = await service.run(
+      {
+        source: "bot",
+        project: { type: "inline", schema: { clips: [{ path: "/video.mp4" }] } },
+        output: { format: "mp4" },
+      },
+      { pollIntervalMs: 1, timeoutMs: 100, eventSinks: [stream], onEvent },
+    )
+
+    expect(result.events.map((event) => event.sequence)).toEqual([0, 1, 2, 3])
+    expect(stream.getEvents("bot-job-5").map((event) => event.status)).toEqual([
+      "queued",
+      "preparing",
+      "rendering",
+      "done",
+    ])
+    expect(stream.getSnapshot("bot-job-5")).toMatchObject({
+      jobId: "bot-job-5",
+      status: "done",
+      progress: 100,
+      artifact: {
+        type: "file",
+        path: path.join(tempDir, "bot-job-5.mp4"),
+        destination: "file",
+        mimeType: "video/mp4",
+      },
+      canCancel: false,
+      canRetry: false,
+      eventCount: 4,
+    })
+    expect(onEvent).toHaveBeenCalledTimes(4)
+  })
+
   it("can cancel a provider render job", async () => {
     const videoJob: VideoRenderJob = {
       id: "video-job-4",
@@ -130,6 +178,7 @@ describe("NodeRenderJobService", () => {
       progress: 50,
     }
     const video = createVideoService(videoJob)
+    const stream = new InMemoryBotRenderJobEventStream()
     const service = new NodeRenderJobService(video, {
       outputDir: tempDir,
       idFactory: () => "bot-job-4",
@@ -141,7 +190,7 @@ describe("NodeRenderJobService", () => {
         project: { type: "inline", schema: { clips: [{ path: "/video.mp4" }] } },
         output: { format: "mp4" },
       },
-      { pollIntervalMs: 10, timeoutMs: 20 },
+      { pollIntervalMs: 10, timeoutMs: 20, eventSinks: [stream] },
     )
 
     await vi.waitFor(async () => {
@@ -151,5 +200,11 @@ describe("NodeRenderJobService", () => {
     expect(video.cancelRender).toHaveBeenCalledWith("video-job-4")
     const result = await runPromise
     expect(result.job.status).toBe("cancelled")
+    expect(stream.getSnapshot("bot-job-4")).toMatchObject({
+      status: "cancelled",
+      canCancel: false,
+      canRetry: true,
+      lastEvent: { status: "cancelled" },
+    })
   })
 })

--- a/src/adapters/node/render-job.ts
+++ b/src/adapters/node/render-job.ts
@@ -3,9 +3,11 @@ import fs from "node:fs/promises"
 import path from "node:path"
 
 import type { IRenderJobService, IVideoService, RenderJob as VideoRenderJob } from "@/core/ports"
+import { createBotRenderJobSnapshot } from "@/core/services"
 import type {
   BotRenderJob,
   BotRenderJobEvent,
+  BotRenderJobEventSink,
   BotRenderJobRequest,
   BotRenderJobResult,
   BotRenderJobRunOptions,
@@ -52,6 +54,13 @@ function isCancelled(job: BotRenderJob): boolean {
 
 export class NodeRenderJobService implements IRenderJobService {
   private jobs = new Map<string, BotRenderJob>()
+  private jobEventHandlers = new Map<
+    string,
+    {
+      onEvent?: BotRenderJobRunOptions["onEvent"]
+      eventSinks: BotRenderJobEventSink[]
+    }
+  >()
   private outputDir: string
   private idFactory: () => string
   private now: () => string
@@ -67,9 +76,17 @@ export class NodeRenderJobService implements IRenderJobService {
 
   async run(request: BotRenderJobRequest, options: BotRenderJobRunOptions = {}): Promise<BotRenderJobResult> {
     const job = this.createJob(request)
+    this.jobEventHandlers.set(job.id, {
+      onEvent: options.onEvent,
+      eventSinks: options.eventSinks ?? [],
+    })
+    const queuedEvent = job.events.at(-1)
+    if (queuedEvent) {
+      await this.dispatch(job, queuedEvent)
+    }
 
     try {
-      await this.emit(job, "preparing", 5, "Preparing render job", options)
+      await this.emit(job, "preparing", 5, "Preparing render job")
       const projectSchema = await this.resolveProjectSchema(request)
       const outputPath = this.resolveOutputPath(request, job.id)
 
@@ -77,7 +94,7 @@ export class NodeRenderJobService implements IRenderJobService {
         return { job, events: [...job.events] }
       }
 
-      await this.emit(job, "rendering", 10, "Starting video render", options)
+      await this.emit(job, "rendering", 10, "Starting video render")
       const providerJobId = await this.video.renderProject(projectSchema, outputPath)
       job.providerJobId = providerJobId
 
@@ -95,10 +112,11 @@ export class NodeRenderJobService implements IRenderJobService {
           destination: request.output.destination ?? "file",
           mimeType: "video/mp4",
         }
+        await this.publishSnapshot(job)
       }
     } catch (error) {
       job.error = errorMessage(error)
-      await this.emit(job, "failed", job.progress, job.error, options)
+      await this.emit(job, "failed", job.progress, job.error)
     }
 
     return {
@@ -121,13 +139,8 @@ export class NodeRenderJobService implements IRenderJobService {
       job.status = "cancelled"
       job.updatedAt = timestamp
       job.progress = Math.min(job.progress, 99)
-      job.events.push({
-        jobId: job.id,
-        status: "cancelled",
-        progress: job.progress,
-        message: "Render job cancelled",
-        timestamp,
-      })
+      const event = this.createEvent(job, "cancelled", job.progress, "Render job cancelled", timestamp)
+      await this.dispatch(job, event)
     }
     return cancelled
   }
@@ -145,13 +158,7 @@ export class NodeRenderJobService implements IRenderJobService {
     }
 
     this.jobs.set(job.id, job)
-    job.events.push({
-      jobId: job.id,
-      status: "queued",
-      progress: 0,
-      message: "Render job queued",
-      timestamp: now,
-    })
+    this.createEvent(job, "queued", 0, "Render job queued", now)
 
     return job
   }
@@ -192,13 +199,13 @@ export class NodeRenderJobService implements IRenderJobService {
       const videoJob = await this.readVideoJob(providerJobId)
 
       if (!videoJob) {
-        await this.emit(job, "done", 100, "Render job completed", options)
+        await this.emit(job, "done", 100, "Render job completed")
         return
       }
 
       const status = normalizeVideoStatus(videoJob.status)
       const progress = typeof videoJob.progress === "number" ? videoJob.progress : job.progress
-      await this.emit(job, status, status === "done" ? 100 : progress, `Render status: ${status}`, options)
+      await this.emit(job, status, status === "done" ? 100 : progress, `Render status: ${status}`)
 
       if (status === "done") return
       if (status === "cancelled") return
@@ -221,27 +228,51 @@ export class NodeRenderJobService implements IRenderJobService {
     }
   }
 
-  private async emit(
-    job: BotRenderJob,
-    status: BotRenderJobStatus,
-    progress: number,
-    message: string,
-    options: BotRenderJobRunOptions,
-  ): Promise<void> {
+  private async emit(job: BotRenderJob, status: BotRenderJobStatus, progress: number, message: string): Promise<void> {
     const timestamp = this.now()
     job.status = status
     job.progress = Math.max(0, Math.min(100, progress))
     job.updatedAt = timestamp
+    const event = this.createEvent(job, status, job.progress, message, timestamp)
+    await this.dispatch(job, event)
+  }
 
+  private createEvent(
+    job: BotRenderJob,
+    status: BotRenderJobStatus,
+    progress: number,
+    message: string,
+    timestamp: string,
+  ): BotRenderJobEvent {
     const event: BotRenderJobEvent = {
       jobId: job.id,
+      sequence: job.events.length,
       status,
-      progress: job.progress,
+      progress,
       message,
       timestamp,
     }
     job.events.push(event)
+    return event
+  }
 
-    await options.onEvent?.(event, job)
+  private async dispatch(job: BotRenderJob, event: BotRenderJobEvent): Promise<void> {
+    const handlers = this.jobEventHandlers.get(job.id)
+    const snapshot = createBotRenderJobSnapshot(job)
+
+    await handlers?.onEvent?.(event, job)
+
+    for (const sink of handlers?.eventSinks ?? []) {
+      await sink.publish(event, snapshot)
+    }
+  }
+
+  private async publishSnapshot(job: BotRenderJob): Promise<void> {
+    const handlers = this.jobEventHandlers.get(job.id)
+    const snapshot = createBotRenderJobSnapshot(job)
+
+    for (const sink of handlers?.eventSinks ?? []) {
+      await sink.publishSnapshot?.(snapshot)
+    }
   }
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -32,11 +32,16 @@ export type {
   SaveDialogOptions,
   Unsubscribe,
 } from "./ports"
-export type { LanguageResponse, ParsedBotWorkflowText } from "./services"
+export type { BotRenderJobRetryOptions, LanguageResponse, ParsedBotWorkflowText } from "./services"
 export {
+  canCancelBotRenderJob,
+  canRetryBotRenderJob,
   createBotRenderJobRequest,
+  createBotRenderJobRetryRequest,
+  createBotRenderJobSnapshot,
   createBotWorkflowRequestFromTelegramLikePayload,
   getAppLanguage,
+  InMemoryBotRenderJobEventStream,
   parseBotWorkflowText,
   setAppLanguage,
 } from "./services"
@@ -49,11 +54,16 @@ export type {
   BotRenderJobArtifact,
   BotRenderJobDestination,
   BotRenderJobEvent,
+  BotRenderJobEventQuery,
+  BotRenderJobEventSink,
+  BotRenderJobEventStreamOptions,
   BotRenderJobMediaInput,
   BotRenderJobProjectInput,
+  BotRenderJobReconnectState,
   BotRenderJobRequest,
   BotRenderJobResult,
   BotRenderJobRunOptions,
+  BotRenderJobSnapshot,
   BotRenderJobSource,
   BotRenderJobStatus,
   BotTemplateSelection,

--- a/src/core/services/__tests__/render-job-events.test.ts
+++ b/src/core/services/__tests__/render-job-events.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest"
+import type { BotRenderJob, BotRenderJobEvent } from "@/core/types"
+import {
+  createBotRenderJobRetryRequest,
+  createBotRenderJobSnapshot,
+  InMemoryBotRenderJobEventStream,
+} from "../render-job-events"
+
+function createJob(status: BotRenderJob["status"] = "rendering"): BotRenderJob {
+  const events: BotRenderJobEvent[] = [
+    {
+      jobId: "job-1",
+      sequence: 0,
+      status: "queued",
+      progress: 0,
+      message: "queued",
+      timestamp: "2026-06-08T00:00:00.000Z",
+    },
+    {
+      jobId: "job-1",
+      sequence: 1,
+      status,
+      progress: status === "failed" ? 40 : 60,
+      message: status,
+      timestamp: "2026-06-08T00:00:01.000Z",
+    },
+  ]
+
+  return {
+    id: "job-1",
+    providerJobId: "provider-1",
+    status,
+    progress: status === "failed" ? 40 : 60,
+    request: {
+      source: "bot",
+      templateId: "promo",
+      output: { format: "mp4", destination: "telegram" },
+      params: { tone: "direct" },
+    },
+    error: status === "failed" ? "Encoding failed" : undefined,
+    createdAt: "2026-06-08T00:00:00.000Z",
+    updatedAt: "2026-06-08T00:00:01.000Z",
+    events,
+  }
+}
+
+describe("render job events", () => {
+  it("creates reconnect snapshots with cancel/retry capabilities", () => {
+    const renderingSnapshot = createBotRenderJobSnapshot(createJob("rendering"))
+    expect(renderingSnapshot).toMatchObject({
+      jobId: "job-1",
+      providerJobId: "provider-1",
+      status: "rendering",
+      progress: 60,
+      eventCount: 2,
+      canCancel: true,
+      canRetry: false,
+      lastEvent: { sequence: 1, status: "rendering" },
+    })
+
+    const failedSnapshot = createBotRenderJobSnapshot(createJob("failed"))
+    expect(failedSnapshot).toMatchObject({
+      status: "failed",
+      canCancel: false,
+      canRetry: true,
+      error: "Encoding failed",
+    })
+  })
+
+  it("stores bounded event history and returns reconnect state after a cursor", () => {
+    const stream = new InMemoryBotRenderJobEventStream({ maxEventsPerJob: 2 })
+    const job = createJob("rendering")
+
+    for (const event of job.events) {
+      stream.publish(event, createBotRenderJobSnapshot(job))
+    }
+
+    const thirdEvent: BotRenderJobEvent = {
+      jobId: "job-1",
+      sequence: 2,
+      status: "rendering",
+      progress: 80,
+      message: "rendering",
+      timestamp: "2026-06-08T00:00:02.000Z",
+    }
+    stream.publish(thirdEvent, {
+      ...createBotRenderJobSnapshot(job),
+      eventCount: 3,
+      lastEvent: thirdEvent,
+      progress: 80,
+    })
+
+    expect(stream.getEvents("job-1").map((event) => event.sequence)).toEqual([1, 2])
+    expect(stream.getReconnectState("job-1", { afterSequence: 1 })).toMatchObject({
+      snapshot: {
+        jobId: "job-1",
+        progress: 80,
+        lastEvent: { sequence: 2 },
+      },
+      events: [{ sequence: 2 }],
+    })
+  })
+
+  it("builds retry requests only for retryable jobs", () => {
+    const failedJob = createJob("failed")
+
+    expect(createBotRenderJobRetryRequest(failedJob, { outputPath: "/tmp/retry.mp4" })).toEqual({
+      source: "bot",
+      templateId: "promo",
+      output: { format: "mp4", destination: "telegram", path: "/tmp/retry.mp4" },
+      params: {
+        tone: "direct",
+        retryOf: "job-1",
+        retryAttempt: 1,
+      },
+    })
+
+    expect(() => createBotRenderJobRetryRequest(createJob("rendering"))).toThrow(
+      "Render job job-1 cannot be retried from status rendering",
+    )
+  })
+})

--- a/src/core/services/index.ts
+++ b/src/core/services/index.ts
@@ -1,2 +1,3 @@
 export * from "./bot-workflow-intake"
 export * from "./language"
+export * from "./render-job-events"

--- a/src/core/services/render-job-events.ts
+++ b/src/core/services/render-job-events.ts
@@ -1,0 +1,121 @@
+import type {
+  BotRenderJob,
+  BotRenderJobEvent,
+  BotRenderJobEventQuery,
+  BotRenderJobEventSink,
+  BotRenderJobEventStreamOptions,
+  BotRenderJobReconnectState,
+  BotRenderJobRequest,
+  BotRenderJobSnapshot,
+  BotRenderJobStatus,
+} from "../types"
+
+const TERMINAL_STATUSES = new Set<BotRenderJobStatus>(["done", "failed", "cancelled"])
+const RETRYABLE_STATUSES = new Set<BotRenderJobStatus>(["failed", "cancelled"])
+
+export interface BotRenderJobRetryOptions {
+  attempt?: number
+  outputPath?: string
+}
+
+export function createBotRenderJobSnapshot(job: BotRenderJob): BotRenderJobSnapshot {
+  return {
+    jobId: job.id,
+    ...(job.providerJobId ? { providerJobId: job.providerJobId } : {}),
+    status: job.status,
+    progress: job.progress,
+    ...(job.artifact ? { artifact: job.artifact } : {}),
+    ...(job.error ? { error: job.error } : {}),
+    createdAt: job.createdAt,
+    updatedAt: job.updatedAt,
+    eventCount: job.events.length,
+    ...(job.events.length > 0 ? { lastEvent: job.events.at(-1) } : {}),
+    canCancel: canCancelBotRenderJob(job.status),
+    canRetry: canRetryBotRenderJob(job.status),
+  }
+}
+
+export function canCancelBotRenderJob(status: BotRenderJobStatus): boolean {
+  return !TERMINAL_STATUSES.has(status)
+}
+
+export function canRetryBotRenderJob(status: BotRenderJobStatus): boolean {
+  return RETRYABLE_STATUSES.has(status)
+}
+
+export function createBotRenderJobRetryRequest(
+  job: BotRenderJob,
+  options: BotRenderJobRetryOptions = {},
+): BotRenderJobRequest {
+  if (!canRetryBotRenderJob(job.status)) {
+    throw new Error(`Render job ${job.id} cannot be retried from status ${job.status}`)
+  }
+
+  const previousAttempt =
+    typeof job.request.params?.retryAttempt === "number" ? Number(job.request.params.retryAttempt) : 0
+  const retryAttempt = options.attempt ?? previousAttempt + 1
+
+  return {
+    ...job.request,
+    output: {
+      ...job.request.output,
+      ...(options.outputPath ? { path: options.outputPath } : {}),
+    },
+    params: {
+      ...job.request.params,
+      retryOf: job.id,
+      retryAttempt,
+    },
+  }
+}
+
+export class InMemoryBotRenderJobEventStream implements BotRenderJobEventSink {
+  private snapshots = new Map<string, BotRenderJobSnapshot>()
+  private events = new Map<string, BotRenderJobEvent[]>()
+  private maxEventsPerJob: number
+
+  constructor(options: BotRenderJobEventStreamOptions = {}) {
+    this.maxEventsPerJob = options.maxEventsPerJob ?? 200
+  }
+
+  publish(event: BotRenderJobEvent, snapshot: BotRenderJobSnapshot): void {
+    const events = this.events.get(event.jobId) ?? []
+    events.push(event)
+
+    if (events.length > this.maxEventsPerJob) {
+      events.splice(0, events.length - this.maxEventsPerJob)
+    }
+
+    this.events.set(event.jobId, events)
+    this.snapshots.set(snapshot.jobId, snapshot)
+  }
+
+  publishSnapshot(snapshot: BotRenderJobSnapshot): void {
+    this.snapshots.set(snapshot.jobId, snapshot)
+  }
+
+  getSnapshot(jobId: string): BotRenderJobSnapshot | null {
+    return this.snapshots.get(jobId) ?? null
+  }
+
+  getEvents(jobId: string, query: BotRenderJobEventQuery = {}): BotRenderJobEvent[] {
+    const events = this.events.get(jobId) ?? []
+    const afterSequence = query.afterSequence
+    const filtered =
+      typeof afterSequence === "number" ? events.filter((event) => event.sequence > afterSequence) : events
+
+    return typeof query.limit === "number" && query.limit >= 0 ? filtered.slice(0, query.limit) : [...filtered]
+  }
+
+  getReconnectState(jobId: string, query: BotRenderJobEventQuery = {}): BotRenderJobReconnectState {
+    return {
+      snapshot: this.getSnapshot(jobId),
+      events: this.getEvents(jobId, query),
+    }
+  }
+
+  clearJob(jobId: string): void {
+    this.snapshots.delete(jobId)
+    this.events.delete(jobId)
+  }
+}

--- a/src/core/types/render-job.ts
+++ b/src/core/types/render-job.ts
@@ -56,10 +56,45 @@ export interface BotRenderJobArtifact {
 
 export interface BotRenderJobEvent {
   jobId: string
+  sequence: number
   status: BotRenderJobStatus
   progress: number
   message?: string
   timestamp: string
+}
+
+export interface BotRenderJobSnapshot {
+  jobId: string
+  providerJobId?: string
+  status: BotRenderJobStatus
+  progress: number
+  artifact?: BotRenderJobArtifact
+  error?: string
+  createdAt: string
+  updatedAt: string
+  eventCount: number
+  lastEvent?: BotRenderJobEvent
+  canCancel: boolean
+  canRetry: boolean
+}
+
+export interface BotRenderJobReconnectState {
+  snapshot: BotRenderJobSnapshot | null
+  events: BotRenderJobEvent[]
+}
+
+export interface BotRenderJobEventSink {
+  publish(event: BotRenderJobEvent, snapshot: BotRenderJobSnapshot): void | Promise<void>
+  publishSnapshot?(snapshot: BotRenderJobSnapshot): void | Promise<void>
+}
+
+export interface BotRenderJobEventStreamOptions {
+  maxEventsPerJob?: number
+}
+
+export interface BotRenderJobEventQuery {
+  afterSequence?: number
+  limit?: number
 }
 
 export interface BotRenderJob {
@@ -79,6 +114,7 @@ export interface BotRenderJobRunOptions {
   pollIntervalMs?: number
   timeoutMs?: number
   onEvent?: (event: BotRenderJobEvent, job: BotRenderJob) => void | Promise<void>
+  eventSinks?: BotRenderJobEventSink[]
 }
 
 export interface BotRenderJobResult {


### PR DESCRIPTION
## Summary

- add render job event sink contracts, sequenced events, snapshots, and reconnect state types
- add `InMemoryBotRenderJobEventStream` plus retry/cancel capability helpers
- wire `NodeRenderJobService` to publish queued/progress/done/cancel events to event sinks
- publish final artifact snapshots for reconnect after render completion
- update the bot-first roadmap and add focused unit coverage

## Verification

- `bun run check:type`
- `bun run check:workspaces`
- `bun run check:boundaries`
- `bun run check:boundaries:baseline`
- `bun run test -- src/core/services/__tests__/render-job-events.test.ts src/adapters/node/__tests__/render-job.test.ts src/cli/commands/__tests__/render-job.test.ts`
- `bunx biome ci` on changed files
- `git diff --check`

Refs #171
Closes #175