### PR TITLE
feat: assemble bot projects from media

### DIFF
--- a/docs/08_tasks/planned/bot-first-workflow.md
+++ b/docs/08_tasks/planned/bot-first-workflow.md
@@ -85,6 +85,15 @@ bot message
 - [x] Возвращать validation errors, render result и reconnect state для бота.
 - [x] Покрыть success/validation/event stream/CLI contract tests.
 
+### B7: Bot project assembly ([#183](https://github.com/chatman-media/timeline-studio/issues/183))
+
+**Цель:** бот может собрать renderable `ProjectSchema` из media/template payload без заранее подготовленного desktop project JSON.
+
+- [x] Добавить deterministic core assembler для `BotRenderJobRequest -> ProjectSchema`.
+- [x] Подключить assembly в workflow runner, сохраняя приоритет explicit `project=file|inline`.
+- [x] Научить Node fallback читать clips из `ProjectSchema.tracks`.
+- [x] Покрыть assembly, runner hydration и Node input extraction tests.
+
 ## Связанные задачи
 
 - [#150](https://github.com/chatman-media/timeline-studio/issues/150) - Phase F / package boundaries
@@ -94,6 +103,7 @@ bot message
 - [#177](https://github.com/chatman-media/timeline-studio/issues/177) - B4: Publishing destinations
 - [#179](https://github.com/chatman-media/timeline-studio/issues/179) - B5: Rust render adapter for bot jobs
 - [#181](https://github.com/chatman-media/timeline-studio/issues/181) - B6: Bot workflow runner
+- [#183](https://github.com/chatman-media/timeline-studio/issues/183) - B7: Bot project assembly
 - [telegram-mini-app.md](./telegram-mini-app.md)
 - [cloud-rendering.md](./cloud-rendering.md)
 - [export-architecture-refactoring.md](./export-architecture-refactoring.md)

--- a/src/adapters/node/__tests__/bot-workflow.test.ts
+++ b/src/adapters/node/__tests__/bot-workflow.test.ts
@@ -66,12 +66,20 @@ describe("NodeBotWorkflowService", () => {
     const eventStream = new InMemoryBotRenderJobEventStream()
     const botWorkflow = new NodeBotWorkflowService(renderJob, {
       intake: { defaultDestination: "file" },
+      projectAssembly: {
+        now: () => "2026-06-08T00:00:00.000Z",
+        defaultClipDurationSeconds: 2,
+      },
       render: { pollIntervalMs: 7, eventSinks: [defaultSink] },
     })
 
     const result = await botWorkflow.runTelegramLikePayload(
       {
-        caption: 'project="./project.json"',
+        caption: "template=promo",
+        video: {
+          file_path: "/tmp/clip.mp4",
+          file_name: "clip.mp4",
+        },
       },
       {
         eventStream,
@@ -82,7 +90,13 @@ describe("NodeBotWorkflowService", () => {
     expect(result.ok).toBe(true)
     expect(run).toHaveBeenCalledOnce()
 
-    const [, options] = run.mock.calls[0]
+    const [request, options] = run.mock.calls[0]
+    expect(request.project).toMatchObject({
+      type: "inline",
+      schema: {
+        timeline: { duration: 2 },
+      },
+    })
     expect(options).toMatchObject({ pollIntervalMs: 7, timeoutMs: 9 })
     expect(options?.eventSinks).toHaveLength(3)
     expect(defaultSink.publish).toHaveBeenCalledOnce()

--- a/src/adapters/node/__tests__/video.test.ts
+++ b/src/adapters/node/__tests__/video.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { NodeVideoService } from "../video"
+import { extractNodeVideoInputFiles, NodeVideoService } from "../video"
 
 describe("NodeVideoService", () => {
   const service = new NodeVideoService()
@@ -94,6 +94,23 @@ describe("NodeVideoService", () => {
   describe("Video Compilation", () => {
     it("throws error for renderProject with empty project", async () => {
       await expect(service.renderProject({}, "/output.mp4")).rejects.toThrow()
+    })
+
+    it("extracts input files from legacy clips and ProjectSchema tracks", () => {
+      expect(
+        extractNodeVideoInputFiles({
+          clips: [{ path: "/legacy/a.mp4" }],
+          tracks: [
+            {
+              clips: [
+                { source: { File: "/project/b.mp4" } },
+                { source: { Stream: "https://cdn.example.com/c.mp4" } },
+                { source: "Generated" },
+              ],
+            },
+          ],
+        }),
+      ).toEqual(["/legacy/a.mp4", "/project/b.mp4", "https://cdn.example.com/c.mp4"])
     })
 
     it("returns empty array for generatePreview", async () => {

--- a/src/adapters/node/bot-workflow.ts
+++ b/src/adapters/node/bot-workflow.ts
@@ -27,6 +27,7 @@ export class NodeBotWorkflowService {
     return runBotWorkflow(workflow, {
       renderJob: this.renderJob,
       intake: mergeOptions(this.defaults.intake, options.intake),
+      projectAssembly: mergeProjectAssemblyOptions(this.defaults.projectAssembly, options.projectAssembly),
       render: mergeRenderOptions(this.defaults.render, options.render),
       includeReconnectState: options.includeReconnectState ?? this.defaults.includeReconnectState ?? true,
       eventStream,
@@ -42,6 +43,7 @@ export class NodeBotWorkflowService {
     return runTelegramLikeBotWorkflow(payload, {
       renderJob: this.renderJob,
       intake: mergeOptions(this.defaults.intake, options.intake),
+      projectAssembly: mergeProjectAssemblyOptions(this.defaults.projectAssembly, options.projectAssembly),
       render: mergeRenderOptions(this.defaults.render, options.render),
       includeReconnectState: options.includeReconnectState ?? this.defaults.includeReconnectState ?? true,
       eventStream,
@@ -70,4 +72,14 @@ function mergeRenderOptions(
     ...merged,
     eventSinks,
   }
+}
+
+function mergeProjectAssemblyOptions(
+  defaults: BotWorkflowRunOptions["projectAssembly"],
+  overrides: BotWorkflowRunOptions["projectAssembly"],
+): BotWorkflowRunOptions["projectAssembly"] {
+  if (overrides === false) return false
+  if (defaults === false && overrides === undefined) return false
+  if (defaults === false) return overrides
+  return mergeOptions(defaults, overrides)
 }

--- a/src/adapters/node/video.ts
+++ b/src/adapters/node/video.ts
@@ -45,6 +45,29 @@ interface ActiveJob {
   progress: RenderProgress
 }
 
+interface NodeVideoLegacyClip {
+  path?: string
+  source_path?: string
+  source?: unknown
+}
+
+interface NodeVideoProjectLike {
+  clips?: NodeVideoLegacyClip[]
+  tracks?: Array<{
+    clips?: NodeVideoLegacyClip[]
+  }>
+}
+
+export function extractNodeVideoInputFiles(projectSchema: unknown): string[] {
+  const schema = projectSchema as NodeVideoProjectLike
+  const legacyClips = schema.clips ?? []
+  const trackClips = schema.tracks?.flatMap((track) => track.clips ?? []) ?? []
+
+  return [...legacyClips, ...trackClips]
+    .map((clip) => clip.path ?? clip.source_path ?? sourceToInputFile(clip.source))
+    .filter((value): value is string => Boolean(value))
+}
+
 export class NodeVideoService implements IVideoService {
   private cacheDir: string
   private ffmpegPath: string
@@ -224,9 +247,7 @@ export class NodeVideoService implements IVideoService {
 
   async renderProject(projectSchema: unknown, outputPath: string): Promise<string> {
     const jobId = crypto.randomUUID()
-    const schema = projectSchema as { clips?: Array<{ path: string; startTime: number; duration: number }> }
-
-    const inputFiles = schema.clips?.map((c) => c.path) || []
+    const inputFiles = extractNodeVideoInputFiles(projectSchema)
 
     if (inputFiles.length === 0) {
       throw new Error("No clips in project")
@@ -283,8 +304,7 @@ export class NodeVideoService implements IVideoService {
   }
 
   async generatePreview(projectSchema: unknown, timestamp: number, quality?: number): Promise<number[]> {
-    const schema = projectSchema as { clips?: Array<{ path: string }> }
-    const firstClip = schema.clips?.[0]?.path
+    const firstClip = extractNodeVideoInputFiles(projectSchema)[0]
 
     if (!firstClip) {
       return []
@@ -565,4 +585,17 @@ export class NodeVideoService implements IVideoService {
     const timestamps = (subtitles as Array<{ startTime: number }>).map((s) => s.startTime)
     return this.extractTimelineFrames({ videoPath, timestamps })
   }
+}
+
+function sourceToInputFile(source: unknown): string | undefined {
+  if (typeof source === "string") {
+    return source === "Generated" ? undefined : source
+  }
+
+  if (!source || typeof source !== "object") return undefined
+
+  if ("File" in source && typeof source.File === "string") return source.File
+  if ("Stream" in source && typeof source.Stream === "string") return source.Stream
+
+  return undefined
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -43,6 +43,7 @@ export type {
 export {
   canCancelBotRenderJob,
   canRetryBotRenderJob,
+  createBotProjectSchemaFromRenderJob,
   createBotRenderJobRequest,
   createBotRenderJobRetryRequest,
   createBotRenderJobSnapshot,
@@ -54,12 +55,15 @@ export {
   runBotWorkflow,
   runTelegramLikeBotWorkflow,
   setAppLanguage,
+  withBotProjectSchema,
 } from "./services"
 
 // Types (re-exported from generated bindings for now)
 export type {
   BotMediaAttachment,
   BotMediaAttachmentType,
+  BotProjectAssemblyOptions,
+  BotProjectAssemblyResolution,
   BotPublishMetadata,
   BotPublishRequest,
   BotPublishResult,

--- a/src/core/services/__tests__/bot-project-assembler.test.ts
+++ b/src/core/services/__tests__/bot-project-assembler.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest"
+import type { BotRenderJobRequest } from "../../types"
+import { createBotProjectSchemaFromRenderJob, withBotProjectSchema } from "../bot-project-assembler"
+
+describe("bot project assembler", () => {
+  it("creates a ProjectSchema from bot media and template hints", () => {
+    const request: BotRenderJobRequest = {
+      source: "bot",
+      templateId: "shorts",
+      media: [
+        {
+          type: "file",
+          value: "/tmp/clip-a.mp4",
+          name: "clip-a.mp4",
+          mimeType: "video/mp4",
+          metadata: { telegramFileId: "file-a" },
+        },
+        {
+          type: "url",
+          value: "https://cdn.example.com/clip-b.mp4",
+          name: "clip-b.mp4",
+        },
+      ],
+      params: {
+        title: "Launch",
+        caption: "Ready",
+        clipDurationSeconds: "3",
+      },
+      output: {
+        format: "mp4",
+        destination: "telegram",
+        resolution: "1080p",
+      },
+    }
+
+    const schema = createBotProjectSchemaFromRenderJob(request, {
+      now: () => "2026-06-08T00:00:00.000Z",
+    })
+
+    expect(schema).toMatchObject({
+      version: "1.0.0",
+      metadata: {
+        name: "Launch",
+        description: "Ready",
+        created_at: "2026-06-08T00:00:00.000Z",
+        modified_at: "2026-06-08T00:00:00.000Z",
+        author: "bot",
+      },
+      timeline: {
+        duration: 6,
+        fps: 30,
+        resolution: [1920, 1080],
+        sample_rate: 48000,
+        aspect_ratio: "Ratio16x9",
+      },
+      tracks: [
+        {
+          id: "bot-video-track",
+          track_type: "Video",
+          clips: [
+            {
+              source: { File: "/tmp/clip-a.mp4" },
+              start_time: 0,
+              end_time: 3,
+              source_start: 0,
+              source_end: 3,
+              template_id: "shorts",
+              template_position: 0,
+              properties: {
+                tags: ["bot"],
+                custom_metadata: {
+                  source: "bot",
+                  name: "clip-a.mp4",
+                  mimeType: "video/mp4",
+                  media: { telegramFileId: "file-a" },
+                },
+              },
+            },
+            {
+              source: { Stream: "https://cdn.example.com/clip-b.mp4" },
+              start_time: 3,
+              end_time: 6,
+              template_id: "shorts",
+              template_position: 1,
+            },
+          ],
+        },
+      ],
+      settings: {
+        export: { format: "Mp4" },
+        preview: { resolution: [1280, 720], format: "Jpeg" },
+        custom: {
+          bot: {
+            templateId: "shorts",
+            params: request.params,
+            destination: "telegram",
+          },
+        },
+        output: { format: "Mp4", duration: 6 },
+        resolution: { width: 1920, height: 1080 },
+        frame_rate: 30,
+        aspect_ratio: "Ratio16x9",
+      },
+    })
+  })
+
+  it("hydrates render jobs without an explicit project", () => {
+    const request: BotRenderJobRequest = {
+      source: "bot",
+      media: [{ type: "file", value: "/tmp/clip.mp4" }],
+      output: { format: "mp4" },
+    }
+
+    const hydrated = withBotProjectSchema(request, {
+      now: () => "2026-06-08T00:00:00.000Z",
+      resolution: [1080, 1920],
+    })
+
+    expect(hydrated.project).toMatchObject({
+      type: "inline",
+      schema: {
+        timeline: {
+          resolution: [1080, 1920],
+          aspect_ratio: "Ratio9x16",
+        },
+      },
+    })
+  })
+
+  it("preserves explicit project inputs and ignores empty media", () => {
+    const explicit: BotRenderJobRequest = {
+      source: "bot",
+      project: { type: "file", path: "/tmp/project.json" },
+      media: [{ type: "file", value: "/tmp/clip.mp4" }],
+      output: { format: "mp4" },
+    }
+    const empty: BotRenderJobRequest = {
+      source: "bot",
+      output: { format: "mp4" },
+    }
+
+    expect(withBotProjectSchema(explicit)).toBe(explicit)
+    expect(createBotProjectSchemaFromRenderJob(empty)).toBeNull()
+    expect(withBotProjectSchema(empty)).toBe(empty)
+  })
+})

--- a/src/core/services/__tests__/bot-workflow-runner.test.ts
+++ b/src/core/services/__tests__/bot-workflow-runner.test.ts
@@ -138,6 +138,56 @@ describe("bot workflow runner", () => {
     expect(runSpy).not.toHaveBeenCalled()
   })
 
+  it("hydrates media-only workflows with an inline ProjectSchema before rendering", async () => {
+    const renderJob = new FakeRenderJobService()
+
+    const result = await runTelegramLikeBotWorkflow(
+      {
+        caption: 'template=promo output="./out.mp4"',
+        video: {
+          file_path: "/tmp/clip.mp4",
+          file_name: "clip.mp4",
+          mime_type: "video/mp4",
+        },
+      },
+      {
+        renderJob,
+        projectAssembly: {
+          now: () => "2026-06-08T00:00:00.000Z",
+          defaultClipDurationSeconds: 4,
+        },
+      },
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+
+    expect(result.renderJob.project).toMatchObject({
+      type: "inline",
+      schema: {
+        metadata: {
+          name: "Bot promo",
+        },
+        timeline: {
+          duration: 4,
+        },
+        tracks: [
+          {
+            track_type: "Video",
+            clips: [
+              {
+                source: { File: "/tmp/clip.mp4" },
+                template_id: "promo",
+                template_position: 0,
+              },
+            ],
+          },
+        ],
+      },
+    })
+    expect(renderJob.lastRequest?.project).toBe(result.renderJob.project)
+  })
+
   it("preserves caller event sinks while adding the workflow event stream", async () => {
     const renderJob = new FakeRenderJobService()
     const eventStream = new InMemoryBotRenderJobEventStream()

--- a/src/core/services/bot-project-assembler.ts
+++ b/src/core/services/bot-project-assembler.ts
@@ -1,0 +1,248 @@
+import type { AspectRatio, Clip, ProjectSchema, Track } from "@/types/contracts/project-schema"
+
+import type {
+  BotProjectAssemblyOptions,
+  BotProjectAssemblyResolution,
+  BotRenderJobMediaInput,
+  BotRenderJobOutput,
+  BotRenderJobRequest,
+} from "../types"
+
+const DEFAULT_CLIP_DURATION_SECONDS = 5
+const DEFAULT_FPS = 30
+const DEFAULT_SAMPLE_RATE = 48000
+
+export function withBotProjectSchema(
+  request: BotRenderJobRequest,
+  options: BotProjectAssemblyOptions = {},
+): BotRenderJobRequest {
+  if (request.project) return request
+
+  const schema = createBotProjectSchemaFromRenderJob(request, options)
+  if (!schema) return request
+
+  return {
+    ...request,
+    project: {
+      type: "inline",
+      schema,
+    },
+  }
+}
+
+export function createBotProjectSchemaFromRenderJob(
+  request: BotRenderJobRequest,
+  options: BotProjectAssemblyOptions = {},
+): ProjectSchema | null {
+  const media = request.media ?? []
+  if (media.length === 0) return null
+
+  const now = options.now?.() ?? new Date().toISOString()
+  const clipDuration = resolveClipDuration(request, options)
+  const resolution = resolveResolution(request.output.resolution, options.resolution)
+  const aspectRatio = resolveAspectRatio(resolution)
+  const fps = options.fps ?? DEFAULT_FPS
+  const sampleRate = options.sampleRate ?? DEFAULT_SAMPLE_RATE
+  const clips = media.map((item, index) => createClip(item, index, request, clipDuration))
+  const duration = Math.max(...clips.map((clip) => clip.end_time), clipDuration)
+  const track: Track = {
+    id: "bot-video-track",
+    track_type: "Video",
+    name: "Bot Video",
+    enabled: true,
+    volume: 1,
+    locked: false,
+    clips,
+    effects: [],
+    filters: [],
+  }
+
+  return {
+    version: "1.0.0",
+    metadata: {
+      name: options.projectName ?? stringParam(request.params?.title) ?? defaultProjectName(request),
+      description: stringParam(request.params?.description) ?? stringParam(request.params?.caption) ?? null,
+      created_at: now,
+      modified_at: now,
+      author: options.author ?? "bot",
+    },
+    timeline: {
+      duration,
+      fps,
+      resolution,
+      sample_rate: sampleRate,
+      aspect_ratio: aspectRatio,
+    },
+    tracks: [track],
+    effects: [],
+    transitions: [],
+    filters: [],
+    templates: [],
+    style_templates: [],
+    subtitles: [],
+    settings: {
+      export: {
+        format: "Mp4",
+        quality: 85,
+        video_bitrate: 8000,
+        audio_bitrate: 192,
+        hardware_acceleration: true,
+        ffmpeg_args: [],
+      },
+      preview: {
+        resolution: previewResolution(resolution),
+        quality: 75,
+        fps,
+        format: "Jpeg",
+      },
+      custom: {
+        bot: {
+          ...(request.templateId ? { templateId: request.templateId } : {}),
+          ...(request.projectId ? { projectId: request.projectId } : {}),
+          ...(request.params ? { params: request.params } : {}),
+          destination: request.output.destination ?? "file",
+        },
+      },
+      output: {
+        format: "Mp4",
+        quality: 85,
+        video_bitrate: 8000,
+        audio_bitrate: 192,
+        duration,
+      },
+      resolution: {
+        width: resolution[0],
+        height: resolution[1],
+      },
+      frame_rate: fps,
+      aspect_ratio: aspectRatio,
+    },
+  }
+}
+
+function createClip(
+  media: BotRenderJobMediaInput,
+  index: number,
+  request: BotRenderJobRequest,
+  duration: number,
+): Clip {
+  const start = index * duration
+  const customMetadata: Record<string, unknown> = {
+    source: "bot",
+  }
+
+  if (media.name) customMetadata.name = media.name
+  if (media.mimeType) customMetadata.mimeType = media.mimeType
+  if (media.metadata) customMetadata.media = media.metadata
+
+  return {
+    id: createClipId(media, index),
+    source: createClipSource(media),
+    start_time: start,
+    end_time: start + duration,
+    source_start: 0,
+    source_end: duration,
+    speed: 1,
+    opacity: 1,
+    effects: [],
+    filters: [],
+    template_id: request.templateId ?? null,
+    template_position: request.templateId ? index : null,
+    color_correction: null,
+    crop: null,
+    transform: null,
+    audio_track_index: null,
+    properties: {
+      notes: media.name ?? null,
+      tags: ["bot"],
+      custom_metadata: customMetadata,
+    },
+  }
+}
+
+function createClipSource(media: BotRenderJobMediaInput): Clip["source"] {
+  return media.type === "url" || isUrl(media.value) ? { Stream: media.value } : { File: media.value }
+}
+
+function createClipId(media: BotRenderJobMediaInput, index: number): string {
+  const source = media.name ?? media.value
+  const slug = source
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48)
+
+  return `bot-clip-${index + 1}${slug ? `-${slug}` : ""}`
+}
+
+function resolveClipDuration(request: BotRenderJobRequest, options: BotProjectAssemblyOptions): number {
+  return (
+    positiveNumber(request.params?.clipDurationSeconds) ??
+    positiveNumber(request.params?.clipDuration) ??
+    positiveNumber(options.defaultClipDurationSeconds) ??
+    DEFAULT_CLIP_DURATION_SECONDS
+  )
+}
+
+function resolveResolution(
+  outputResolution: BotRenderJobOutput["resolution"],
+  optionResolution?: BotProjectAssemblyResolution,
+): [number, number] {
+  if (Array.isArray(optionResolution)) {
+    return [optionResolution[0], optionResolution[1]]
+  }
+
+  switch (optionResolution ?? outputResolution) {
+    case "720p":
+      return [1280, 720]
+    case "4k":
+      return [3840, 2160]
+    default:
+      return [1920, 1080]
+  }
+}
+
+function resolveAspectRatio([width, height]: [number, number]): AspectRatio {
+  const ratio = width / height
+
+  if (isClose(ratio, 16 / 9)) return "Ratio16x9"
+  if (isClose(ratio, 4 / 3)) return "Ratio4x3"
+  if (isClose(ratio, 21 / 9)) return "Ratio21x9"
+  if (isClose(ratio, 1)) return "Ratio1x1"
+  if (isClose(ratio, 9 / 16)) return "Ratio9x16"
+
+  return { Custom: ratio }
+}
+
+function previewResolution([width, height]: [number, number]): [number, number] {
+  if (width <= 1280 && height <= 720) return [width, height]
+
+  const scale = Math.min(1280 / width, 720 / height)
+  return [Math.round(width * scale), Math.round(height * scale)]
+}
+
+function defaultProjectName(request: BotRenderJobRequest): string {
+  return request.templateId ? `Bot ${request.templateId}` : "Bot Render Job"
+}
+
+function stringParam(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined
+}
+
+function positiveNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) return value
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number.parseFloat(value)
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined
+  }
+
+  return undefined
+}
+
+function isUrl(value: string): boolean {
+  return value.startsWith("http://") || value.startsWith("https://")
+}
+
+function isClose(actual: number, expected: number): boolean {
+  return Math.abs(actual - expected) < 0.01
+}

--- a/src/core/services/bot-workflow-runner.ts
+++ b/src/core/services/bot-workflow-runner.ts
@@ -6,6 +6,7 @@ import type {
   BotWorkflowRunResult,
   TelegramLikeBotPayload,
 } from "../types"
+import { withBotProjectSchema } from "./bot-project-assembler"
 import { createBotRenderJobRequest, createBotWorkflowRequestFromTelegramLikePayload } from "./bot-workflow-intake"
 import { InMemoryBotRenderJobEventStream } from "./render-job-events"
 
@@ -36,7 +37,12 @@ export async function runBotWorkflow(
     eventSinks.push(options.eventStream)
   }
 
-  const result = await options.renderJob.run(intake.renderJob, {
+  const renderJob =
+    options.projectAssembly === false
+      ? intake.renderJob
+      : withBotProjectSchema(intake.renderJob, options.projectAssembly)
+
+  const result = await options.renderJob.run(renderJob, {
     ...options.render,
     eventSinks,
   })
@@ -44,7 +50,7 @@ export async function runBotWorkflow(
   return {
     ok: true,
     workflow,
-    renderJob: intake.renderJob,
+    renderJob,
     result,
     warnings: intake.warnings,
     ...(options.includeReconnectState && options.eventStream

--- a/src/core/services/index.ts
+++ b/src/core/services/index.ts
@@ -1,3 +1,4 @@
+export * from "./bot-project-assembler"
 export * from "./bot-workflow-intake"
 export * from "./bot-workflow-runner"
 export * from "./language"

--- a/src/core/types/bot-workflow.ts
+++ b/src/core/types/bot-workflow.ts
@@ -100,8 +100,21 @@ export type BotWorkflowRunResult =
 
 export interface BotWorkflowRunOptions {
   intake?: BotWorkflowIntakeOptions
+  projectAssembly?: BotProjectAssemblyOptions | false
   render?: BotRenderJobRunOptions
   includeReconnectState?: boolean
+}
+
+export type BotProjectAssemblyResolution = BotRenderJobOutput["resolution"] | readonly [number, number]
+
+export interface BotProjectAssemblyOptions {
+  projectName?: string
+  author?: string
+  defaultClipDurationSeconds?: number
+  fps?: number
+  sampleRate?: number
+  resolution?: BotProjectAssemblyResolution
+  now?: () => string
 }
 
 export interface BotWorkflowIntakeOptions {


### PR DESCRIPTION
## Summary

- Add a deterministic core `ProjectSchema` assembler for bot media/template render jobs.
- Hydrate bot workflow render jobs with inline `ProjectSchema` when no explicit project is provided.
- Carry `projectAssembly` options through `NodeBotWorkflowService`.
- Teach the Node video fallback to extract input files from `ProjectSchema.tracks` while preserving legacy `clips` support.
- Document B7 in the bot-first roadmap.

## Tests

- `bun run test -- src/core/services/__tests__/bot-project-assembler.test.ts src/core/services/__tests__/bot-workflow-runner.test.ts src/adapters/node/__tests__/bot-workflow.test.ts src/adapters/node/__tests__/video.test.ts src/cli/commands/__tests__/bot-workflow.test.ts`
- `bun run check:type`
- `bun run check:workspaces`
- `bun run check:boundaries:baseline`
- `bunx biome ci docs/08_tasks/planned/bot-first-workflow.md src/core/types/bot-workflow.ts src/core/services/index.ts src/core/services/bot-project-assembler.ts src/core/services/bot-workflow-runner.ts src/core/services/__tests__/bot-project-assembler.test.ts src/core/services/__tests__/bot-workflow-runner.test.ts src/core/index.ts src/adapters/node/bot-workflow.ts src/adapters/node/__tests__/bot-workflow.test.ts src/adapters/node/video.ts src/adapters/node/__tests__/video.test.ts`
- `git diff --check`

Refs #171
Closes #183
