### PR TITLE
feat: add bot workflow runner

### DIFF
--- a/docs/08_tasks/planned/bot-first-workflow.md
+++ b/docs/08_tasks/planned/bot-first-workflow.md
@@ -75,6 +75,16 @@ bot message
 - [x] Добавить CLI-флаги `render-job --rust-render`.
 - [x] Покрыть completed/failed/cancel scenarios.
 
+### B6: Bot workflow runner ([#181](https://github.com/chatman-media/timeline-studio/issues/181))
+
+**Цель:** связать Telegram-like payload -> intake -> render job -> event stream -> result в один worker-friendly workflow.
+
+- [x] Добавить core runner поверх `BotWorkflowRequest` и `IRenderJobService`.
+- [x] Добавить Node service wiring для CLI/worker использования без React/Tauri состояния.
+- [x] Добавить CLI-команду `bot-workflow <payload.json>` с JSON output/status file.
+- [x] Возвращать validation errors, render result и reconnect state для бота.
+- [x] Покрыть success/validation/event stream/CLI contract tests.
+
 ## Связанные задачи
 
 - [#150](https://github.com/chatman-media/timeline-studio/issues/150) - Phase F / package boundaries
@@ -83,6 +93,7 @@ bot message
 - [#175](https://github.com/chatman-media/timeline-studio/issues/175) - B3: Worker event stream
 - [#177](https://github.com/chatman-media/timeline-studio/issues/177) - B4: Publishing destinations
 - [#179](https://github.com/chatman-media/timeline-studio/issues/179) - B5: Rust render adapter for bot jobs
+- [#181](https://github.com/chatman-media/timeline-studio/issues/181) - B6: Bot workflow runner
 - [telegram-mini-app.md](./telegram-mini-app.md)
 - [cloud-rendering.md](./cloud-rendering.md)
 - [export-architecture-refactoring.md](./export-architecture-refactoring.md)

--- a/src/adapters/node/__tests__/bot-workflow.test.ts
+++ b/src/adapters/node/__tests__/bot-workflow.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest"
+import { InMemoryBotRenderJobEventStream } from "@/core/services"
+import type {
+  BotRenderJob,
+  BotRenderJobEvent,
+  BotRenderJobRequest,
+  BotRenderJobResult,
+  BotRenderJobRunOptions,
+  BotRenderJobSnapshot,
+} from "@/core/types"
+import { NodeBotWorkflowService } from "../bot-workflow"
+import type { NodeRenderJobService } from "../render-job"
+
+function createRenderJobService() {
+  const run = vi.fn(async (request: BotRenderJobRequest, options: BotRenderJobRunOptions = {}) => {
+    const event: BotRenderJobEvent = {
+      jobId: "job-1",
+      sequence: 0,
+      status: "done",
+      progress: 100,
+      timestamp: "2026-06-08T00:00:00.000Z",
+    }
+    const job: BotRenderJob = {
+      id: "job-1",
+      status: "done",
+      progress: 100,
+      request,
+      createdAt: "2026-06-08T00:00:00.000Z",
+      updatedAt: "2026-06-08T00:00:01.000Z",
+      events: [event],
+    }
+    const snapshot: BotRenderJobSnapshot = {
+      jobId: "job-1",
+      status: "done",
+      progress: 100,
+      createdAt: job.createdAt,
+      updatedAt: job.updatedAt,
+      eventCount: 1,
+      lastEvent: event,
+      canCancel: false,
+      canRetry: false,
+    }
+
+    for (const sink of options.eventSinks ?? []) {
+      await sink.publish(event, snapshot)
+    }
+
+    return { job, events: [event] } satisfies BotRenderJobResult
+  })
+
+  return {
+    service: {
+      run,
+      getJob: vi.fn(),
+      cancelJob: vi.fn(),
+    } as unknown as NodeRenderJobService,
+    run,
+  }
+}
+
+describe("NodeBotWorkflowService", () => {
+  it("runs Telegram-like payloads with merged defaults, caller options, and event stream", async () => {
+    const { service: renderJob, run } = createRenderJobService()
+    const defaultSink = { publish: vi.fn() }
+    const callerSink = { publish: vi.fn() }
+    const eventStream = new InMemoryBotRenderJobEventStream()
+    const botWorkflow = new NodeBotWorkflowService(renderJob, {
+      intake: { defaultDestination: "file" },
+      render: { pollIntervalMs: 7, eventSinks: [defaultSink] },
+    })
+
+    const result = await botWorkflow.runTelegramLikePayload(
+      {
+        caption: 'project="./project.json"',
+      },
+      {
+        eventStream,
+        render: { timeoutMs: 9, eventSinks: [callerSink] },
+      },
+    )
+
+    expect(result.ok).toBe(true)
+    expect(run).toHaveBeenCalledOnce()
+
+    const [, options] = run.mock.calls[0]
+    expect(options).toMatchObject({ pollIntervalMs: 7, timeoutMs: 9 })
+    expect(options?.eventSinks).toHaveLength(3)
+    expect(defaultSink.publish).toHaveBeenCalledOnce()
+    expect(callerSink.publish).toHaveBeenCalledOnce()
+    expect(eventStream.getSnapshot("job-1")).toMatchObject({ status: "done" })
+  })
+})

--- a/src/adapters/node/bot-workflow.ts
+++ b/src/adapters/node/bot-workflow.ts
@@ -1,0 +1,73 @@
+import { InMemoryBotRenderJobEventStream, runBotWorkflow, runTelegramLikeBotWorkflow } from "@/core/services"
+import type {
+  BotWorkflowRequest,
+  BotWorkflowRunOptions,
+  BotWorkflowRunResult,
+  TelegramLikeBotPayload,
+} from "@/core/types"
+
+import type { NodeRenderJobService } from "./render-job"
+
+export interface NodeBotWorkflowServiceOptions extends BotWorkflowRunOptions {
+  eventStream?: InMemoryBotRenderJobEventStream
+}
+
+export class NodeBotWorkflowService {
+  constructor(
+    private readonly renderJob: NodeRenderJobService,
+    private readonly defaults: NodeBotWorkflowServiceOptions = {},
+  ) {}
+
+  async runWorkflow(
+    workflow: BotWorkflowRequest,
+    options: NodeBotWorkflowServiceOptions = {},
+  ): Promise<BotWorkflowRunResult> {
+    const eventStream = options.eventStream ?? this.defaults.eventStream ?? new InMemoryBotRenderJobEventStream()
+
+    return runBotWorkflow(workflow, {
+      renderJob: this.renderJob,
+      intake: mergeOptions(this.defaults.intake, options.intake),
+      render: mergeRenderOptions(this.defaults.render, options.render),
+      includeReconnectState: options.includeReconnectState ?? this.defaults.includeReconnectState ?? true,
+      eventStream,
+    })
+  }
+
+  async runTelegramLikePayload(
+    payload: TelegramLikeBotPayload,
+    options: NodeBotWorkflowServiceOptions = {},
+  ): Promise<BotWorkflowRunResult> {
+    const eventStream = options.eventStream ?? this.defaults.eventStream ?? new InMemoryBotRenderJobEventStream()
+
+    return runTelegramLikeBotWorkflow(payload, {
+      renderJob: this.renderJob,
+      intake: mergeOptions(this.defaults.intake, options.intake),
+      render: mergeRenderOptions(this.defaults.render, options.render),
+      includeReconnectState: options.includeReconnectState ?? this.defaults.includeReconnectState ?? true,
+      eventStream,
+    })
+  }
+}
+
+function mergeOptions<T extends object>(defaults: T | undefined, overrides: T | undefined): T | undefined {
+  if (!defaults && !overrides) return undefined
+  return {
+    ...defaults,
+    ...overrides,
+  } as T
+}
+
+function mergeRenderOptions(
+  defaults: BotWorkflowRunOptions["render"],
+  overrides: BotWorkflowRunOptions["render"],
+): BotWorkflowRunOptions["render"] {
+  const merged = mergeOptions(defaults, overrides)
+  const eventSinks = [...(defaults?.eventSinks ?? []), ...(overrides?.eventSinks ?? [])]
+
+  if (eventSinks.length === 0) return merged
+
+  return {
+    ...merged,
+    eventSinks,
+  }
+}

--- a/src/adapters/node/index.ts
+++ b/src/adapters/node/index.ts
@@ -9,6 +9,7 @@ import { container } from "@/core/container"
 
 import { type NodeAIOptions, NodeAIService } from "./ai"
 import { type NodeBackendOptions, NodeBackendService } from "./backend"
+import { NodeBotWorkflowService, type NodeBotWorkflowServiceOptions } from "./bot-workflow"
 import { NodeEventService } from "./event"
 import { type NodeLanguageOptions, NodeLanguageService } from "./language"
 import { type NodeMediaOptions, NodeMediaService } from "./media"
@@ -23,6 +24,7 @@ import { type NodeVideoOptions, NodeVideoService } from "./video"
 // Re-exports
 export { type NodeAIOptions, NodeAIService } from "./ai"
 export { type NodeBackendOptions, NodeBackendService } from "./backend"
+export { NodeBotWorkflowService, type NodeBotWorkflowServiceOptions } from "./bot-workflow"
 export { NodeEventService } from "./event"
 export { type NodeLanguageOptions, NodeLanguageService } from "./language"
 export { type NodeMediaOptions, NodeMediaService } from "./media"
@@ -55,6 +57,8 @@ export interface NodeAppOptions {
   publish?: NodePublishOptions
   /** Опции для bot-first RenderJob сервиса */
   renderJob?: NodeRenderJobServiceOptions
+  /** Опции для bot-first workflow runner */
+  botWorkflow?: NodeBotWorkflowServiceOptions
   /** Автоматически подключаться к бэкенду */
   autoConnect?: boolean
 }
@@ -71,6 +75,7 @@ export interface NodeAppServices {
   language: NodeLanguageService
   publish: NodePublishService
   renderJob: NodeRenderJobService
+  botWorkflow: NodeBotWorkflowService
 }
 
 /**
@@ -111,6 +116,7 @@ export async function initNodeApp(options: NodeAppOptions = {}): Promise<NodeApp
     ...options.renderJob,
     publisher: options.renderJob?.publisher ?? publish,
   })
+  const botWorkflow = new NodeBotWorkflowService(renderJob, options.botWorkflow)
 
   // Register in container
   container.registerBackend(backend)
@@ -140,6 +146,7 @@ export async function initNodeApp(options: NodeAppOptions = {}): Promise<NodeApp
     language,
     publish,
     renderJob,
+    botWorkflow,
   }
 }
 
@@ -153,6 +160,11 @@ export async function initNodeApp(options: NodeAppOptions = {}): Promise<NodeApp
 export function createNodeServices(options: NodeAppOptions = {}): NodeAppServices {
   const video = createNodeVideoService(options.video, options.rustRender)
   const publish = new NodePublishService(options.publish)
+  const renderJob = new NodeRenderJobService(video, {
+    ...options.renderJob,
+    publisher: options.renderJob?.publisher ?? publish,
+  })
+  const botWorkflow = new NodeBotWorkflowService(renderJob, options.botWorkflow)
 
   return {
     backend: new NodeBackendService(options.backend),
@@ -165,10 +177,8 @@ export function createNodeServices(options: NodeAppOptions = {}): NodeAppService
     ai: new NodeAIService(options.ai),
     language: new NodeLanguageService(options.language),
     publish,
-    renderJob: new NodeRenderJobService(video, {
-      ...options.renderJob,
-      publisher: options.renderJob?.publisher ?? publish,
-    }),
+    renderJob,
+    botWorkflow,
   }
 }
 

--- a/src/cli/__tests__/index.integration.test.ts
+++ b/src/cli/__tests__/index.integration.test.ts
@@ -4,8 +4,10 @@
 
 import { Command } from "commander"
 import { describe, expect, it } from "vitest"
+import { botWorkflowCommand } from "../commands/bot-workflow"
 import { infoCommand } from "../commands/info"
 import { renderCommand } from "../commands/render"
+import { renderJobCommand } from "../commands/render-job"
 import { transcribeCommand } from "../commands/transcribe"
 
 describe("Timeline Studio CLI Integration", () => {
@@ -31,14 +33,18 @@ describe("Timeline Studio CLI Integration", () => {
       program.addCommand(infoCommand)
       program.addCommand(transcribeCommand)
       program.addCommand(renderCommand)
+      program.addCommand(renderJobCommand)
+      program.addCommand(botWorkflowCommand)
 
       const commands = program.commands
-      expect(commands).toHaveLength(3)
+      expect(commands).toHaveLength(5)
 
       const commandNames = commands.map((cmd) => cmd.name())
       expect(commandNames).toContain("info")
       expect(commandNames).toContain("transcribe")
       expect(commandNames).toContain("render")
+      expect(commandNames).toContain("render-job")
+      expect(commandNames).toContain("bot-workflow")
     })
   })
 
@@ -90,6 +96,32 @@ describe("Timeline Studio CLI Integration", () => {
       expect(options.some((opt) => opt.long === "--no-audio")).toBe(true)
       expect(options.some((opt) => opt.long === "--verbose")).toBe(true)
     })
+
+    it("should have render-job command properly configured", () => {
+      expect(renderJobCommand.name()).toBe("render-job")
+      expect(renderJobCommand.description()).toBe("Run a bot-first render job from JSON")
+
+      const args = renderJobCommand.registeredArguments
+      expect(args).toHaveLength(1)
+      expect(args[0].name()).toBe("job")
+
+      const options = renderJobCommand.options
+      expect(options.some((opt) => opt.long === "--status-file")).toBe(true)
+      expect(options.some((opt) => opt.long === "--rust-render")).toBe(true)
+    })
+
+    it("should have bot-workflow command properly configured", () => {
+      expect(botWorkflowCommand.name()).toBe("bot-workflow")
+      expect(botWorkflowCommand.description()).toBe("Run a bot-first workflow from Telegram-like JSON")
+
+      const args = botWorkflowCommand.registeredArguments
+      expect(args).toHaveLength(1)
+      expect(args[0].name()).toBe("payload")
+
+      const options = botWorkflowCommand.options
+      expect(options.some((opt) => opt.long === "--status-file")).toBe(true)
+      expect(options.some((opt) => opt.long === "--default-destination")).toBe(true)
+    })
   })
 
   describe("Command options", () => {
@@ -139,6 +171,8 @@ describe("Timeline Studio CLI Integration", () => {
       program.addCommand(infoCommand)
       program.addCommand(transcribeCommand)
       program.addCommand(renderCommand)
+      program.addCommand(renderJobCommand)
+      program.addCommand(botWorkflowCommand)
 
       const helpText = program.helpInformation()
 
@@ -155,12 +189,16 @@ describe("Timeline Studio CLI Integration", () => {
       program.addCommand(infoCommand)
       program.addCommand(transcribeCommand)
       program.addCommand(renderCommand)
+      program.addCommand(renderJobCommand)
+      program.addCommand(botWorkflowCommand)
 
       const helpText = program.helpInformation()
 
       expect(helpText).toContain("info")
       expect(helpText).toContain("transcribe")
       expect(helpText).toContain("render")
+      expect(helpText).toContain("render-job")
+      expect(helpText).toContain("bot-workflow")
     })
   })
 
@@ -227,8 +265,10 @@ describe("Timeline Studio CLI Integration", () => {
         .addCommand(infoCommand)
         .addCommand(transcribeCommand)
         .addCommand(renderCommand)
+        .addCommand(renderJobCommand)
+        .addCommand(botWorkflowCommand)
 
-      expect(program.commands).toHaveLength(3)
+      expect(program.commands).toHaveLength(5)
     })
   })
 
@@ -237,12 +277,16 @@ describe("Timeline Studio CLI Integration", () => {
       expect(infoCommand.name()).toBe("info")
       expect(transcribeCommand.name()).toBe("transcribe")
       expect(renderCommand.name()).toBe("render")
+      expect(renderJobCommand.name()).toBe("render-job")
+      expect(botWorkflowCommand.name()).toBe("bot-workflow")
     })
 
     it("should maintain command descriptions", () => {
       expect(infoCommand.description()).toBeTruthy()
       expect(transcribeCommand.description()).toBeTruthy()
       expect(renderCommand.description()).toBeTruthy()
+      expect(renderJobCommand.description()).toBeTruthy()
+      expect(botWorkflowCommand.description()).toBeTruthy()
     })
   })
 })

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -7,8 +7,10 @@
 
 import { Command } from "commander"
 import { describe, expect, it } from "vitest"
+import { botWorkflowCommand } from "../commands/bot-workflow"
 import { infoCommand } from "../commands/info"
 import { renderCommand } from "../commands/render"
+import { renderJobCommand } from "../commands/render-job"
 import { transcribeCommand } from "../commands/transcribe"
 
 describe("Timeline Studio CLI", () => {
@@ -58,12 +60,16 @@ describe("Timeline Studio CLI", () => {
       program.addCommand(infoCommand)
       program.addCommand(transcribeCommand)
       program.addCommand(renderCommand)
+      program.addCommand(renderJobCommand)
+      program.addCommand(botWorkflowCommand)
 
       const commands = program.commands
-      expect(commands).toHaveLength(3)
+      expect(commands).toHaveLength(5)
       expect(commands.map((cmd) => cmd.name())).toContain("info")
       expect(commands.map((cmd) => cmd.name())).toContain("transcribe")
       expect(commands.map((cmd) => cmd.name())).toContain("render")
+      expect(commands.map((cmd) => cmd.name())).toContain("render-job")
+      expect(commands.map((cmd) => cmd.name())).toContain("bot-workflow")
     })
   })
 

--- a/src/cli/commands/__tests__/bot-workflow.test.ts
+++ b/src/cli/commands/__tests__/bot-workflow.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for bot-first workflow command.
+ */
+
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import type { BotWorkflowRunResult } from "@/core/types"
+import { botWorkflowCommand, readTelegramLikeBotPayload, serializeBotWorkflowRunResult } from "../bot-workflow"
+
+describe("bot-workflow command", () => {
+  let tempDir: string
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bot-workflow-command-"))
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  it("should have correct command shape", () => {
+    expect(botWorkflowCommand.name()).toBe("bot-workflow")
+    expect(botWorkflowCommand.description()).toBe("Run a bot-first workflow from Telegram-like JSON")
+    expect(botWorkflowCommand.registeredArguments[0].name()).toBe("payload")
+    expect(botWorkflowCommand.options.some((option) => option.long === "--status-file")).toBe(true)
+    expect(botWorkflowCommand.options.some((option) => option.long === "--pretty")).toBe(true)
+    expect(botWorkflowCommand.options.some((option) => option.long === "--rust-render")).toBe(true)
+    expect(botWorkflowCommand.options.some((option) => option.long === "--default-destination")).toBe(true)
+    expect(botWorkflowCommand.options.some((option) => option.long === "--default-output")).toBe(true)
+  })
+
+  it("reads Telegram-like bot payload JSON", async () => {
+    const payloadPath = path.join(tempDir, "payload.json")
+    await fs.writeFile(
+      payloadPath,
+      JSON.stringify({
+        chat: { id: 42 },
+        caption: "template=promo destination=telegram",
+        video: { file_id: "telegram-file-1", file_name: "clip.mp4" },
+      }),
+    )
+
+    const payload = await readTelegramLikeBotPayload(payloadPath)
+
+    expect(payload).toMatchObject({
+      chat: { id: 42 },
+      caption: "template=promo destination=telegram",
+      video: { file_id: "telegram-file-1", file_name: "clip.mp4" },
+    })
+  })
+
+  it("rejects non-object payload JSON", async () => {
+    const payloadPath = path.join(tempDir, "payload.json")
+    await fs.writeFile(payloadPath, JSON.stringify([]))
+
+    await expect(readTelegramLikeBotPayload(payloadPath)).rejects.toThrow("Bot workflow payload JSON must be an object")
+  })
+
+  it("serializes compact and pretty workflow results", () => {
+    const result: BotWorkflowRunResult = {
+      ok: false,
+      workflow: { source: "telegram" },
+      errors: [
+        {
+          code: "missing_input",
+          field: "workflow",
+          message: "Workflow requires input",
+          userMessage: "Send a video file, link, project, or choose a template.",
+        },
+      ],
+    }
+
+    expect(serializeBotWorkflowRunResult(result)).not.toContain("\n")
+    expect(serializeBotWorkflowRunResult(result, true)).toContain("\n")
+  })
+})

--- a/src/cli/commands/bot-workflow.ts
+++ b/src/cli/commands/bot-workflow.ts
@@ -1,0 +1,126 @@
+/**
+ * Bot-first workflow command.
+ *
+ * Reads a Telegram-like payload JSON file, normalizes it into the bot workflow
+ * contract, runs the render job, and writes a machine-readable result.
+ */
+
+import fs from "node:fs/promises"
+import path from "node:path"
+import { Command } from "commander"
+
+import { initNodeApp } from "@/adapters/node"
+import type { BotRenderJobDestination, BotWorkflowRunResult, TelegramLikeBotPayload } from "@/core/types"
+
+export interface BotWorkflowCommandOptions {
+  statusFile?: string
+  pretty?: boolean
+  pollInterval?: string
+  timeout?: string
+  rustRender?: boolean
+  rustRenderCommand?: string
+  rustRenderKind?: "timeline" | "timeline-render"
+  defaultDestination?: BotRenderJobDestination
+  defaultOutput?: string
+}
+
+export const botWorkflowCommand = new Command("bot-workflow")
+  .description("Run a bot-first workflow from Telegram-like JSON")
+  .argument("<payload>", "Path to Telegram-like bot payload JSON")
+  .option("--status-file <path>", "Write final workflow result JSON to a file")
+  .option("--pretty", "Pretty-print JSON output")
+  .option("--poll-interval <ms>", "Render polling interval in milliseconds", "1000")
+  .option("--timeout <ms>", "Render timeout in milliseconds", "3600000")
+  .option("--rust-render", "Run rendering through the Rust headless ts-render CLI")
+  .option("--rust-render-command <path>", "Path/name for timeline or timeline-render command")
+  .option("--rust-render-kind <kind>", "Rust render command kind: timeline or timeline-render")
+  .option("--default-destination <destination>", "Fallback destination when payload has no destination hint")
+  .option("--default-output <path>", "Fallback output path when payload has no output hint")
+  .action(async (payloadFile: string, options: BotWorkflowCommandOptions) => {
+    try {
+      const result = await runBotWorkflowPayloadFile(payloadFile, options)
+      const serialized = serializeBotWorkflowRunResult(result, options.pretty)
+
+      if (options.statusFile) {
+        await fs.writeFile(path.resolve(options.statusFile), `${serialized}\n`)
+      }
+
+      process.stdout.write(`${serialized}\n`)
+      if (!result.ok || result.result.job.status === "failed" || result.result.job.status === "cancelled") {
+        process.exit(1)
+      }
+    } catch (error) {
+      const failed = createFailedBotWorkflowResult(error)
+      const serialized = serializeBotWorkflowRunResult(failed, options.pretty)
+      process.stderr.write(`${serialized}\n`)
+      process.exit(1)
+    }
+  })
+
+export async function runBotWorkflowPayloadFile(
+  payloadFile: string,
+  options: BotWorkflowCommandOptions = {},
+): Promise<BotWorkflowRunResult> {
+  const payload = await readTelegramLikeBotPayload(payloadFile)
+  const services = await initNodeApp({
+    autoConnect: false,
+    rustRender: options.rustRender
+      ? {
+          command: options.rustRenderCommand,
+          commandKind: options.rustRenderKind,
+        }
+      : undefined,
+  })
+
+  return services.botWorkflow.runTelegramLikePayload(payload, {
+    intake: {
+      defaultDestination: options.defaultDestination,
+      defaultOutputPath: options.defaultOutput,
+    },
+    render: {
+      pollIntervalMs: parsePositiveInteger(options.pollInterval, 1000),
+      timeoutMs: parsePositiveInteger(options.timeout, 3600000),
+    },
+    includeReconnectState: true,
+  })
+}
+
+export async function readTelegramLikeBotPayload(payloadFile: string): Promise<TelegramLikeBotPayload> {
+  const payloadPath = path.resolve(payloadFile)
+  const content = await fs.readFile(payloadPath, "utf-8")
+  const parsed = JSON.parse(content) as TelegramLikeBotPayload
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("Bot workflow payload JSON must be an object")
+  }
+
+  return parsed
+}
+
+export function serializeBotWorkflowRunResult(result: BotWorkflowRunResult, pretty = false): string {
+  return JSON.stringify(result, null, pretty ? 2 : 0)
+}
+
+function createFailedBotWorkflowResult(error: unknown): BotWorkflowRunResult {
+  const message = error instanceof Error ? error.message : String(error)
+  return {
+    ok: false,
+    workflow: {
+      source: "telegram",
+    },
+    errors: [
+      {
+        code: "missing_input",
+        field: "payload",
+        message,
+        userMessage: "Could not read the bot request. Send the payload again.",
+      },
+    ],
+  }
+}
+
+function parsePositiveInteger(value: string | undefined, fallback: number): number {
+  if (!value) return fallback
+  const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -2,6 +2,7 @@
  * CLI Commands
  */
 
+export { botWorkflowCommand } from "./bot-workflow"
 export { infoCommand } from "./info"
 export { renderCommand } from "./render"
 export { renderJobCommand } from "./render-job"

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -20,6 +20,7 @@
 
 import { Command } from "commander"
 
+import { botWorkflowCommand } from "./commands/bot-workflow"
 import { infoCommand } from "./commands/info"
 import { renderCommand } from "./commands/render"
 import { renderJobCommand } from "./commands/render-job"
@@ -34,6 +35,7 @@ program.addCommand(infoCommand)
 program.addCommand(transcribeCommand)
 program.addCommand(renderCommand)
 program.addCommand(renderJobCommand)
+program.addCommand(botWorkflowCommand)
 
 // Запуск
 program.parse(process.argv)

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -33,7 +33,13 @@ export type {
   SaveDialogOptions,
   Unsubscribe,
 } from "./ports"
-export type { BotRenderJobRetryOptions, LanguageResponse, ParsedBotWorkflowText } from "./services"
+export type {
+  BotRenderJobRetryOptions,
+  BotWorkflowRunnerOptions,
+  LanguageResponse,
+  ParsedBotWorkflowText,
+  TelegramLikeBotWorkflowRunnerOptions,
+} from "./services"
 export {
   canCancelBotRenderJob,
   canRetryBotRenderJob,
@@ -41,9 +47,12 @@ export {
   createBotRenderJobRetryRequest,
   createBotRenderJobSnapshot,
   createBotWorkflowRequestFromTelegramLikePayload,
+  createTelegramLikeBotWorkflow,
   getAppLanguage,
   InMemoryBotRenderJobEventStream,
   parseBotWorkflowText,
+  runBotWorkflow,
+  runTelegramLikeBotWorkflow,
   setAppLanguage,
 } from "./services"
 
@@ -76,6 +85,8 @@ export type {
   BotWorkflowIntakeResult,
   BotWorkflowOutput,
   BotWorkflowRequest,
+  BotWorkflowRunOptions,
+  BotWorkflowRunResult,
   BotWorkflowSource,
   BotWorkflowValidationCode,
   BotWorkflowValidationError,

--- a/src/core/services/__tests__/bot-workflow-runner.test.ts
+++ b/src/core/services/__tests__/bot-workflow-runner.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it, vi } from "vitest"
+import type { IRenderJobService } from "../../ports"
+import type {
+  BotRenderJob,
+  BotRenderJobEvent,
+  BotRenderJobRequest,
+  BotRenderJobResult,
+  BotRenderJobRunOptions,
+} from "../../types"
+import { runBotWorkflow, runTelegramLikeBotWorkflow } from "../bot-workflow-runner"
+import { InMemoryBotRenderJobEventStream } from "../render-job-events"
+
+class FakeRenderJobService implements IRenderJobService {
+  lastRequest?: BotRenderJobRequest
+  lastOptions?: BotRenderJobRunOptions
+
+  async run(request: BotRenderJobRequest, options: BotRenderJobRunOptions = {}): Promise<BotRenderJobResult> {
+    this.lastRequest = request
+    this.lastOptions = options
+
+    const event: BotRenderJobEvent = {
+      jobId: "job-1",
+      sequence: 0,
+      status: "done",
+      progress: 100,
+      timestamp: "2026-06-08T00:00:00.000Z",
+    }
+    const job: BotRenderJob = {
+      id: "job-1",
+      status: "done",
+      progress: 100,
+      request,
+      artifact: {
+        type: "file",
+        path: request.output.path,
+        destination: request.output.destination ?? "file",
+        mimeType: "video/mp4",
+      },
+      createdAt: "2026-06-08T00:00:00.000Z",
+      updatedAt: "2026-06-08T00:00:01.000Z",
+      events: [event],
+    }
+    const snapshot = {
+      jobId: job.id,
+      status: job.status,
+      progress: job.progress,
+      artifact: job.artifact,
+      createdAt: job.createdAt,
+      updatedAt: job.updatedAt,
+      eventCount: job.events.length,
+      lastEvent: event,
+      canCancel: false,
+      canRetry: false,
+    }
+
+    for (const sink of options.eventSinks ?? []) {
+      await sink.publish(event, snapshot)
+    }
+
+    return { job, events: [event] }
+  }
+
+  async getJob(jobId: string): Promise<BotRenderJob | null> {
+    return jobId === "job-1" ? null : null
+  }
+
+  async cancelJob(): Promise<boolean> {
+    return false
+  }
+}
+
+describe("bot workflow runner", () => {
+  it("normalizes Telegram-like payload, runs render job, and returns reconnect state", async () => {
+    const renderJob = new FakeRenderJobService()
+    const eventStream = new InMemoryBotRenderJobEventStream()
+
+    const result = await runTelegramLikeBotWorkflow(
+      {
+        chat: { id: "chat-1" },
+        caption: 'project="./project.json" destination=file output="./out.mp4" tone=fast',
+      },
+      {
+        renderJob,
+        eventStream,
+        render: { pollIntervalMs: 5, timeoutMs: 10 },
+        includeReconnectState: true,
+      },
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+
+    expect(renderJob.lastRequest).toMatchObject({
+      source: "bot",
+      project: { type: "file", path: "./project.json" },
+      params: { tone: "fast" },
+      output: { format: "mp4", path: "./out.mp4", destination: "file" },
+    })
+    expect(renderJob.lastOptions).toMatchObject({ pollIntervalMs: 5, timeoutMs: 10 })
+    expect(result.result.job.status).toBe("done")
+    expect(result.reconnectState?.snapshot).toMatchObject({ jobId: "job-1", status: "done" })
+    expect(result.reconnectState?.events).toHaveLength(1)
+  })
+
+  it("returns validation errors without running render job", async () => {
+    const renderJob = new FakeRenderJobService()
+    const runSpy = vi.spyOn(renderJob, "run")
+
+    const result = await runBotWorkflow(
+      {
+        source: "telegram",
+        media: [{ type: "file", value: "" }],
+      },
+      { renderJob },
+    )
+
+    expect(result).toEqual({
+      ok: false,
+      workflow: {
+        source: "telegram",
+        media: [{ type: "file", value: "" }],
+      },
+      errors: [
+        {
+          code: "invalid_media",
+          field: "media.0.value",
+          message: "Media attachment value cannot be empty",
+          userMessage: "One of the attached files is empty or unavailable. Send it again.",
+        },
+        {
+          code: "missing_input",
+          field: "workflow",
+          message: "Workflow requires a template, project, or media attachment",
+          userMessage: "Send a video file, link, project, or choose a template.",
+        },
+      ],
+    })
+    expect(runSpy).not.toHaveBeenCalled()
+  })
+
+  it("preserves caller event sinks while adding the workflow event stream", async () => {
+    const renderJob = new FakeRenderJobService()
+    const eventStream = new InMemoryBotRenderJobEventStream()
+    const callerSink = {
+      publish: vi.fn(),
+    }
+
+    await runBotWorkflow(
+      {
+        source: "telegram",
+        project: { type: "inline", schema: { clips: [] } },
+        output: { format: "mp4", destination: "file" },
+      },
+      {
+        renderJob,
+        eventStream,
+        render: { eventSinks: [callerSink] },
+      },
+    )
+
+    expect(renderJob.lastOptions?.eventSinks).toHaveLength(2)
+    expect(callerSink.publish).toHaveBeenCalledTimes(1)
+    expect(eventStream.getSnapshot("job-1")).toMatchObject({ status: "done" })
+  })
+})

--- a/src/core/services/bot-workflow-runner.ts
+++ b/src/core/services/bot-workflow-runner.ts
@@ -1,0 +1,65 @@
+import type { IRenderJobService } from "../ports"
+import type {
+  BotWorkflowIntakeOptions,
+  BotWorkflowRequest,
+  BotWorkflowRunOptions,
+  BotWorkflowRunResult,
+  TelegramLikeBotPayload,
+} from "../types"
+import { createBotRenderJobRequest, createBotWorkflowRequestFromTelegramLikePayload } from "./bot-workflow-intake"
+import { InMemoryBotRenderJobEventStream } from "./render-job-events"
+
+export interface BotWorkflowRunnerOptions extends BotWorkflowRunOptions {
+  renderJob: IRenderJobService
+  eventStream?: InMemoryBotRenderJobEventStream
+}
+
+export interface TelegramLikeBotWorkflowRunnerOptions extends BotWorkflowRunnerOptions {
+  intake?: BotWorkflowIntakeOptions
+}
+
+export async function runBotWorkflow(
+  workflow: BotWorkflowRequest,
+  options: BotWorkflowRunnerOptions,
+): Promise<BotWorkflowRunResult> {
+  const intake = createBotRenderJobRequest(workflow, options.intake)
+  if (!intake.ok) {
+    return {
+      ok: false,
+      workflow,
+      errors: intake.errors,
+    }
+  }
+
+  const eventSinks = [...(options.render?.eventSinks ?? [])]
+  if (options.eventStream) {
+    eventSinks.push(options.eventStream)
+  }
+
+  const result = await options.renderJob.run(intake.renderJob, {
+    ...options.render,
+    eventSinks,
+  })
+
+  return {
+    ok: true,
+    workflow,
+    renderJob: intake.renderJob,
+    result,
+    warnings: intake.warnings,
+    ...(options.includeReconnectState && options.eventStream
+      ? { reconnectState: options.eventStream.getReconnectState(result.job.id) }
+      : {}),
+  }
+}
+
+export function createTelegramLikeBotWorkflow(payload: TelegramLikeBotPayload): BotWorkflowRequest {
+  return createBotWorkflowRequestFromTelegramLikePayload(payload)
+}
+
+export async function runTelegramLikeBotWorkflow(
+  payload: TelegramLikeBotPayload,
+  options: TelegramLikeBotWorkflowRunnerOptions,
+): Promise<BotWorkflowRunResult> {
+  return runBotWorkflow(createTelegramLikeBotWorkflow(payload), options)
+}

--- a/src/core/services/index.ts
+++ b/src/core/services/index.ts
@@ -1,3 +1,4 @@
 export * from "./bot-workflow-intake"
+export * from "./bot-workflow-runner"
 export * from "./language"
 export * from "./render-job-events"

--- a/src/core/types/bot-workflow.ts
+++ b/src/core/types/bot-workflow.ts
@@ -9,7 +9,10 @@ import type {
   BotRenderJobDestination,
   BotRenderJobOutput,
   BotRenderJobProjectInput,
+  BotRenderJobReconnectState,
   BotRenderJobRequest,
+  BotRenderJobResult,
+  BotRenderJobRunOptions,
 } from "./render-job"
 
 export type BotWorkflowSource = "telegram" | "api" | "cli" | "desktop"
@@ -79,6 +82,27 @@ export type BotWorkflowIntakeResult =
       ok: false
       errors: BotWorkflowValidationError[]
     }
+
+export type BotWorkflowRunResult =
+  | {
+      ok: true
+      workflow: BotWorkflowRequest
+      renderJob: BotRenderJobRequest
+      result: BotRenderJobResult
+      warnings: BotWorkflowValidationError[]
+      reconnectState?: BotRenderJobReconnectState
+    }
+  | {
+      ok: false
+      workflow: BotWorkflowRequest
+      errors: BotWorkflowValidationError[]
+    }
+
+export interface BotWorkflowRunOptions {
+  intake?: BotWorkflowIntakeOptions
+  render?: BotRenderJobRunOptions
+  includeReconnectState?: boolean
+}
 
 export interface BotWorkflowIntakeOptions {
   defaultDestination?: BotRenderJobDestination


### PR DESCRIPTION
## Summary\n- add a core bot workflow runner that connects Telegram-like payloads through intake into IRenderJobService\n- wire NodeBotWorkflowService into initNodeApp/createNodeServices and expose the workflow runner exports\n- add timeline-studio bot-workflow <payload.json> CLI with JSON output/status file and Rust render opt-in flags\n- update the bot-first roadmap with B6 and add runner/adapter/CLI contract tests\n\n## Tests\n- bun run test -- src/core/services/__tests__/bot-workflow-runner.test.ts src/core/services/__tests__/bot-workflow-intake.test.ts src/adapters/node/__tests__/bot-workflow.test.ts src/adapters/node/__tests__/render-job.test.ts src/cli/commands/__tests__/bot-workflow.test.ts src/cli/commands/__tests__/render-job.test.ts src/cli/__tests__/index.test.ts src/cli/__tests__/index.integration.test.ts\n- bun run check:type\n- bun run check:workspaces\n- bun run check:boundaries:baseline\n- bunx biome ci docs/08_tasks/planned/bot-first-workflow.md src/adapters/node/index.ts src/adapters/node/bot-workflow.ts src/adapters/node/__tests__/bot-workflow.test.ts src/cli/__tests__/index.integration.test.ts src/cli/__tests__/index.test.ts src/cli/commands/__tests__/bot-workflow.test.ts src/cli/commands/bot-workflow.ts src/cli/commands/index.ts src/cli/index.ts src/core/index.ts src/core/services/__tests__/bot-workflow-runner.test.ts src/core/services/bot-workflow-runner.ts src/core/services/index.ts src/core/types/bot-workflow.ts\n- git diff --check\n\nRefs #171\nCloses #181