### PR TITLE
feat: add bot publishing destinations

### DIFF
--- a/docs/08_tasks/planned/bot-first-workflow.md
+++ b/docs/08_tasks/planned/bot-first-workflow.md
@@ -58,13 +58,13 @@ bot message
 - [x] Поддержать status snapshots для reconnect/retry.
 - [x] Покрыть cancel/retry сценарии.
 
-### B4: Publishing destinations
+### B4: Publishing destinations ([#177](https://github.com/chatman-media/timeline-studio/issues/177))
 
 **Цель:** подключать Telegram/YouTube/TikTok как destination после готового render artifact.
 
-- [ ] Добавить `IPublishService` core port.
-- [ ] Добавить destination-specific publishing adapters.
-- [ ] Связать publish phase с `BotRenderJobStatus = "publishing"`.
+- [x] Добавить `IPublishService` core port.
+- [x] Добавить destination-specific publishing adapters.
+- [x] Связать publish phase с `BotRenderJobStatus = "publishing"`.
 
 ## Связанные задачи
 
@@ -72,6 +72,7 @@ bot message
 - [#171](https://github.com/chatman-media/timeline-studio/issues/171) - Epic: Bot-first workflow
 - [#173](https://github.com/chatman-media/timeline-studio/issues/173) - B2: Bot intake contract
 - [#175](https://github.com/chatman-media/timeline-studio/issues/175) - B3: Worker event stream
+- [#177](https://github.com/chatman-media/timeline-studio/issues/177) - B4: Publishing destinations
 - [telegram-mini-app.md](./telegram-mini-app.md)
 - [cloud-rendering.md](./cloud-rendering.md)
 - [export-architecture-refactoring.md](./export-architecture-refactoring.md)

--- a/src/adapters/node/__tests__/publish.test.ts
+++ b/src/adapters/node/__tests__/publish.test.ts
@@ -1,0 +1,137 @@
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { NodePublishService } from "../publish"
+
+describe("NodePublishService", () => {
+  let tempDir: string
+  let artifactPath: string
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "node-publish-service-"))
+    artifactPath = path.join(tempDir, "video.mp4")
+    await fs.writeFile(artifactPath, "video")
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  it("publishes file artifacts as local results", async () => {
+    const service = new NodePublishService()
+
+    await expect(
+      service.publish({
+        destination: "file",
+        artifact: {
+          type: "file",
+          path: artifactPath,
+          destination: "file",
+          mimeType: "video/mp4",
+        },
+      }),
+    ).resolves.toEqual({
+      destination: "file",
+      status: "done",
+      artifact: {
+        type: "file",
+        path: artifactPath,
+        destination: "file",
+        mimeType: "video/mp4",
+      },
+      metadata: undefined,
+    })
+  })
+
+  it("publishes telegram artifacts through an injected client", async () => {
+    const client = {
+      sendVideo: vi.fn().mockResolvedValue({
+        messageId: "message-1",
+        url: "https://t.me/channel/1",
+      }),
+    }
+    const service = new NodePublishService({ telegram: { client } })
+
+    await expect(
+      service.publish({
+        destination: "telegram",
+        artifact: {
+          type: "file",
+          path: artifactPath,
+          destination: "file",
+          mimeType: "video/mp4",
+        },
+        metadata: {
+          chatId: "chat-1",
+          caption: "Done",
+        },
+      }),
+    ).resolves.toEqual({
+      destination: "telegram",
+      status: "done",
+      artifact: {
+        type: "url",
+        url: "https://t.me/channel/1",
+        destination: "telegram",
+        mimeType: "video/mp4",
+      },
+      providerId: "message-1",
+      url: "https://t.me/channel/1",
+      metadata: {
+        chatId: "chat-1",
+        caption: "Done",
+      },
+    })
+
+    expect(client.sendVideo).toHaveBeenCalledWith({
+      path: artifactPath,
+      chatId: "chat-1",
+      caption: "Done",
+      mimeType: "video/mp4",
+      metadata: {
+        chatId: "chat-1",
+        caption: "Done",
+      },
+    })
+  })
+
+  it("returns failed results for incomplete telegram configuration", async () => {
+    const service = new NodePublishService()
+
+    await expect(
+      service.publish({
+        destination: "telegram",
+        artifact: {
+          type: "file",
+          path: artifactPath,
+          destination: "file",
+          mimeType: "video/mp4",
+        },
+      }),
+    ).resolves.toMatchObject({
+      destination: "telegram",
+      status: "failed",
+      error: "Telegram publisher is not configured",
+    })
+  })
+
+  it("returns unsupported for destinations without node publishers yet", async () => {
+    const service = new NodePublishService()
+
+    await expect(
+      service.publish({
+        destination: "youtube",
+        artifact: {
+          type: "file",
+          path: artifactPath,
+          destination: "file",
+        },
+      }),
+    ).resolves.toMatchObject({
+      destination: "youtube",
+      status: "unsupported",
+      error: "Publishing to youtube is not implemented yet",
+    })
+  })
+})

--- a/src/adapters/node/__tests__/render-job.test.ts
+++ b/src/adapters/node/__tests__/render-job.test.ts
@@ -4,6 +4,7 @@ import path from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { IVideoService, RenderJob as VideoRenderJob } from "@/core/ports"
 import { InMemoryBotRenderJobEventStream } from "@/core/services"
+import { NodePublishService } from "../publish"
 import { NodeRenderJobService } from "../render-job"
 
 function createVideoService(videoJob: VideoRenderJob): IVideoService {
@@ -83,14 +84,14 @@ describe("NodeRenderJobService", () => {
       {
         source: "cli",
         project: { type: "file", path: projectPath },
-        output: { format: "mp4", destination: "telegram" },
+        output: { format: "mp4" },
       },
       { pollIntervalMs: 1, timeoutMs: 100 },
     )
 
     expect(result.job.status).toBe("done")
     expect(result.job.artifact?.path).toBe(path.join(tempDir, "bot-job-2.mp4"))
-    expect(result.job.artifact?.destination).toBe("telegram")
+    expect(result.job.artifact?.destination).toBe("file")
     expect(video.renderProject).toHaveBeenCalledWith(
       { clips: [{ path: "/clip.mov" }] },
       path.join(tempDir, "bot-job-2.mp4"),
@@ -169,6 +170,92 @@ describe("NodeRenderJobService", () => {
       eventCount: 4,
     })
     expect(onEvent).toHaveBeenCalledTimes(4)
+  })
+
+  it("publishes a rendered artifact to telegram destination", async () => {
+    const videoJob: VideoRenderJob = {
+      id: "video-job-6",
+      status: "completed",
+      progress: 100,
+    }
+    const video = createVideoService(videoJob)
+    const stream = new InMemoryBotRenderJobEventStream()
+    const telegramClient = {
+      sendVideo: vi.fn().mockResolvedValue({
+        messageId: "telegram-message-1",
+        url: "https://t.me/channel/1",
+        metadata: { chatId: "chat-1" },
+      }),
+    }
+    const publisher = new NodePublishService({
+      telegram: {
+        client: telegramClient,
+      },
+    })
+    const service = new NodeRenderJobService(video, {
+      outputDir: tempDir,
+      idFactory: () => "bot-job-6",
+      publisher,
+    })
+
+    const result = await service.run(
+      {
+        source: "bot",
+        project: { type: "inline", schema: { clips: [{ path: "/video.mp4" }] } },
+        params: {
+          telegramChatId: "chat-1",
+          caption: "Ready",
+        },
+        output: { format: "mp4", destination: "telegram" },
+      },
+      { pollIntervalMs: 1, timeoutMs: 100, eventSinks: [stream] },
+    )
+
+    expect(result.job.status).toBe("done")
+    expect(result.events.map((event) => event.status)).toEqual([
+      "queued",
+      "preparing",
+      "rendering",
+      "rendering",
+      "publishing",
+      "done",
+    ])
+    expect(result.job.artifact).toEqual({
+      type: "url",
+      url: "https://t.me/channel/1",
+      destination: "telegram",
+      mimeType: "video/mp4",
+    })
+    expect(result.job.publications).toEqual([
+      {
+        destination: "telegram",
+        status: "done",
+        artifact: result.job.artifact,
+        providerId: "telegram-message-1",
+        url: "https://t.me/channel/1",
+        metadata: {
+          caption: "Ready",
+          chatId: "chat-1",
+          provider: { chatId: "chat-1" },
+        },
+      },
+    ])
+    expect(telegramClient.sendVideo).toHaveBeenCalledWith({
+      path: path.join(tempDir, "bot-job-6.mp4"),
+      chatId: "chat-1",
+      caption: "Ready",
+      mimeType: "video/mp4",
+      metadata: {
+        caption: "Ready",
+        chatId: "chat-1",
+      },
+    })
+    expect(stream.getSnapshot("bot-job-6")).toMatchObject({
+      status: "done",
+      artifact: { type: "url", destination: "telegram" },
+      publications: [{ destination: "telegram", status: "done" }],
+      lastEvent: { status: "done" },
+    })
   })
 
   it("can cancel a provider render job", async () => {

--- a/src/adapters/node/index.ts
+++ b/src/adapters/node/index.ts
@@ -14,6 +14,7 @@ import { type NodeLanguageOptions, NodeLanguageService } from "./language"
 import { type NodeMediaOptions, NodeMediaService } from "./media"
 import { NodeBackendBridgeService } from "./node-backend-bridge"
 import { type NodePlatformOptions, NodePlatformService } from "./platform"
+import { type NodePublishOptions, NodePublishService } from "./publish"
 import { NodeRenderJobService, type NodeRenderJobServiceOptions } from "./render-job"
 import { type NodeStorageOptions, NodeStorageService } from "./storage"
 import { type NodeVideoOptions, NodeVideoService } from "./video"
@@ -26,6 +27,7 @@ export { type NodeLanguageOptions, NodeLanguageService } from "./language"
 export { type NodeMediaOptions, NodeMediaService } from "./media"
 export { NodeBackendBridgeService } from "./node-backend-bridge"
 export { type NodePlatformOptions, NodePlatformService } from "./platform"
+export { type NodePublishOptions, NodePublishService } from "./publish"
 export { NodeRenderJobService, type NodeRenderJobServiceOptions } from "./render-job"
 export { type NodeStorageOptions, NodeStorageService } from "./storage"
 export { type NodeVideoOptions, NodeVideoService } from "./video"
@@ -45,6 +47,8 @@ export interface NodeAppOptions {
   backend?: NodeBackendOptions
   /** Опции для Language сервиса */
   language?: NodeLanguageOptions
+  /** Опции для bot-first Publish сервиса */
+  publish?: NodePublishOptions
   /** Опции для bot-first RenderJob сервиса */
   renderJob?: NodeRenderJobServiceOptions
   /** Автоматически подключаться к бэкенду */
@@ -61,6 +65,7 @@ export interface NodeAppServices {
   video: NodeVideoService
   ai: NodeAIService
   language: NodeLanguageService
+  publish: NodePublishService
   renderJob: NodeRenderJobService
 }
 
@@ -97,7 +102,11 @@ export async function initNodeApp(options: NodeAppOptions = {}): Promise<NodeApp
   const video = new NodeVideoService(options.video)
   const ai = new NodeAIService(options.ai)
   const language = new NodeLanguageService(options.language)
-  const renderJob = new NodeRenderJobService(video, options.renderJob)
+  const publish = new NodePublishService(options.publish)
+  const renderJob = new NodeRenderJobService(video, {
+    ...options.renderJob,
+    publisher: options.renderJob?.publisher ?? publish,
+  })
 
   // Register in container
   container.registerBackend(backend)
@@ -125,6 +134,7 @@ export async function initNodeApp(options: NodeAppOptions = {}): Promise<NodeApp
     video,
     ai,
     language,
+    publish,
     renderJob,
   }
 }
@@ -138,6 +148,7 @@ export async function initNodeApp(options: NodeAppOptions = {}): Promise<NodeApp
  */
 export function createNodeServices(options: NodeAppOptions = {}): NodeAppServices {
   const video = new NodeVideoService(options.video)
+  const publish = new NodePublishService(options.publish)
 
   return {
     backend: new NodeBackendService(options.backend),
@@ -149,6 +160,10 @@ export function createNodeServices(options: NodeAppOptions = {}): NodeAppService
     video,
     ai: new NodeAIService(options.ai),
     language: new NodeLanguageService(options.language),
-    renderJob: new NodeRenderJobService(video, options.renderJob),
+    publish,
+    renderJob: new NodeRenderJobService(video, {
+      ...options.renderJob,
+      publisher: options.renderJob?.publisher ?? publish,
+    }),
   }
 }

--- a/src/adapters/node/publish.ts
+++ b/src/adapters/node/publish.ts
@@ -1,0 +1,169 @@
+import fs from "node:fs/promises"
+
+import type { IPublishService } from "@/core/ports"
+import type {
+  BotPublishMetadata,
+  BotPublishRequest,
+  BotPublishResult,
+  BotRenderJobArtifact,
+  BotRenderJobDestination,
+} from "@/core/types"
+
+export interface NodeTelegramPublishPayload {
+  path: string
+  chatId: string
+  caption?: string
+  mimeType?: string
+  metadata?: BotPublishMetadata
+}
+
+export interface NodeTelegramPublishResult {
+  messageId?: string
+  url?: string
+  metadata?: Record<string, unknown>
+}
+
+export interface NodeTelegramPublishClient {
+  sendVideo(payload: NodeTelegramPublishPayload): Promise<NodeTelegramPublishResult>
+}
+
+export interface NodePublishOptions {
+  telegram?: {
+    defaultChatId?: string
+    client?: NodeTelegramPublishClient
+  }
+}
+
+export class NodePublishService implements IPublishService {
+  constructor(private readonly options: NodePublishOptions = {}) {}
+
+  canPublish(destination: BotRenderJobDestination): boolean {
+    if (destination === "file") return true
+    if (destination === "telegram") return Boolean(this.options.telegram?.client)
+    return false
+  }
+
+  async publish(request: BotPublishRequest): Promise<BotPublishResult> {
+    switch (request.destination) {
+      case "file":
+        return this.publishFile(request)
+      case "telegram":
+        return this.publishTelegram(request)
+      default:
+        return {
+          destination: request.destination,
+          status: "unsupported",
+          error: `Publishing to ${request.destination} is not implemented yet`,
+        }
+    }
+  }
+
+  private async publishFile(request: BotPublishRequest): Promise<BotPublishResult> {
+    if (!request.artifact.path) {
+      return {
+        destination: "file",
+        status: "failed",
+        error: "File publishing requires a local artifact path",
+      }
+    }
+
+    try {
+      await fs.access(request.artifact.path)
+    } catch {
+      return {
+        destination: "file",
+        status: "failed",
+        error: `File artifact does not exist: ${request.artifact.path}`,
+      }
+    }
+
+    return {
+      destination: "file",
+      status: "done",
+      artifact: {
+        ...request.artifact,
+        destination: "file",
+      },
+      metadata: request.metadata,
+    }
+  }
+
+  private async publishTelegram(request: BotPublishRequest): Promise<BotPublishResult> {
+    const client = this.options.telegram?.client
+    if (!client) {
+      return {
+        destination: "telegram",
+        status: "failed",
+        error: "Telegram publisher is not configured",
+      }
+    }
+
+    if (!request.artifact.path) {
+      return {
+        destination: "telegram",
+        status: "failed",
+        error: "Telegram publishing requires a local file artifact",
+      }
+    }
+
+    const chatId = request.metadata?.chatId ?? this.options.telegram?.defaultChatId
+    if (!chatId) {
+      return {
+        destination: "telegram",
+        status: "failed",
+        error: "Telegram publishing requires chatId metadata or defaultChatId",
+      }
+    }
+
+    let published: NodeTelegramPublishResult
+    try {
+      published = await client.sendVideo({
+        path: request.artifact.path,
+        chatId,
+        caption: request.metadata?.caption ?? request.metadata?.title,
+        mimeType: request.artifact.mimeType,
+        metadata: request.metadata,
+      })
+    } catch (error) {
+      return {
+        destination: "telegram",
+        status: "failed",
+        error: error instanceof Error ? error.message : String(error),
+      }
+    }
+
+    const artifact = createPublishedArtifact("telegram", request.artifact, published.url)
+
+    return {
+      destination: "telegram",
+      status: "done",
+      artifact,
+      providerId: published.messageId,
+      url: published.url,
+      metadata: {
+        ...request.metadata,
+        ...(published.metadata ? { provider: published.metadata } : {}),
+      },
+    }
+  }
+}
+
+function createPublishedArtifact(
+  destination: BotRenderJobDestination,
+  artifact: BotRenderJobArtifact,
+  url?: string,
+): BotRenderJobArtifact {
+  if (url) {
+    return {
+      type: "url",
+      url,
+      destination,
+      mimeType: artifact.mimeType,
+    }
+  }
+
+  return {
+    ...artifact,
+    destination,
+  }
+}

--- a/src/adapters/node/render-job.ts
+++ b/src/adapters/node/render-job.ts
@@ -2,10 +2,12 @@ import crypto from "node:crypto"
 import fs from "node:fs/promises"
 import path from "node:path"
 
-import type { IRenderJobService, IVideoService, RenderJob as VideoRenderJob } from "@/core/ports"
+import type { IPublishService, IRenderJobService, IVideoService, RenderJob as VideoRenderJob } from "@/core/ports"
 import { createBotRenderJobSnapshot } from "@/core/services"
 import type {
+  BotPublishMetadata,
   BotRenderJob,
+  BotRenderJobArtifact,
   BotRenderJobEvent,
   BotRenderJobEventSink,
   BotRenderJobRequest,
@@ -18,6 +20,7 @@ export interface NodeRenderJobServiceOptions {
   outputDir?: string
   idFactory?: () => string
   now?: () => string
+  publisher?: IPublishService
 }
 
 const DEFAULT_POLL_INTERVAL_MS = 1000
@@ -64,6 +67,7 @@ export class NodeRenderJobService implements IRenderJobService {
   private outputDir: string
   private idFactory: () => string
   private now: () => string
+  private publisher?: IPublishService
 
   constructor(
     private readonly video: IVideoService,
@@ -72,6 +76,7 @@ export class NodeRenderJobService implements IRenderJobService {
     this.outputDir = options.outputDir ?? process.cwd()
     this.idFactory = options.idFactory ?? (() => crypto.randomUUID())
     this.now = options.now ?? (() => new Date().toISOString())
+    this.publisher = options.publisher
   }
 
   async run(request: BotRenderJobRequest, options: BotRenderJobRunOptions = {}): Promise<BotRenderJobResult> {
@@ -103,14 +108,15 @@ export class NodeRenderJobService implements IRenderJobService {
         return { job, events: [...job.events] }
       }
 
-      await this.waitForVideoJob(job, providerJobId, options)
+      const shouldPublish = this.shouldPublish(request)
+      await this.waitForVideoJob(job, providerJobId, options, shouldPublish)
 
-      if (job.status === "done") {
-        job.artifact = {
-          type: "file",
-          path: outputPath,
-          destination: request.output.destination ?? "file",
-          mimeType: "video/mp4",
+      if (job.status === "done" || (shouldPublish && job.status === "rendering")) {
+        const artifact = this.createFileArtifact(outputPath)
+        if (shouldPublish) {
+          await this.publishArtifact(job, artifact, request)
+        } else {
+          job.artifact = artifact
         }
         await this.publishSnapshot(job)
       }
@@ -188,6 +194,7 @@ export class NodeRenderJobService implements IRenderJobService {
     job: BotRenderJob,
     providerJobId: string,
     options: BotRenderJobRunOptions,
+    shouldPublish: boolean,
   ): Promise<void> {
     const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS
     const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
@@ -199,13 +206,17 @@ export class NodeRenderJobService implements IRenderJobService {
       const videoJob = await this.readVideoJob(providerJobId)
 
       if (!videoJob) {
-        await this.emit(job, "done", 100, "Render job completed")
+        await this.emit(job, shouldPublish ? "rendering" : "done", shouldPublish ? 90 : 100, "Render job completed")
         return
       }
 
       const status = normalizeVideoStatus(videoJob.status)
       const progress = typeof videoJob.progress === "number" ? videoJob.progress : job.progress
-      await this.emit(job, status, status === "done" ? 100 : progress, `Render status: ${status}`)
+      if (status === "done" && shouldPublish) {
+        await this.emit(job, "rendering", 90, "Render job completed")
+      } else {
+        await this.emit(job, status, status === "done" ? 100 : progress, `Render status: ${status}`)
+      }
 
       if (status === "done") return
       if (status === "cancelled") return
@@ -226,6 +237,73 @@ export class NodeRenderJobService implements IRenderJobService {
       const activeJobs = await this.video.getActiveJobs()
       return activeJobs.find((job) => job.id === providerJobId) ?? null
     }
+  }
+
+  private shouldPublish(request: BotRenderJobRequest): boolean {
+    return Boolean(request.output.destination && request.output.destination !== "file")
+  }
+
+  private createFileArtifact(outputPath: string): BotRenderJobArtifact {
+    return {
+      type: "file",
+      path: outputPath,
+      destination: "file",
+      mimeType: "video/mp4",
+    }
+  }
+
+  private async publishArtifact(
+    job: BotRenderJob,
+    artifact: BotRenderJobArtifact,
+    request: BotRenderJobRequest,
+  ): Promise<void> {
+    const destination = request.output.destination
+    if (!destination || destination === "file") {
+      job.artifact = artifact
+      return
+    }
+
+    if (!this.publisher) {
+      throw new Error(`Publish service is not configured for ${destination}`)
+    }
+
+    await this.emit(job, "publishing", 95, `Publishing render artifact to ${destination}`)
+    const publication = await this.publisher.publish({
+      jobId: job.id,
+      destination,
+      artifact,
+      metadata: this.resolvePublishMetadata(request),
+      params: request.params,
+    })
+
+    job.publications = [...(job.publications ?? []), publication]
+
+    if (publication.status !== "done" || !publication.artifact) {
+      throw new Error(publication.error ?? `Publishing to ${destination} failed`)
+    }
+
+    job.artifact = publication.artifact
+    await this.emit(job, "done", 100, `Published render artifact to ${destination}`)
+  }
+
+  private resolvePublishMetadata(request: BotRenderJobRequest): BotPublishMetadata {
+    const params = request.params ?? {}
+    const metadata: BotPublishMetadata = {}
+    const title = stringParam(params.title)
+    const description = stringParam(params.description)
+    const caption = stringParam(params.caption)
+    const chatId = stringParam(params.chatId) ?? stringParam(params.telegramChatId)
+    const tags = stringArrayParam(params.tags)
+    const visibility = visibilityParam(params.visibility)
+
+    if (title) metadata.title = title
+    if (description) metadata.description = description
+    if (caption) metadata.caption = caption
+    if (chatId) metadata.chatId = chatId
+    if (tags) metadata.tags = tags
+    if (visibility) metadata.visibility = visibility
+
+    return metadata
   }
 
   private async emit(job: BotRenderJob, status: BotRenderJobStatus, progress: number, message: string): Promise<void> {
@@ -275,4 +353,28 @@ export class NodeRenderJobService implements IRenderJobService {
       await sink.publishSnapshot?.(snapshot)
     }
   }
+}
+
+function stringParam(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined
+}
+
+function stringArrayParam(value: unknown): string[] | undefined {
+  if (Array.isArray(value)) {
+    const tags = value.filter((item): item is string => typeof item === "string" && item.trim().length > 0)
+    return tags.length > 0 ? tags.map((item) => item.trim()) : undefined
+  }
+
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value
+      .split(",")
+      .map((item) => item.trim())
+      .filter(Boolean)
+  }
+
+  return undefined
+}
+
+function visibilityParam(value: unknown): "private" | "unlisted" | "public" | undefined {
+  return value === "private" || value === "unlisted" || value === "public" ? value : undefined
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -24,6 +24,7 @@ export type {
   ILanguageService,
   INodeBackendService,
   IPlatformService,
+  IPublishService,
   IRenderJobService,
   IStorageService,
   NodeBackendHealth,
@@ -50,6 +51,10 @@ export {
 export type {
   BotMediaAttachment,
   BotMediaAttachmentType,
+  BotPublishMetadata,
+  BotPublishRequest,
+  BotPublishResult,
+  BotPublishStatus,
   BotRenderJob,
   BotRenderJobArtifact,
   BotRenderJobDestination,

--- a/src/core/ports/index.ts
+++ b/src/core/ports/index.ts
@@ -70,6 +70,7 @@ export type {
   OpenDialogOptions,
   SaveDialogOptions,
 } from "./platform.port"
+export type { IPublishService } from "./publish.port"
 export type { IRenderJobService } from "./render-job.port"
 export type { IStorageService } from "./storage.port"
 export type {

--- a/src/core/ports/publish.port.ts
+++ b/src/core/ports/publish.port.ts
@@ -1,0 +1,6 @@
+import type { BotPublishRequest, BotPublishResult, BotRenderJobDestination } from "../types"
+
+export interface IPublishService {
+  canPublish(destination: BotRenderJobDestination): boolean
+  publish(request: BotPublishRequest): Promise<BotPublishResult>
+}

--- a/src/core/services/render-job-events.ts
+++ b/src/core/services/render-job-events.ts
@@ -25,6 +25,7 @@ export function createBotRenderJobSnapshot(job: BotRenderJob): BotRenderJobSnaps
     status: job.status,
     progress: job.progress,
     ...(job.artifact ? { artifact: job.artifact } : {}),
+    ...(job.publications ? { publications: job.publications } : {}),
     ...(job.error ? { error: job.error } : {}),
     createdAt: job.createdAt,
     updatedAt: job.updatedAt,

--- a/src/core/types/render-job.ts
+++ b/src/core/types/render-job.ts
@@ -11,6 +11,8 @@ export type BotRenderJobStatus = "queued" | "preparing" | "rendering" | "publish
 
 export type BotRenderJobDestination = "file" | "telegram" | "youtube" | "tiktok" | "vimeo"
 
+export type BotPublishStatus = "done" | "failed" | "unsupported"
+
 export interface BotRenderJobMediaInput {
   type: "file" | "url"
   value: string
@@ -54,6 +56,34 @@ export interface BotRenderJobArtifact {
   mimeType?: string
 }
 
+export interface BotPublishMetadata {
+  title?: string
+  description?: string
+  caption?: string
+  chatId?: string
+  tags?: string[]
+  visibility?: "private" | "unlisted" | "public"
+  provider?: Record<string, unknown>
+}
+
+export interface BotPublishRequest {
+  jobId?: string
+  destination: BotRenderJobDestination
+  artifact: BotRenderJobArtifact
+  metadata?: BotPublishMetadata
+  params?: Record<string, unknown>
+}
+
+export interface BotPublishResult {
+  destination: BotRenderJobDestination
+  status: BotPublishStatus
+  artifact?: BotRenderJobArtifact
+  providerId?: string
+  url?: string
+  error?: string
+  metadata?: BotPublishMetadata
+}
+
 export interface BotRenderJobEvent {
   jobId: string
   sequence: number
@@ -69,6 +99,7 @@ export interface BotRenderJobSnapshot {
   status: BotRenderJobStatus
   progress: number
   artifact?: BotRenderJobArtifact
+  publications?: BotPublishResult[]
   error?: string
   createdAt: string
   updatedAt: string
@@ -104,6 +135,7 @@ export interface BotRenderJob {
   progress: number
   request: BotRenderJobRequest
   artifact?: BotRenderJobArtifact
+  publications?: BotPublishResult[]
   error?: string
   createdAt: string
   updatedAt: string


### PR DESCRIPTION
## Summary

- add `IPublishService` plus publish request/result metadata contracts
- add Node publish adapter with file baseline and Telegram via injectable client
- wire `NodeRenderJobService` to enter `publishing` for non-file destinations and store publication results
- include publications in render job snapshots for bot reconnect
- update bot-first roadmap and add focused tests for file, Telegram, unsupported destinations, and render-job publish phase

## Verification

- `bun run check:type`
- `bun run check:workspaces`
- `bun run check:boundaries`
- `bun run check:boundaries:baseline`
- `bun run test -- src/adapters/node/__tests__/publish.test.ts src/adapters/node/__tests__/render-job.test.ts src/core/services/__tests__/render-job-events.test.ts src/cli/commands/__tests__/render-job.test.ts`
- `bunx biome ci` on changed files
- `git diff --check`

Refs #171
Closes #177