### PR TITLE
feat: add telegram bot worker entrypoint

### DIFF
--- a/docs/08_tasks/planned/bot-first-workflow.md
+++ b/docs/08_tasks/planned/bot-first-workflow.md
@@ -113,6 +113,17 @@ bot message
 - [x] Прокинуть status options через `NodeBotWorkflowService`, `initNodeApp` и CLI opt-in flags.
 - [x] Покрыть validation, render progress, Node Telegram delivery и CLI contract tests.
 
+### B10: Telegram bot worker entrypoint ([#189](https://github.com/chatman-media/timeline-studio/issues/189))
+
+**Цель:** принять настоящий Telegram `Update`/`getUpdates` batch и запустить bot-first workflow без промежуточного hand-written payload JSON.
+
+- [x] Добавить Node worker, который конвертирует Telegram `Update` в `TelegramLikeBotPayload`.
+- [x] Добавить Telegram Bot API `getUpdates` client с injectable `fetch`.
+- [x] Поддержать token-based Telegram `sendVideo` publishing для возврата готового ролика в чат.
+- [x] Добавить CLI `bot-worker` для `--update-file` и `--poll-once`.
+- [x] Автоматически прокидывать Telegram `chatId` в render params для publish phase.
+- [x] Покрыть update conversion, worker handling, polling, Bot API publishing, CLI contract tests.
+
 ## Связанные задачи
 
 - [#150](https://github.com/chatman-media/timeline-studio/issues/150) - Phase F / package boundaries
@@ -125,6 +136,7 @@ bot message
 - [#183](https://github.com/chatman-media/timeline-studio/issues/183) - B7: Bot project assembly
 - [#185](https://github.com/chatman-media/timeline-studio/issues/185) - B8: Bot media resolver
 - [#187](https://github.com/chatman-media/timeline-studio/issues/187) - B9: Bot status notifier
+- [#189](https://github.com/chatman-media/timeline-studio/issues/189) - B10: Telegram bot worker entrypoint
 - [telegram-mini-app.md](./telegram-mini-app.md)
 - [cloud-rendering.md](./cloud-rendering.md)
 - [export-architecture-refactoring.md](./export-architecture-refactoring.md)

--- a/src/adapters/node/__tests__/publish.test.ts
+++ b/src/adapters/node/__tests__/publish.test.ts
@@ -96,6 +96,59 @@ describe("NodePublishService", () => {
     })
   })
 
+  it("publishes telegram artifacts through Bot API fetch", async () => {
+    const fetchMock = vi.fn(async (_url: string, _init?: { method?: string; body?: BodyInit }) => ({
+      ok: true,
+      status: 200,
+      async json() {
+        return { ok: true, result: { message_id: 99 } }
+      },
+    }))
+    const service = new NodePublishService({
+      telegram: {
+        botToken: "token-1",
+      },
+      fetch: fetchMock,
+    })
+
+    await expect(
+      service.publish({
+        destination: "telegram",
+        artifact: {
+          type: "file",
+          path: artifactPath,
+          destination: "file",
+          mimeType: "video/mp4",
+        },
+        metadata: {
+          chatId: "chat-1",
+          caption: "Done",
+        },
+      }),
+    ).resolves.toMatchObject({
+      destination: "telegram",
+      status: "done",
+      artifact: {
+        type: "file",
+        path: artifactPath,
+        destination: "telegram",
+        mimeType: "video/mp4",
+      },
+      providerId: "99",
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.telegram.org/bottoken-1/sendVideo",
+      expect.objectContaining({
+        method: "POST",
+      }),
+    )
+    const body = fetchMock.mock.calls[0]?.[1]?.body as FormData
+    expect(body.get("chat_id")).toBe("chat-1")
+    expect(body.get("caption")).toBe("Done")
+    expect(body.get("video")).toBeInstanceOf(Blob)
+  })
+
   it("returns failed results for incomplete telegram configuration", async () => {
     const service = new NodePublishService()
 

--- a/src/adapters/node/__tests__/telegram-bot-worker.test.ts
+++ b/src/adapters/node/__tests__/telegram-bot-worker.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it, vi } from "vitest"
+import type { BotWorkflowRunResult } from "@/core/types"
+import type { NodeBotWorkflowService } from "../bot-workflow"
+import {
+  createTelegramLikePayloadFromUpdate,
+  NodeTelegramBotApiClient,
+  NodeTelegramBotWorker,
+  type TelegramBotUpdate,
+} from "../telegram-bot-worker"
+
+const failedResult: BotWorkflowRunResult = {
+  ok: false,
+  workflow: { source: "telegram" },
+  errors: [
+    {
+      code: "missing_input",
+      field: "workflow",
+      message: "Workflow requires input",
+      userMessage: "Send a video file, link, project, or choose a template.",
+    },
+  ],
+}
+
+function createWorkflowService() {
+  const runTelegramLikePayload = vi.fn(async () => failedResult)
+
+  return {
+    service: {
+      runTelegramLikePayload,
+    } as unknown as NodeBotWorkflowService,
+    runTelegramLikePayload,
+  }
+}
+
+describe("Telegram bot worker", () => {
+  it("converts Telegram updates into Telegram-like workflow payloads", () => {
+    const payload = createTelegramLikePayloadFromUpdate({
+      update_id: 10,
+      message: {
+        message_id: 7,
+        chat: { id: 42 },
+        from: { id: "user-1" },
+        caption: "template=promo",
+        video: {
+          file_id: "telegram-file-id",
+          file_unique_id: "unique-file-id",
+          file_name: "clip.mp4",
+          mime_type: "video/mp4",
+        },
+      },
+    })
+
+    expect(payload).toEqual({
+      chat: { id: 42 },
+      from: { id: "user-1" },
+      message_id: 7,
+      caption: "template=promo",
+      video: {
+        file_id: "telegram-file-id",
+        file_unique_id: "unique-file-id",
+        file_name: "clip.mp4",
+        mime_type: "video/mp4",
+      },
+    })
+  })
+
+  it("handles supported updates through the bot workflow service", async () => {
+    const { service, runTelegramLikePayload } = createWorkflowService()
+    const onResult = vi.fn()
+    const worker = new NodeTelegramBotWorker({
+      workflow: service,
+      workflowOptions: {
+        intake: { defaultDestination: "telegram" },
+      },
+      onResult,
+    })
+    const update: TelegramBotUpdate = {
+      update_id: 11,
+      message: {
+        message_id: "message-1",
+        chat: { id: "chat-1" },
+        text: "template=promo",
+      },
+    }
+
+    const result = await worker.handleUpdate(update, {
+      workflowOptions: {
+        render: { timeoutMs: 10 },
+      },
+    })
+
+    expect(result).toMatchObject({
+      skipped: false,
+      updateId: 11,
+      result: failedResult,
+    })
+    expect(runTelegramLikePayload).toHaveBeenCalledWith(
+      {
+        chat: { id: "chat-1" },
+        message_id: "message-1",
+        text: "template=promo",
+      },
+      {
+        intake: { defaultDestination: "telegram" },
+        render: { timeoutMs: 10 },
+      },
+    )
+    expect(onResult).toHaveBeenCalledWith(result)
+  })
+
+  it("skips updates without supported message payloads", async () => {
+    const { service, runTelegramLikePayload } = createWorkflowService()
+    const worker = new NodeTelegramBotWorker({ workflow: service })
+
+    const result = await worker.handleUpdate({ update_id: 12 })
+
+    expect(result).toEqual({
+      skipped: true,
+      reason: "Telegram update does not contain a supported message",
+      updateId: 12,
+      update: { update_id: 12 },
+    })
+    expect(runTelegramLikePayload).not.toHaveBeenCalled()
+  })
+
+  it("fetches Telegram updates through Bot API", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      async json() {
+        return {
+          ok: true,
+          result: [{ update_id: 20, message: { message_id: 1, chat: { id: "chat-1" }, text: "template=promo" } }],
+        }
+      },
+    }))
+    const client = new NodeTelegramBotApiClient("token-1", { fetch: fetchMock })
+
+    await expect(
+      client.getUpdates({
+        offset: 19,
+        limit: 10,
+        timeoutSeconds: 25,
+        allowedUpdates: ["message"],
+      }),
+    ).resolves.toEqual([{ update_id: 20, message: { message_id: 1, chat: { id: "chat-1" }, text: "template=promo" } }])
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.telegram.org/bottoken-1/getUpdates?offset=19&limit=10&timeout=25&allowed_updates=%5B%22message%22%5D",
+    )
+  })
+
+  it("polls one update batch and returns the next offset", async () => {
+    const { service, runTelegramLikePayload } = createWorkflowService()
+    const client = {
+      getUpdates: vi.fn(async () => [
+        { update_id: 30, message: { message_id: 1, chat: { id: "chat-1" }, text: "template=promo" } },
+        { update_id: 32 },
+      ]),
+    }
+    const worker = new NodeTelegramBotWorker({ workflow: service, client })
+
+    const result = await worker.pollOnce({ offset: 30, timeoutSeconds: 1 })
+
+    expect(client.getUpdates).toHaveBeenCalledWith({ offset: 30, timeoutSeconds: 1 })
+    expect(result.nextOffset).toBe(33)
+    expect(result.updates).toHaveLength(2)
+    expect(result.updates[0]).toMatchObject({ skipped: false, updateId: 30 })
+    expect(result.updates[1]).toMatchObject({ skipped: true, updateId: 32 })
+    expect(runTelegramLikePayload).toHaveBeenCalledOnce()
+  })
+})

