### PR TITLE
feat: add rust render adapter for bot jobs

### DIFF
--- a/docs/08_tasks/planned/bot-first-workflow.md
+++ b/docs/08_tasks/planned/bot-first-workflow.md
@@ -66,6 +66,15 @@ bot message
 - [x] Добавить destination-specific publishing adapters.
 - [x] Связать publish phase с `BotRenderJobStatus = "publishing"`.
 
+### B5: Rust render adapter ([#179](https://github.com/chatman-media/timeline-studio/issues/179))
+
+**Цель:** подключить bot-first render job к вынесенному Rust `ts-render`, а не к старой Node ffmpeg-concat реализации.
+
+- [x] Добавить Node `IVideoService` adapter поверх `timeline render` / `timeline-render --project`.
+- [x] Добавить opt-in wiring через `initNodeApp({ rustRender })`.
+- [x] Добавить CLI-флаги `render-job --rust-render`.
+- [x] Покрыть completed/failed/cancel scenarios.
+
 ## Связанные задачи
 
 - [#150](https://github.com/chatman-media/timeline-studio/issues/150) - Phase F / package boundaries
@@ -73,6 +82,7 @@ bot message
 - [#173](https://github.com/chatman-media/timeline-studio/issues/173) - B2: Bot intake contract
 - [#175](https://github.com/chatman-media/timeline-studio/issues/175) - B3: Worker event stream
 - [#177](https://github.com/chatman-media/timeline-studio/issues/177) - B4: Publishing destinations
+- [#179](https://github.com/chatman-media/timeline-studio/issues/179) - B5: Rust render adapter for bot jobs
 - [telegram-mini-app.md](./telegram-mini-app.md)
 - [cloud-rendering.md](./cloud-rendering.md)
 - [export-architecture-refactoring.md](./export-architecture-refactoring.md)

--- a/src/adapters/node/__tests__/rust-render-video.test.ts
+++ b/src/adapters/node/__tests__/rust-render-video.test.ts
@@ -1,0 +1,116 @@
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { NodeRustRenderVideoService } from "../rust-render-video"
+
+describe("NodeRustRenderVideoService", () => {
+  let tempDir: string
+  let nowTick = 0
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "rust-render-video-service-"))
+    nowTick = 0
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  it("runs a ProjectSchema through a Rust render command", async () => {
+    const outputPath = path.join(tempDir, "out.mp4")
+    const service = new NodeRustRenderVideoService({
+      tempDir,
+      idFactory: () => "rust-job-1",
+      now: () => `2026-06-08T00:00:0${nowTick++}.000Z`,
+      renderCommand: (projectPath, outputPath) => ({
+        command: process.execPath,
+        args: [
+          "-e",
+          [
+            "const fs = require('node:fs')",
+            "const [projectPath, outputPath] = process.argv.slice(1)",
+            "JSON.parse(fs.readFileSync(projectPath, 'utf8'))",
+            "process.stdout.write('..')",
+            "fs.writeFileSync(outputPath, 'rendered')",
+          ].join(";"),
+          projectPath,
+          outputPath,
+        ],
+      }),
+    })
+
+    const jobId = await service.renderProject({ name: "project" }, outputPath)
+
+    expect(jobId).toBe("rust-job-1")
+    await vi.waitFor(async () => {
+      await expect(service.getRenderJob(jobId)).resolves.toMatchObject({
+        status: "completed",
+        progress: 100,
+        outputPath,
+      })
+    })
+    await expect(fs.readFile(outputPath, "utf-8")).resolves.toBe("rendered")
+    await expect(fs.access(path.join(tempDir, "rust-job-1.project.json"))).rejects.toThrow()
+  })
+
+  it("marks a rust render command failure as a failed render job", async () => {
+    const service = new NodeRustRenderVideoService({
+      tempDir,
+      idFactory: () => "rust-job-2",
+      renderCommand: (projectPath, outputPath) => ({
+        command: process.execPath,
+        args: [
+          "-e",
+          [
+            "const [projectPath, outputPath] = process.argv.slice(1)",
+            "void projectPath",
+            "void outputPath",
+            "process.stderr.write('rust render failed')",
+            "process.exit(7)",
+          ].join(";"),
+          projectPath,
+          outputPath,
+        ],
+      }),
+    })
+
+    const jobId = await service.renderProject({ name: "project" }, path.join(tempDir, "failed.mp4"))
+
+    await vi.waitFor(async () => {
+      await expect(service.getRenderJob(jobId)).resolves.toMatchObject({
+        status: "failed",
+        error: "rust render failed",
+      })
+    })
+  })
+
+  it("can cancel a rust render process", async () => {
+    const service = new NodeRustRenderVideoService({
+      tempDir,
+      idFactory: () => "rust-job-3",
+      renderCommand: (projectPath, outputPath) => ({
+        command: process.execPath,
+        args: [
+          "-e",
+          [
+            "const [projectPath, outputPath] = process.argv.slice(1)",
+            "void projectPath",
+            "void outputPath",
+            "setTimeout(() => {}, 10000)",
+          ].join(";"),
+          projectPath,
+          outputPath,
+        ],
+      }),
+    })
+
+    const jobId = await service.renderProject({ name: "project" }, path.join(tempDir, "cancelled.mp4"))
+
+    await expect(service.cancelRender(jobId)).resolves.toBe(true)
+    await expect(service.getRenderJob(jobId)).resolves.toMatchObject({
+      status: "cancelled",
+      progress: 0,
+    })
+  })
+})

--- a/src/adapters/node/index.ts
+++ b/src/adapters/node/index.ts
@@ -16,6 +16,7 @@ import { NodeBackendBridgeService } from "./node-backend-bridge"
 import { type NodePlatformOptions, NodePlatformService } from "./platform"
 import { type NodePublishOptions, NodePublishService } from "./publish"
 import { NodeRenderJobService, type NodeRenderJobServiceOptions } from "./render-job"
+import { type NodeRustRenderVideoOptions, NodeRustRenderVideoService } from "./rust-render-video"
 import { type NodeStorageOptions, NodeStorageService } from "./storage"
 import { type NodeVideoOptions, NodeVideoService } from "./video"
 
@@ -29,6 +30,7 @@ export { NodeBackendBridgeService } from "./node-backend-bridge"
 export { type NodePlatformOptions, NodePlatformService } from "./platform"
 export { type NodePublishOptions, NodePublishService } from "./publish"
 export { NodeRenderJobService, type NodeRenderJobServiceOptions } from "./render-job"
+export { type NodeRustRenderVideoOptions, NodeRustRenderVideoService } from "./rust-render-video"
 export { type NodeStorageOptions, NodeStorageService } from "./storage"
 export { type NodeVideoOptions, NodeVideoService } from "./video"
 
@@ -41,6 +43,8 @@ export interface NodeAppOptions {
   media?: NodeMediaOptions
   /** Опции для Video сервиса */
   video?: NodeVideoOptions
+  /** Опции для Rust headless render adapter */
+  rustRender?: boolean | NodeRustRenderVideoOptions
   /** Опции для AI сервиса */
   ai?: NodeAIOptions
   /** Опции для Backend сервиса */
@@ -99,7 +103,7 @@ export async function initNodeApp(options: NodeAppOptions = {}): Promise<NodeApp
   const event = new NodeEventService()
   const media = new NodeMediaService(options.media)
   const nodeBackend = new NodeBackendBridgeService()
-  const video = new NodeVideoService(options.video)
+  const video = createNodeVideoService(options.video, options.rustRender)
   const ai = new NodeAIService(options.ai)
   const language = new NodeLanguageService(options.language)
   const publish = new NodePublishService(options.publish)
@@ -147,7 +151,7 @@ export async function initNodeApp(options: NodeAppOptions = {}): Promise<NodeApp
  * @returns Объект со всеми сервисами
  */
 export function createNodeServices(options: NodeAppOptions = {}): NodeAppServices {
-  const video = new NodeVideoService(options.video)
+  const video = createNodeVideoService(options.video, options.rustRender)
   const publish = new NodePublishService(options.publish)
 
   return {
@@ -166,4 +170,16 @@ export function createNodeServices(options: NodeAppOptions = {}): NodeAppService
       publisher: options.renderJob?.publisher ?? publish,
     }),
   }
+}
+
+function createNodeVideoService(
+  videoOptions?: NodeVideoOptions,
+  rustRenderOptions?: boolean | NodeRustRenderVideoOptions,
+): NodeVideoService {
+  if (!rustRenderOptions) {
+    return new NodeVideoService(videoOptions)
+  }
+
+  const options = rustRenderOptions === true ? videoOptions : { ...videoOptions, ...rustRenderOptions }
+  return new NodeRustRenderVideoService(options)
 }

--- a/src/adapters/node/rust-render-video.ts
+++ b/src/adapters/node/rust-render-video.ts
@@ -1,0 +1,254 @@
+import { type ChildProcess, type SpawnOptions, spawn } from "node:child_process"
+import crypto from "node:crypto"
+import fs from "node:fs"
+import fsPromises from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+
+import type { RenderJob, RenderProgress } from "@/core/ports"
+
+import { type NodeVideoOptions, NodeVideoService } from "./video"
+
+export type NodeRustRenderCommandKind = "timeline" | "timeline-render"
+
+export interface NodeRustRenderCommand {
+  command: string
+  args: string[]
+  cwd?: string
+  env?: Record<string, string | undefined>
+}
+
+export interface NodeRustRenderVideoOptions extends NodeVideoOptions {
+  command?: string
+  commandKind?: NodeRustRenderCommandKind
+  cwd?: string
+  tempDir?: string
+  idFactory?: () => string
+  now?: () => string
+  renderCommand?: (projectPath: string, outputPath: string) => NodeRustRenderCommand
+}
+
+interface RustActiveJob {
+  process: ChildProcess
+  job: RenderJob
+  progress: RenderProgress
+  projectPath: string
+  stderr: string
+  stdout: string
+}
+
+export class NodeRustRenderVideoService extends NodeVideoService {
+  private readonly rustJobs = new Map<string, RustActiveJob>()
+  private readonly tempDir: string
+  private readonly command?: string
+  private readonly commandKind?: NodeRustRenderCommandKind
+  private readonly cwd?: string
+  private readonly idFactory: () => string
+  private readonly now: () => string
+  private readonly renderCommand?: (projectPath: string, outputPath: string) => NodeRustRenderCommand
+
+  constructor(options: NodeRustRenderVideoOptions = {}) {
+    super(options)
+    this.tempDir = options.tempDir ?? path.join(os.tmpdir(), "timeline-studio-rust-render")
+    this.command = options.command
+    this.commandKind = options.commandKind
+    this.cwd = options.cwd
+    this.idFactory = options.idFactory ?? (() => crypto.randomUUID())
+    this.now = options.now ?? (() => new Date().toISOString())
+    this.renderCommand = options.renderCommand
+  }
+
+  override async renderProject(projectSchema: unknown, outputPath: string): Promise<string> {
+    await fsPromises.mkdir(this.tempDir, { recursive: true })
+    await fsPromises.mkdir(path.dirname(path.resolve(outputPath)), { recursive: true })
+
+    const jobId = this.idFactory()
+    const projectPath = path.join(this.tempDir, `${jobId}.project.json`)
+    await fsPromises.writeFile(projectPath, JSON.stringify(projectSchema, null, 2))
+
+    const command = this.resolveCommand(projectPath, path.resolve(outputPath))
+    const child = spawn(command.command, command.args, this.resolveSpawnOptions(command))
+    const job: RenderJob = {
+      id: jobId,
+      status: "running",
+      progress: 0,
+      outputPath: path.resolve(outputPath),
+      startedAt: this.now(),
+    }
+    const progress: RenderProgress = {
+      jobId,
+      progress: 0,
+      stage: "rendering",
+      currentFrame: 0,
+      totalFrames: 0,
+      eta: 0,
+    }
+    const activeJob: RustActiveJob = {
+      process: child,
+      job,
+      progress,
+      projectPath,
+      stderr: "",
+      stdout: "",
+    }
+
+    this.rustJobs.set(jobId, activeJob)
+    this.attachProcessListeners(activeJob)
+
+    return jobId
+  }
+
+  override async getActiveJobs(): Promise<RenderJob[]> {
+    return Array.from(this.rustJobs.values()).map((entry) => entry.job)
+  }
+
+  override async getRenderJob(jobId: string): Promise<RenderJob> {
+    const activeJob = this.rustJobs.get(jobId)
+    if (!activeJob) {
+      throw new Error(`Job not found: ${jobId}`)
+    }
+    return activeJob.job
+  }
+
+  override async getRenderProgress(jobId: string): Promise<RenderProgress> {
+    const activeJob = this.rustJobs.get(jobId)
+    if (!activeJob) {
+      throw new Error(`Job not found: ${jobId}`)
+    }
+    return activeJob.progress
+  }
+
+  override async cancelRender(jobId: string): Promise<boolean> {
+    const activeJob = this.rustJobs.get(jobId)
+    if (!activeJob) return false
+
+    activeJob.job.status = "cancelled"
+    activeJob.job.completedAt = this.now()
+    activeJob.progress.stage = "cancelled"
+    activeJob.process.kill("SIGTERM")
+    return true
+  }
+
+  private resolveCommand(projectPath: string, outputPath: string): NodeRustRenderCommand {
+    if (this.renderCommand) {
+      return this.renderCommand(projectPath, outputPath)
+    }
+
+    const command = this.command ?? defaultRustRenderCommand()
+    const commandKind = this.commandKind ?? inferCommandKind(command)
+
+    if (commandKind === "timeline-render") {
+      return {
+        command,
+        args: ["--project", projectPath, outputPath],
+        cwd: this.cwd,
+      }
+    }
+
+    return {
+      command,
+      args: ["render", projectPath, outputPath],
+      cwd: this.cwd,
+    }
+  }
+
+  private resolveSpawnOptions(command: NodeRustRenderCommand): SpawnOptions {
+    return {
+      cwd: command.cwd ?? this.cwd,
+      env: {
+        ...process.env,
+        ...command.env,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    }
+  }
+
+  private attachProcessListeners(activeJob: RustActiveJob): void {
+    activeJob.process.stdout?.on("data", (chunk: Buffer | string) => {
+      const text = chunk.toString()
+      activeJob.stdout += text
+      this.advanceProgress(activeJob, text)
+    })
+
+    activeJob.process.stderr?.on("data", (chunk: Buffer | string) => {
+      activeJob.stderr += chunk.toString()
+    })
+
+    activeJob.process.on("error", (error) => {
+      this.markFailed(activeJob, error.message)
+    })
+
+    activeJob.process.on("close", (code, signal) => {
+      void this.finalizeProcess(activeJob, code, signal)
+    })
+  }
+
+  private advanceProgress(activeJob: RustActiveJob, text: string): void {
+    const dotCount = (text.match(/\./g) ?? []).length
+    if (dotCount === 0) return
+
+    activeJob.progress.progress = Math.min(90, activeJob.progress.progress + dotCount * 5)
+    activeJob.job.progress = activeJob.progress.progress
+  }
+
+  private async finalizeProcess(activeJob: RustActiveJob, code: number | null, signal: NodeJS.Signals | null) {
+    await fsPromises.unlink(activeJob.projectPath).catch(() => {})
+
+    if (activeJob.job.status === "cancelled") {
+      return
+    }
+
+    if (code !== 0) {
+      this.markFailed(
+        activeJob,
+        activeJob.stderr.trim() || `Rust render command exited with code ${code ?? "null"} signal ${signal ?? "none"}`,
+      )
+      return
+    }
+
+    try {
+      const stats = await fsPromises.stat(activeJob.job.outputPath ?? "")
+      if (stats.size <= 0) {
+        this.markFailed(activeJob, "Rust render command produced an empty output file")
+        return
+      }
+    } catch (error) {
+      this.markFailed(activeJob, error instanceof Error ? error.message : String(error))
+      return
+    }
+
+    activeJob.job.status = "completed"
+    activeJob.job.completedAt = this.now()
+    activeJob.job.progress = 100
+    activeJob.progress.progress = 100
+    activeJob.progress.stage = "completed"
+  }
+
+  private markFailed(activeJob: RustActiveJob, error: string): void {
+    if (activeJob.job.status === "cancelled") return
+
+    activeJob.job.status = "failed"
+    activeJob.job.completedAt = this.now()
+    activeJob.job.error = error
+    activeJob.job.progress = 0
+    activeJob.progress.progress = 0
+    activeJob.progress.stage = "failed"
+  }
+}
+
+function inferCommandKind(command: string): NodeRustRenderCommandKind {
+  return path.basename(command).includes("timeline-render") ? "timeline-render" : "timeline"
+}
+
+function defaultRustRenderCommand(): string {
+  const workspaceTimeline = path.resolve(process.cwd(), "crates/target/debug/timeline")
+  if (fs.existsSync(workspaceTimeline)) return workspaceTimeline
+
+  const workspaceTimelineRender = path.resolve(process.cwd(), "crates/target/debug/timeline-render")
+  if (fs.existsSync(workspaceTimelineRender)) return workspaceTimelineRender
+
+  const localTimelineRender = path.resolve(process.cwd(), "crates/ts-render/target/debug/timeline-render")
+  if (fs.existsSync(localTimelineRender)) return localTimelineRender
+
+  return "timeline"
+}

--- a/src/cli/commands/__tests__/render-job.test.ts
+++ b/src/cli/commands/__tests__/render-job.test.ts
@@ -25,6 +25,8 @@ describe("render-job command", () => {
     expect(renderJobCommand.registeredArguments[0].name()).toBe("job")
     expect(renderJobCommand.options.some((option) => option.long === "--status-file")).toBe(true)
     expect(renderJobCommand.options.some((option) => option.long === "--pretty")).toBe(true)
+    expect(renderJobCommand.options.some((option) => option.long === "--rust-render")).toBe(true)
+    expect(renderJobCommand.options.some((option) => option.long === "--rust-render-command")).toBe(true)
   })
 
   it("reads render job JSON and defaults source to cli", async () => {

--- a/src/cli/commands/render-job.ts
+++ b/src/cli/commands/render-job.ts
@@ -17,6 +17,9 @@ export interface RenderJobCommandOptions {
   pretty?: boolean
   pollInterval?: string
   timeout?: string
+  rustRender?: boolean
+  rustRenderCommand?: string
+  rustRenderKind?: "timeline" | "timeline-render"
 }
 
 export const renderJobCommand = new Command("render-job")
@@ -26,6 +29,9 @@ export const renderJobCommand = new Command("render-job")
   .option("--pretty", "Pretty-print JSON output")
   .option("--poll-interval <ms>", "Render polling interval in milliseconds", "1000")
   .option("--timeout <ms>", "Render timeout in milliseconds", "3600000")
+  .option("--rust-render", "Run rendering through the Rust headless ts-render CLI")
+  .option("--rust-render-command <path>", "Path/name for timeline or timeline-render command")
+  .option("--rust-render-kind <kind>", "Rust render command kind: timeline or timeline-render")
   .action(async (jobFile: string, options: RenderJobCommandOptions) => {
     try {
       const result = await runRenderJobFile(jobFile, options)
@@ -69,7 +75,15 @@ export async function runRenderJobFile(
   options: RenderJobCommandOptions = {},
 ): Promise<BotRenderJobResult> {
   const request = await readRenderJobRequest(jobFile)
-  const services = await initNodeApp({ autoConnect: false })
+  const services = await initNodeApp({
+    autoConnect: false,
+    rustRender: options.rustRender
+      ? {
+          command: options.rustRenderCommand,
+          commandKind: options.rustRenderKind,
+        }
+      : undefined,
+  })
 
   return services.renderJob.run(request, {
     pollIntervalMs: parsePositiveInteger(options.pollInterval, 1000),


### PR DESCRIPTION
## Summary

- add `NodeRustRenderVideoService`, an `IVideoService` adapter backed by Rust `timeline render` / `timeline-render --project`
- keep existing Node ffmpeg-concat video service as default while adding opt-in `initNodeApp({ rustRender })` wiring
- add `render-job --rust-render` CLI flags for bot-first jobs to use the Rust headless render core
- track completed, failed, and cancelled Rust render processes as render jobs
- update the bot-first roadmap and add focused process-level tests

## Verification

- `bun run check:type`
- `bun run check:workspaces`
- `bun run check:boundaries`
- `bun run check:boundaries:baseline`
- `bun run test -- src/adapters/node/__tests__/rust-render-video.test.ts src/adapters/node/__tests__/render-job.test.ts src/cli/commands/__tests__/render-job.test.ts`
- `bunx biome ci` on changed files
- `git diff --check`

Refs #171
Closes #179