--- a/src/adapters/node/index.ts
+++ b/src/adapters/node/index.ts
@@ -47,10 +47,35 @@ export { type NodeLanguageOptions, NodeLanguageService } from "./language"
 export { type NodeMediaOptions, NodeMediaService } from "./media"
 export { NodeBackendBridgeService } from "./node-backend-bridge"
 export { type NodePlatformOptions, NodePlatformService } from "./platform"
-export { type NodePublishOptions, NodePublishService } from "./publish"
+export {
+  type NodePublishFetch,
+  type NodePublishFetchResponse,
+  type NodePublishOptions,
+  NodePublishService,
+  type NodeTelegramPublishClient,
+  type NodeTelegramPublishPayload,
+  type NodeTelegramPublishResult,
+} from "./publish"
 export { NodeRenderJobService, type NodeRenderJobServiceOptions } from "./render-job"
 export { type NodeRustRenderVideoOptions, NodeRustRenderVideoService } from "./rust-render-video"
 export { type NodeStorageOptions, NodeStorageService } from "./storage"
+export {
+  createTelegramLikePayloadFromUpdate,
+  NodeTelegramBotApiClient,
+  type NodeTelegramBotClient,
+  NodeTelegramBotWorker,
+  type NodeTelegramBotWorkerHandleOptions,
+  type NodeTelegramBotWorkerOptions,
+  type NodeTelegramBotWorkerPollOptions,
+  type NodeTelegramBotWorkerPollResult,
+  type NodeTelegramBotWorkerUpdateResult,
+  type TelegramBotFetch,
+  type TelegramBotFetchResponse,
+  type TelegramBotFile,
+  type TelegramBotGetUpdatesOptions,
+  type TelegramBotMessage,
+  type TelegramBotUpdate,
+} from "./telegram-bot-worker"
 export { type NodeVideoOptions, NodeVideoService } from "./video"
 
 export interface NodeAppOptions {

--- a/src/adapters/node/publish.ts
+++ b/src/adapters/node/publish.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises"
+import path from "node:path"
 
 import type { IPublishService } from "@/core/ports"
 import type {
@@ -27,10 +28,32 @@ export interface NodeTelegramPublishClient {
   sendVideo(payload: NodeTelegramPublishPayload): Promise<NodeTelegramPublishResult>
 }
 
+export interface NodePublishFetchResponse {
+  ok: boolean
+  status: number
+  statusText?: string
+  json?(): Promise<unknown>
+}
+
+export type NodePublishFetch = (
+  url: string,
+  init?: { method?: string; body?: BodyInit },
+) => Promise<NodePublishFetchResponse>
+
 export interface NodePublishOptions {
   telegram?: {
     defaultChatId?: string
+    botToken?: string
     client?: NodeTelegramPublishClient
+  }
+  fetch?: NodePublishFetch
+}
+
+interface TelegramSendVideoResponse {
+  ok?: boolean
+  description?: string
+  result?: {
+    message_id?: number
   }
 }
 
@@ -39,7 +62,7 @@ export class NodePublishService implements IPublishService {
 
   canPublish(destination: BotRenderJobDestination): boolean {
     if (destination === "file") return true
-    if (destination === "telegram") return Boolean(this.options.telegram?.client)
+    if (destination === "telegram") return Boolean(this.options.telegram?.client || this.options.telegram?.botToken)
     return false
   }
 
@@ -90,7 +113,8 @@ export class NodePublishService implements IPublishService {
 
   private async publishTelegram(request: BotPublishRequest): Promise<BotPublishResult> {
     const client = this.options.telegram?.client
-    if (!client) {
+    const botToken = this.options.telegram?.botToken
+    if (!client && !botToken) {
       return {
         destination: "telegram",
         status: "failed",
@@ -117,13 +141,14 @@ export class NodePublishService implements IPublishService {
 
     let published: NodeTelegramPublishResult
     try {
-      published = await client.sendVideo({
+      const payload = {
         path: request.artifact.path,
         chatId,
         caption: request.metadata?.caption ?? request.metadata?.title,
         mimeType: request.artifact.mimeType,
         metadata: request.metadata,
-      })
+      }
+      published = client ? await client.sendVideo(payload) : await this.sendTelegramVideo(botToken, payload)
     } catch (error) {
       return {
         destination: "telegram",
@@ -146,6 +171,39 @@ export class NodePublishService implements IPublishService {
       },
     }
   }
+
+  private async sendTelegramVideo(
+    botToken: string | undefined,
+    payload: NodeTelegramPublishPayload,
+  ): Promise<NodeTelegramPublishResult> {
+    if (!botToken) {
+      throw new Error("Telegram publisher is not configured")
+    }
+
+    const file = await fs.readFile(payload.path)
+    const form = new FormData()
+    form.set("chat_id", payload.chatId)
+    if (payload.caption) form.set("caption", payload.caption)
+    form.set("video", new Blob([file], { type: payload.mimeType ?? "video/mp4" }), path.basename(payload.path))
+
+    const response = await (this.options.fetch ?? globalFetch)(`https://api.telegram.org/bot${botToken}/sendVideo`, {
+      method: "POST",
+      body: form,
+    })
+
+    if (!response.ok) {
+      throw new Error(`Telegram sendVideo failed: ${response.status} ${response.statusText ?? ""}`.trim())
+    }
+
+    const body = (await response.json?.()) as TelegramSendVideoResponse | undefined
+    if (body && body.ok === false) {
+      throw new Error(body.description ?? "Telegram sendVideo failed")
+    }
+
+    return {
+      messageId: body?.result?.message_id === undefined ? undefined : String(body.result.message_id),
+    }
+  }
 }
 
 function createPublishedArtifact(
@@ -166,4 +224,11 @@ function createPublishedArtifact(
     ...artifact,
     destination,
   }
+}
+
+function globalFetch(url: string, init?: { method?: string; body?: BodyInit }): Promise<NodePublishFetchResponse> {
+  if (typeof fetch !== "function") {
+    throw new Error("No fetch implementation is available for Telegram publishing")
+  }
+  return fetch(url, init) as Promise<NodePublishFetchResponse>
 }

--- a/src/adapters/node/telegram-bot-worker.ts
+++ b/src/adapters/node/telegram-bot-worker.ts
@@ -1,0 +1,256 @@
+import type { BotWorkflowRunResult, TelegramLikeBotFile, TelegramLikeBotPayload } from "@/core/types"
+
+import type { NodeBotWorkflowService, NodeBotWorkflowServiceOptions } from "./bot-workflow"
+
+export interface TelegramBotFile {
+  file_id?: string
+  file_unique_id?: string
+  file_name?: string
+  mime_type?: string
+  file_path?: string
+}
+
+export interface TelegramBotMessage {
+  message_id?: string | number
+  chat?: {
+    id?: string | number
+  }
+  from?: {
+    id?: string | number
+  }
+  text?: string
+  caption?: string
+  document?: TelegramBotFile
+  video?: TelegramBotFile
+  audio?: TelegramBotFile
+  animation?: TelegramBotFile
+  photo?: TelegramBotFile[]
+}
+
+export interface TelegramBotUpdate {
+  update_id: number
+  message?: TelegramBotMessage
+  edited_message?: TelegramBotMessage
+  channel_post?: TelegramBotMessage
+  edited_channel_post?: TelegramBotMessage
+}
+
+export interface TelegramBotGetUpdatesOptions {
+  offset?: number
+  limit?: number
+  timeoutSeconds?: number
+  allowedUpdates?: string[]
+}
+
+export interface TelegramBotFetchResponse {
+  ok: boolean
+  status: number
+  statusText?: string
+  json?(): Promise<unknown>
+}
+
+export type TelegramBotFetch = (
+  url: string,
+  init?: { method?: string; headers?: Record<string, string>; body?: string },
+) => Promise<TelegramBotFetchResponse>
+
+export interface NodeTelegramBotClient {
+  getUpdates(options?: TelegramBotGetUpdatesOptions): Promise<TelegramBotUpdate[]>
+}
+
+export interface NodeTelegramBotWorkerOptions {
+  workflow: NodeBotWorkflowService
+  client?: NodeTelegramBotClient
+  botToken?: string
+  fetch?: TelegramBotFetch
+  workflowOptions?: NodeBotWorkflowServiceOptions
+  onResult?: (result: NodeTelegramBotWorkerUpdateResult) => void | Promise<void>
+}
+
+export interface NodeTelegramBotWorkerHandleOptions {
+  workflowOptions?: NodeBotWorkflowServiceOptions
+}
+
+export type NodeTelegramBotWorkerUpdateResult =
+  | {
+      skipped: true
+      reason: string
+      updateId: number
+      update: TelegramBotUpdate
+    }
+  | {
+      skipped: false
+      updateId: number
+      update: TelegramBotUpdate
+      payload: TelegramLikeBotPayload
+      result: BotWorkflowRunResult
+    }
+
+export interface NodeTelegramBotWorkerPollOptions extends TelegramBotGetUpdatesOptions {
+  workflowOptions?: NodeBotWorkflowServiceOptions
+}
+
+export interface NodeTelegramBotWorkerPollResult {
+  updates: NodeTelegramBotWorkerUpdateResult[]
+  nextOffset?: number
+}
+
+interface TelegramGetUpdatesResponse {
+  ok?: boolean
+  description?: string
+  result?: unknown
+}
+
+export class NodeTelegramBotApiClient implements NodeTelegramBotClient {
+  private readonly fetch: TelegramBotFetch
+
+  constructor(
+    private readonly botToken: string,
+    options: { fetch?: TelegramBotFetch } = {},
+  ) {
+    this.fetch = options.fetch ?? globalFetch
+  }
+
+  async getUpdates(options: TelegramBotGetUpdatesOptions = {}): Promise<TelegramBotUpdate[]> {
+    const params = new URLSearchParams()
+    if (options.offset !== undefined) params.set("offset", String(options.offset))
+    if (options.limit !== undefined) params.set("limit", String(options.limit))
+    if (options.timeoutSeconds !== undefined) params.set("timeout", String(options.timeoutSeconds))
+    if (options.allowedUpdates?.length) params.set("allowed_updates", JSON.stringify(options.allowedUpdates))
+
+    const query = params.toString()
+    const response = await this.fetch(
+      `https://api.telegram.org/bot${this.botToken}/getUpdates${query ? `?${query}` : ""}`,
+    )
+    if (!response.ok) {
+      throw new Error(`Telegram getUpdates failed: ${response.status} ${response.statusText ?? ""}`.trim())
+    }
+
+    const body = (await response.json?.()) as TelegramGetUpdatesResponse | undefined
+    if (!body?.ok || !Array.isArray(body.result)) {
+      throw new Error(body?.description ?? "Telegram getUpdates response did not include result")
+    }
+
+    return body.result as TelegramBotUpdate[]
+  }
+}
+
+export class NodeTelegramBotWorker {
+  private readonly workflowOptions?: NodeBotWorkflowServiceOptions
+
+  constructor(private readonly options: NodeTelegramBotWorkerOptions) {
+    this.workflowOptions = options.workflowOptions
+  }
+
+  async handleUpdate(
+    update: TelegramBotUpdate,
+    options: NodeTelegramBotWorkerHandleOptions = {},
+  ): Promise<NodeTelegramBotWorkerUpdateResult> {
+    const payload = createTelegramLikePayloadFromUpdate(update)
+    if (!payload) {
+      const result: NodeTelegramBotWorkerUpdateResult = {
+        skipped: true,
+        reason: "Telegram update does not contain a supported message",
+        updateId: update.update_id,
+        update,
+      }
+      await this.options.onResult?.(result)
+      return result
+    }
+
+    const result: NodeTelegramBotWorkerUpdateResult = {
+      skipped: false,
+      updateId: update.update_id,
+      update,
+      payload,
+      result: await this.options.workflow.runTelegramLikePayload(
+        payload,
+        mergeWorkflowOptions(this.workflowOptions, options.workflowOptions),
+      ),
+    }
+    await this.options.onResult?.(result)
+    return result
+  }
+
+  async pollOnce(options: NodeTelegramBotWorkerPollOptions = {}): Promise<NodeTelegramBotWorkerPollResult> {
+    const client = this.resolveClient()
+    const { workflowOptions, ...getUpdatesOptions } = options
+    const updates = await client.getUpdates(getUpdatesOptions)
+    const results: NodeTelegramBotWorkerUpdateResult[] = []
+    let nextOffset = options.offset
+
+    for (const update of updates) {
+      results.push(await this.handleUpdate(update, { workflowOptions }))
+      nextOffset = Math.max(nextOffset ?? 0, update.update_id + 1)
+    }
+
+    return {
+      updates: results,
+      ...(nextOffset !== undefined ? { nextOffset } : {}),
+    }
+  }
+
+  private resolveClient(): NodeTelegramBotClient {
+    if (this.options.client) return this.options.client
+    if (!this.options.botToken) {
+      throw new Error("Telegram bot token or client is required for polling")
+    }
+    return new NodeTelegramBotApiClient(this.options.botToken, { fetch: this.options.fetch })
+  }
+}
+
+export function createTelegramLikePayloadFromUpdate(update: TelegramBotUpdate): TelegramLikeBotPayload | null {
+  const message = update.message ?? update.edited_message ?? update.channel_post ?? update.edited_channel_post
+  if (!message) return null
+
+  return {
+    ...(message.chat?.id !== undefined ? { chat: { id: message.chat.id } } : {}),
+    ...(message.from?.id !== undefined ? { from: { id: message.from.id } } : {}),
+    ...(message.message_id !== undefined ? { message_id: message.message_id } : {}),
+    ...(message.text ? { text: message.text } : {}),
+    ...(message.caption ? { caption: message.caption } : {}),
+    ...(message.document ? { document: telegramFile(message.document) } : {}),
+    ...(message.video ? { video: telegramFile(message.video) } : {}),
+    ...(message.audio ? { audio: telegramFile(message.audio) } : {}),
+    ...(message.animation ? { animation: telegramFile(message.animation) } : {}),
+    ...(message.photo ? { photo: message.photo.map(telegramFile) } : {}),
+  }
+}
+
+function telegramFile(file: TelegramBotFile): TelegramLikeBotFile {
+  return {
+    ...(file.file_id ? { file_id: file.file_id } : {}),
+    ...(file.file_unique_id ? { file_unique_id: file.file_unique_id } : {}),
+    ...(file.file_name ? { file_name: file.file_name } : {}),
+    ...(file.mime_type ? { mime_type: file.mime_type } : {}),
+    ...(file.file_path ? { file_path: file.file_path } : {}),
+  }
+}
+
+function mergeWorkflowOptions(
+  defaults: NodeBotWorkflowServiceOptions | undefined,
+  overrides: NodeBotWorkflowServiceOptions | undefined,
+): NodeBotWorkflowServiceOptions | undefined {
+  if (!defaults && !overrides) return undefined
+  return {
+    ...defaults,
+    ...overrides,
+    intake: mergeObject(defaults?.intake, overrides?.intake),
+    render: mergeObject(defaults?.render, overrides?.render),
+  }
+}
+
+function mergeObject<T extends object>(defaults: T | undefined, overrides: T | undefined): T | undefined {
+  if (!defaults && !overrides) return undefined
+  return { ...defaults, ...overrides } as T
+}
+
+function globalFetch(
+  url: string,
+  init?: { method?: string; headers?: Record<string, string>; body?: string },
+): Promise<TelegramBotFetchResponse> {
+  if (typeof fetch !== "function") {
+    throw new Error("No fetch implementation is available for Telegram bot polling")
+  }
+  return fetch(url, init) as Promise<TelegramBotFetchResponse>
+}

--- a/src/cli/__tests__/index.integration.test.ts
+++ b/src/cli/__tests__/index.integration.test.ts
@@ -4,6 +4,7 @@
 
 import { Command } from "commander"
 import { describe, expect, it } from "vitest"
+import { botWorkerCommand } from "../commands/bot-worker"
 import { botWorkflowCommand } from "../commands/bot-workflow"
 import { infoCommand } from "../commands/info"
 import { renderCommand } from "../commands/render"
@@ -35,9 +36,10 @@ describe("Timeline Studio CLI Integration", () => {
       program.addCommand(renderCommand)
       program.addCommand(renderJobCommand)
       program.addCommand(botWorkflowCommand)
+      program.addCommand(botWorkerCommand)
 
       const commands = program.commands
-      expect(commands).toHaveLength(5)
+      expect(commands).toHaveLength(6)
 
       const commandNames = commands.map((cmd) => cmd.name())
       expect(commandNames).toContain("info")
@@ -45,6 +47,7 @@ describe("Timeline Studio CLI Integration", () => {
       expect(commandNames).toContain("render")
       expect(commandNames).toContain("render-job")
       expect(commandNames).toContain("bot-workflow")
+      expect(commandNames).toContain("bot-worker")
     })
   })
 
@@ -122,6 +125,16 @@ describe("Timeline Studio CLI Integration", () => {
       expect(options.some((opt) => opt.long === "--status-file")).toBe(true)
       expect(options.some((opt) => opt.long === "--default-destination")).toBe(true)
     })
+
+    it("should have bot-worker command properly configured", () => {
+      expect(botWorkerCommand.name()).toBe("bot-worker")
+      expect(botWorkerCommand.description()).toBe("Run a Telegram bot worker for bot-first workflows")
+
+      const options = botWorkerCommand.options
+      expect(options.some((opt) => opt.long === "--update-file")).toBe(true)
+      expect(options.some((opt) => opt.long === "--poll-once")).toBe(true)
+      expect(options.some((opt) => opt.long === "--telegram-bot-token")).toBe(true)
+    })
   })
 
   describe("Command options", () => {
@@ -173,6 +186,7 @@ describe("Timeline Studio CLI Integration", () => {
       program.addCommand(renderCommand)
       program.addCommand(renderJobCommand)
       program.addCommand(botWorkflowCommand)
+      program.addCommand(botWorkerCommand)
 
       const helpText = program.helpInformation()
 
@@ -191,6 +205,7 @@ describe("Timeline Studio CLI Integration", () => {
       program.addCommand(renderCommand)
       program.addCommand(renderJobCommand)
       program.addCommand(botWorkflowCommand)
+      program.addCommand(botWorkerCommand)
 
       const helpText = program.helpInformation()
 
@@ -199,6 +214,7 @@ describe("Timeline Studio CLI Integration", () => {
       expect(helpText).toContain("render")
       expect(helpText).toContain("render-job")
       expect(helpText).toContain("bot-workflow")
+      expect(helpText).toContain("bot-worker")
     })
   })
 
@@ -267,8 +283,9 @@ describe("Timeline Studio CLI Integration", () => {
         .addCommand(renderCommand)
         .addCommand(renderJobCommand)
         .addCommand(botWorkflowCommand)
+        .addCommand(botWorkerCommand)
 
-      expect(program.commands).toHaveLength(5)
+      expect(program.commands).toHaveLength(6)
     })
   })
 
@@ -279,6 +296,7 @@ describe("Timeline Studio CLI Integration", () => {
       expect(renderCommand.name()).toBe("render")
       expect(renderJobCommand.name()).toBe("render-job")
       expect(botWorkflowCommand.name()).toBe("bot-workflow")
+      expect(botWorkerCommand.name()).toBe("bot-worker")
     })
 
     it("should maintain command descriptions", () => {
@@ -287,6 +305,7 @@ describe("Timeline Studio CLI Integration", () => {
       expect(renderCommand.description()).toBeTruthy()
       expect(renderJobCommand.description()).toBeTruthy()
       expect(botWorkflowCommand.description()).toBeTruthy()
+      expect(botWorkerCommand.description()).toBeTruthy()
     })
   })
 })

--- a/src/cli/__tests__/index.test.ts
+++ b/src/cli/__tests__/index.test.ts
@@ -7,6 +7,7 @@
 
 import { Command } from "commander"
 import { describe, expect, it } from "vitest"
+import { botWorkerCommand } from "../commands/bot-worker"
 import { botWorkflowCommand } from "../commands/bot-workflow"
 import { infoCommand } from "../commands/info"
 import { renderCommand } from "../commands/render"
@@ -62,14 +63,16 @@ describe("Timeline Studio CLI", () => {
       program.addCommand(renderCommand)
       program.addCommand(renderJobCommand)
       program.addCommand(botWorkflowCommand)
+      program.addCommand(botWorkerCommand)
 
       const commands = program.commands
-      expect(commands).toHaveLength(5)
+      expect(commands).toHaveLength(6)
       expect(commands.map((cmd) => cmd.name())).toContain("info")
       expect(commands.map((cmd) => cmd.name())).toContain("transcribe")
       expect(commands.map((cmd) => cmd.name())).toContain("render")
       expect(commands.map((cmd) => cmd.name())).toContain("render-job")
       expect(commands.map((cmd) => cmd.name())).toContain("bot-workflow")
+      expect(commands.map((cmd) => cmd.name())).toContain("bot-worker")
     })
   })
 

--- a/src/cli/commands/__tests__/bot-worker.test.ts
+++ b/src/cli/commands/__tests__/bot-worker.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for Telegram bot worker command.
+ */
+
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { botWorkerCommand, readTelegramBotUpdate, serializeBotWorkerResult } from "../bot-worker"
+
+describe("bot-worker command", () => {
+  let tempDir: string
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bot-worker-command-"))
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  it("should have correct command shape", () => {
+    expect(botWorkerCommand.name()).toBe("bot-worker")
+    expect(botWorkerCommand.description()).toBe("Run a Telegram bot worker for bot-first workflows")
+    expect(botWorkerCommand.options.some((option) => option.long === "--update-file")).toBe(true)
+    expect(botWorkerCommand.options.some((option) => option.long === "--poll-once")).toBe(true)
+    expect(botWorkerCommand.options.some((option) => option.long === "--telegram-bot-token")).toBe(true)
+    expect(botWorkerCommand.options.some((option) => option.long === "--no-status-updates")).toBe(true)
+    expect(botWorkerCommand.options.some((option) => option.long === "--status-chat-id")).toBe(true)
+    expect(botWorkerCommand.options.some((option) => option.long === "--rust-render")).toBe(true)
+    expect(botWorkerCommand.options.some((option) => option.long === "--default-destination")).toBe(true)
+  })
+
+  it("reads Telegram update JSON", async () => {
+    const updatePath = path.join(tempDir, "update.json")
+    await fs.writeFile(
+      updatePath,
+      JSON.stringify({
+        update_id: 100,
+        message: {
+          message_id: 7,
+          chat: { id: "chat-1" },
+          text: "template=promo",
+        },
+      }),
+    )
+
+    await expect(readTelegramBotUpdate(updatePath)).resolves.toEqual({
+      update_id: 100,
+      message: {
+        message_id: 7,
+        chat: { id: "chat-1" },
+        text: "template=promo",
+      },
+    })
+  })
+
+  it("rejects invalid Telegram update JSON", async () => {
+    const updatePath = path.join(tempDir, "update.json")
+    await fs.writeFile(updatePath, JSON.stringify({ message: {} }))
+
+    await expect(readTelegramBotUpdate(updatePath)).rejects.toThrow(
+      "Telegram update JSON must include numeric update_id",
+    )
+  })
+
+  it("serializes compact and pretty worker results", () => {
+    const result = {
+      skipped: true as const,
+      reason: "Telegram update does not contain a supported message",
+      updateId: 1,
+      update: { update_id: 1 },
+    }
+
+    expect(serializeBotWorkerResult(result)).not.toContain("\n")
+    expect(serializeBotWorkerResult(result, true)).toContain("\n")
+  })
+})

--- a/src/cli/commands/bot-worker.ts
+++ b/src/cli/commands/bot-worker.ts
@@ -1,0 +1,231 @@
+/**
+ * Telegram bot worker command.
+ *
+ * Accepts raw Telegram Update JSON or one getUpdates batch, converts updates to
+ * the bot workflow contract, and runs the same headless workflow as bot-workflow.
+ */
+
+import fs from "node:fs/promises"
+import path from "node:path"
+import { Command } from "commander"
+import type {
+  NodeTelegramBotWorkerPollResult,
+  NodeTelegramBotWorkerUpdateResult,
+  TelegramBotUpdate,
+} from "@/adapters/node"
+import { initNodeApp, NodeTelegramBotWorker } from "@/adapters/node"
+import type { BotRenderJobDestination } from "@/core/types"
+
+export interface BotWorkerCommandOptions {
+  updateFile?: string
+  pollOnce?: boolean
+  statusFile?: string
+  pretty?: boolean
+  telegramBotToken?: string
+  statusUpdates?: boolean
+  statusChatId?: string
+  pollOffset?: string
+  pollLimit?: string
+  pollTimeout?: string
+  mediaDir?: string
+  downloadRemoteMedia?: boolean
+  pollInterval?: string
+  timeout?: string
+  rustRender?: boolean
+  rustRenderCommand?: string
+  rustRenderKind?: "timeline" | "timeline-render"
+  defaultDestination?: BotRenderJobDestination
+  defaultOutput?: string
+}
+
+export type BotWorkerCommandResult = NodeTelegramBotWorkerUpdateResult | NodeTelegramBotWorkerPollResult
+
+export const botWorkerCommand = new Command("bot-worker")
+  .description("Run a Telegram bot worker for bot-first workflows")
+  .option("--update-file <path>", "Handle one raw Telegram Update JSON file")
+  .option("--poll-once", "Fetch and handle one Telegram getUpdates batch")
+  .option("--status-file <path>", "Write worker result JSON to a file")
+  .option("--pretty", "Pretty-print JSON output")
+  .option("--telegram-bot-token <token>", "Telegram Bot API token for polling, media, status, and publishing")
+  .option("--no-status-updates", "Disable Telegram workflow status messages")
+  .option("--status-chat-id <id>", "Fallback Telegram chat id for status updates and publishing")
+  .option("--poll-offset <id>", "Telegram getUpdates offset")
+  .option("--poll-limit <count>", "Telegram getUpdates limit", "100")
+  .option("--poll-timeout <seconds>", "Telegram getUpdates long-poll timeout in seconds", "25")
+  .option("--media-dir <path>", "Directory for resolved bot media downloads")
+  .option("--download-remote-media", "Download remote URL media before rendering")
+  .option("--poll-interval <ms>", "Render polling interval in milliseconds", "1000")
+  .option("--timeout <ms>", "Render timeout in milliseconds", "3600000")
+  .option("--rust-render", "Run rendering through the Rust headless ts-render CLI")
+  .option("--rust-render-command <path>", "Path/name for timeline or timeline-render command")
+  .option("--rust-render-kind <kind>", "Rust render command kind: timeline or timeline-render")
+  .option("--default-destination <destination>", "Fallback destination when update has no destination hint")
+  .option("--default-output <path>", "Fallback output path when update has no output hint")
+  .action(async (options: BotWorkerCommandOptions) => {
+    try {
+      const result = await runBotWorker(options)
+      const serialized = serializeBotWorkerResult(result, options.pretty)
+
+      if (options.statusFile) {
+        await fs.writeFile(path.resolve(options.statusFile), `${serialized}\n`)
+      }
+
+      process.stdout.write(`${serialized}\n`)
+      if (isFailedWorkerResult(result)) {
+        process.exit(1)
+      }
+    } catch (error) {
+      const failed = serializeBotWorkerFailure(error, options.pretty)
+      process.stderr.write(`${failed}\n`)
+      process.exit(1)
+    }
+  })
+
+export async function runBotWorker(options: BotWorkerCommandOptions = {}): Promise<BotWorkerCommandResult> {
+  if (!options.updateFile && !options.pollOnce) {
+    throw new Error("Provide --update-file or --poll-once")
+  }
+
+  if (options.pollOnce && !options.telegramBotToken) {
+    throw new Error("--telegram-bot-token is required with --poll-once")
+  }
+
+  const services = await initNodeApp({
+    autoConnect: false,
+    botMediaResolver: createBotMediaResolverOptions(options),
+    botStatus: createBotStatusOptions(options),
+    publish: createBotPublishOptions(options),
+    rustRender: options.rustRender
+      ? {
+          command: options.rustRenderCommand,
+          commandKind: options.rustRenderKind,
+        }
+      : undefined,
+  })
+  const worker = new NodeTelegramBotWorker({
+    workflow: services.botWorkflow,
+    botToken: options.telegramBotToken,
+    workflowOptions: {
+      intake: {
+        defaultDestination: options.defaultDestination,
+        defaultOutputPath: options.defaultOutput,
+      },
+      render: {
+        pollIntervalMs: parsePositiveInteger(options.pollInterval, 1000),
+        timeoutMs: parsePositiveInteger(options.timeout, 3600000),
+      },
+      includeReconnectState: true,
+    },
+  })
+
+  if (options.updateFile) {
+    return worker.handleUpdate(await readTelegramBotUpdate(options.updateFile))
+  }
+
+  return worker.pollOnce({
+    offset: parseOptionalPositiveInteger(options.pollOffset),
+    limit: parsePositiveInteger(options.pollLimit, 100),
+    timeoutSeconds: parsePositiveInteger(options.pollTimeout, 25),
+  })
+}
+
+export async function readTelegramBotUpdate(updateFile: string): Promise<TelegramBotUpdate> {
+  const updatePath = path.resolve(updateFile)
+  const content = await fs.readFile(updatePath, "utf-8")
+  const parsed = JSON.parse(content) as TelegramBotUpdate
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("Telegram update JSON must be an object")
+  }
+
+  if (!Number.isFinite(parsed.update_id)) {
+    throw new Error("Telegram update JSON must include numeric update_id")
+  }
+
+  return parsed
+}
+
+export function serializeBotWorkerResult(result: BotWorkerCommandResult, pretty = false): string {
+  return JSON.stringify(result, null, pretty ? 2 : 0)
+}
+
+function createBotMediaResolverOptions(options: BotWorkerCommandOptions) {
+  if (!options.telegramBotToken && !options.mediaDir && !options.downloadRemoteMedia) {
+    return undefined
+  }
+
+  return {
+    ...(options.mediaDir ? { downloadDir: path.resolve(options.mediaDir) } : {}),
+    downloadRemoteUrls: options.downloadRemoteMedia ?? false,
+    ...(options.telegramBotToken
+      ? {
+          telegram: {
+            botToken: options.telegramBotToken,
+          },
+        }
+      : {}),
+  }
+}
+
+function createBotStatusOptions(options: BotWorkerCommandOptions) {
+  if (options.statusUpdates === false || !options.telegramBotToken) {
+    return undefined
+  }
+
+  return {
+    telegram: {
+      botToken: options.telegramBotToken,
+      ...(options.statusChatId ? { defaultChatId: options.statusChatId } : {}),
+    },
+  }
+}
+
+function createBotPublishOptions(options: BotWorkerCommandOptions) {
+  if (!options.telegramBotToken) {
+    return undefined
+  }
+
+  return {
+    telegram: {
+      botToken: options.telegramBotToken,
+      ...(options.statusChatId ? { defaultChatId: options.statusChatId } : {}),
+    },
+  }
+}
+
+function isFailedWorkerResult(result: BotWorkerCommandResult): boolean {
+  if ("updates" in result) {
+    return result.updates.some(isFailedUpdateResult)
+  }
+
+  return isFailedUpdateResult(result)
+}
+
+function isFailedUpdateResult(result: NodeTelegramBotWorkerUpdateResult): boolean {
+  if (result.skipped) return false
+  if (!result.result.ok) return true
+  return result.result.result.job.status === "failed" || result.result.result.job.status === "cancelled"
+}
+
+function serializeBotWorkerFailure(error: unknown, pretty = false): string {
+  return JSON.stringify(
+    {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    },
+    null,
+    pretty ? 2 : 0,
+  )
+}
+
+function parsePositiveInteger(value: string | undefined, fallback: number): number {
+  if (!value) return fallback
+  const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+function parseOptionalPositiveInteger(value: string | undefined): number | undefined {
+  if (!value) return undefined
+  const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined
+}

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -2,6 +2,7 @@
  * CLI Commands
  */
 
+export { botWorkerCommand } from "./bot-worker"
 export { botWorkflowCommand } from "./bot-workflow"
 export { infoCommand } from "./info"
 export { renderCommand } from "./render"

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,7 @@
  */
 
 import { Command } from "commander"
-
+import { botWorkerCommand } from "./commands/bot-worker"
 import { botWorkflowCommand } from "./commands/bot-workflow"
 import { infoCommand } from "./commands/info"
 import { renderCommand } from "./commands/render"
@@ -36,6 +36,7 @@ program.addCommand(transcribeCommand)
 program.addCommand(renderCommand)
 program.addCommand(renderJobCommand)
 program.addCommand(botWorkflowCommand)
+program.addCommand(botWorkerCommand)
 
 // Запуск
 program.parse(process.argv)

--- a/src/core/services/__tests__/bot-workflow-intake.test.ts
+++ b/src/core/services/__tests__/bot-workflow-intake.test.ts
@@ -62,6 +62,8 @@ describe("bot workflow intake", () => {
 
   it("creates a render job request from template, media, params, and output hints", () => {
     const workflow = createBotWorkflowRequestFromTelegramLikePayload({
+      chat: { id: "chat-1" },
+      message_id: "message-1",
       caption: "template=promo destination=telegram audience=founders",
       document: {
         url: "https://cdn.example.com/input.mov",
@@ -87,6 +89,8 @@ describe("bot workflow intake", () => {
           },
         ],
         params: {
+          telegramChatId: "chat-1",
+          telegramReplyToMessageId: "message-1",
           audience: "founders",
         },
         output: {
@@ -100,6 +104,7 @@ describe("bot workflow intake", () => {
   it("prefers structured workflow fields over text hints", () => {
     const result = createBotRenderJobRequest({
       source: "telegram",
+      chatId: "chat-1",
       text: "template=text-template destination=file tone=calm",
       template: {
         id: "structured-template",
@@ -109,6 +114,7 @@ describe("bot workflow intake", () => {
         },
       },
       params: {
+        telegramChatId: "override-chat",
         tone: "urgent",
       },
       output: {
@@ -123,6 +129,7 @@ describe("bot workflow intake", () => {
         source: "bot",
         templateId: "structured-template",
         params: {
+          telegramChatId: "override-chat",
           tone: "urgent",
           ratio: "9:16",
         },

--- a/src/core/services/bot-workflow-intake.ts
+++ b/src/core/services/bot-workflow-intake.ts
@@ -30,7 +30,12 @@ export function createBotRenderJobRequest(
   const templateId = firstNonEmpty(workflow.template?.id, textHints.templateId, options.defaultTemplateId)
   const project = workflow.project ?? workflow.template?.project ?? projectFromText(textHints.projectPath)
   const media = normalizeMedia(workflow.media ?? [], errors)
-  const params = mergeParams(textHints.params, workflow.template?.params, workflow.params)
+  const params = mergeParams(
+    createWorkflowDefaultParams(workflow),
+    textHints.params,
+    workflow.template?.params,
+    workflow.params,
+  )
   const output = normalizeOutput(workflow, textHints.output, options, errors)
 
   if (workflow.template && !workflow.template.id.trim()) {
@@ -278,6 +283,15 @@ function projectFromText(projectPath?: string): BotRenderJobRequest["project"] {
 
 function mergeParams(...records: Array<Record<string, unknown> | undefined>): Record<string, unknown> {
   return Object.assign({}, ...records.filter(Boolean))
+}
+
+function createWorkflowDefaultParams(workflow: BotWorkflowRequest): Record<string, unknown> | undefined {
+  if (!workflow.chatId && !workflow.messageId) return undefined
+
+  return {
+    ...(workflow.chatId ? { telegramChatId: workflow.chatId } : {}),
+    ...(workflow.messageId ? { telegramReplyToMessageId: workflow.messageId } : {}),
+  }
 }
 
 function validationError(


### PR DESCRIPTION
## Summary
- add a Node Telegram bot worker that converts raw Telegram Update payloads into Telegram-like workflow payloads and can process one getUpdates batch
- add token-based Telegram sendVideo publishing and automatically pass Telegram chat/message ids into render params for publish metadata
- add the bot-worker CLI entrypoint for update-file and poll-once worker runs, plus roadmap coverage for B10

## Tests
- bun run test -- src/core/services/__tests__/bot-workflow-intake.test.ts src/adapters/node/__tests__/publish.test.ts src/adapters/node/__tests__/telegram-bot-worker.test.ts src/cli/commands/__tests__/bot-worker.test.ts src/cli/__tests__/index.test.ts src/cli/__tests__/index.integration.test.ts
- bun run check:type
- bun run check:workspaces
- bun run check:boundaries:baseline
- bunx biome ci src/core/services/bot-workflow-intake.ts src/core/services/__tests__/bot-workflow-intake.test.ts src/adapters/node/publish.ts src/adapters/node/__tests__/publish.test.ts src/adapters/node/telegram-bot-worker.ts src/adapters/node/__tests__/telegram-bot-worker.test.ts src/adapters/node/index.ts src/cli/commands/bot-worker.ts src/cli/commands/__tests__/bot-worker.test.ts src/cli/commands/index.ts src/cli/index.ts src/cli/__tests__/index.test.ts src/cli/__tests__/index.integration.test.ts docs/08_tasks/planned/bot-first-workflow.md
- git diff --check

Refs #171
Closes #189
