### PR TITLE
feat: route telegram bot commands

### DIFF
--- a/docs/08_tasks/planned/bot-first-workflow.md
+++ b/docs/08_tasks/planned/bot-first-workflow.md
@@ -135,6 +135,16 @@ bot message
 - [x] Сохранить поведение `--poll-once` без изменений.
 - [x] Покрыть polling loop, offset persistence, file offset store и CLI contract tests.
 
+### B12: Telegram bot command routing ([#193](https://github.com/chatman-media/timeline-studio/issues/193))
+
+**Цель:** обрабатывать служебные команды бота до render workflow, чтобы `/start` и `/help` не превращались в validation error.
+
+- [x] Добавить detection для `/start` и `/help` в Node Telegram worker.
+- [x] Отправлять command responses через injected responder или Telegram Bot API token.
+- [x] Возвращать machine-readable command-handled worker result без запуска render workflow.
+- [x] Оставить возможность отключить command routing для command-like workflow messages.
+- [x] Покрыть command routing, Bot API command response delivery и command parser tests.
+
 ## Связанные задачи
 
 - [#150](https://github.com/chatman-media/timeline-studio/issues/150) - Phase F / package boundaries
@@ -149,6 +159,7 @@ bot message
 - [#187](https://github.com/chatman-media/timeline-studio/issues/187) - B9: Bot status notifier
 - [#189](https://github.com/chatman-media/timeline-studio/issues/189) - B10: Telegram bot worker entrypoint
 - [#191](https://github.com/chatman-media/timeline-studio/issues/191) - B11: Telegram bot polling loop state
+- [#193](https://github.com/chatman-media/timeline-studio/issues/193) - B12: Telegram bot command routing
 - [telegram-mini-app.md](./telegram-mini-app.md)
 - [cloud-rendering.md](./cloud-rendering.md)
 - [export-architecture-refactoring.md](./export-architecture-refactoring.md)

--- a/src/adapters/node/__tests__/bot-status.test.ts
+++ b/src/adapters/node/__tests__/bot-status.test.ts
@@ -62,6 +62,39 @@ describe("NodeBotStatusNotifier", () => {
     })
   })
 
+  it("sends direct Telegram messages through Bot API fetch", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      async json() {
+        return { ok: true, result: { message_id: 9 } }
+      },
+    }))
+    const notifier = new NodeBotStatusNotifier({
+      telegram: {
+        botToken: "token-1",
+      },
+      fetch: fetchMock,
+    })
+
+    await notifier.sendMessage({
+      chatId: "42",
+      text: "Send a video file, link, project, or choose a template.",
+      replyToMessageId: "7",
+      metadata: { command: "help" },
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith("https://api.telegram.org/bottoken-1/sendMessage", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        chat_id: "42",
+        text: "Send a video file, link, project, or choose a template.",
+        reply_to_message_id: 7,
+      }),
+    })
+  })
+
   it("uses default chat id and skips delivery without a client or bot token", async () => {
     const fetchMock = vi.fn()
     const notifier = new NodeBotStatusNotifier({

--- a/src/adapters/node/__tests__/telegram-bot-worker.test.ts
+++ b/src/adapters/node/__tests__/telegram-bot-worker.test.ts
@@ -6,9 +6,11 @@ import type { BotWorkflowRunResult } from "@/core/types"
 import type { NodeBotWorkflowService } from "../bot-workflow"
 import {
   createTelegramLikePayloadFromUpdate,
+  defaultTelegramBotCommandText,
   NodeTelegramBotApiClient,
   NodeTelegramBotFileOffsetStore,
   NodeTelegramBotWorker,
+  parseTelegramBotCommand,
   type TelegramBotUpdate,
 } from "../telegram-bot-worker"
 
@@ -122,6 +124,109 @@ describe("Telegram bot worker", () => {
     expect(onResult).toHaveBeenCalledWith(result)
   })
 
+  it("routes help commands to a command responder without running workflow", async () => {
+    const { service, runTelegramLikePayload } = createWorkflowService()
+    const commandResponder = {
+      sendMessage: vi.fn(async () => ({ messageId: "help-message-1" })),
+    }
+    const worker = new NodeTelegramBotWorker({
+      workflow: service,
+      commandResponder,
+      commandFormatter: ({ command }) => `Handled ${command}`,
+    })
+    const update: TelegramBotUpdate = {
+      update_id: 13,
+      message: {
+        message_id: 9,
+        chat: { id: "chat-1" },
+        text: "/help",
+      },
+    }
+
+    const result = await worker.handleUpdate(update)
+
+    expect(result).toMatchObject({
+      skipped: true,
+      reason: "Telegram bot command handled",
+      command: "help",
+      responseText: "Handled help",
+    })
+    expect(commandResponder.sendMessage).toHaveBeenCalledWith({
+      chatId: "chat-1",
+      text: "Handled help",
+      replyToMessageId: "9",
+      metadata: {
+        command: "help",
+        source: "telegram-bot-worker",
+      },
+    })
+    expect(runTelegramLikePayload).not.toHaveBeenCalled()
+  })
+
+  it("routes start commands through Bot API when a bot token is configured", async () => {
+    const { service, runTelegramLikePayload } = createWorkflowService()
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      async json() {
+        return { ok: true, result: { message_id: 10 } }
+      },
+    }))
+    const worker = new NodeTelegramBotWorker({
+      workflow: service,
+      botToken: "token-1",
+      fetch: fetchMock,
+    })
+
+    const result = await worker.handleUpdate({
+      update_id: 14,
+      message: {
+        message_id: 10,
+        chat: { id: 42 },
+        text: "/start@TimelineStudioBot",
+      },
+    })
+
+    expect(result).toMatchObject({
+      skipped: true,
+      command: "start",
+      responseText: defaultTelegramBotCommandText(),
+    })
+    expect(fetchMock).toHaveBeenCalledWith("https://api.telegram.org/bottoken-1/sendMessage", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        chat_id: "42",
+        text: defaultTelegramBotCommandText(),
+        reply_to_message_id: 10,
+      }),
+    })
+    expect(runTelegramLikePayload).not.toHaveBeenCalled()
+  })
+
+  it("can disable command routing for command-like workflow messages", async () => {
+    const { service, runTelegramLikePayload } = createWorkflowService()
+    const worker = new NodeTelegramBotWorker({
+      workflow: service,
+      disableCommandRouting: true,
+    })
+
+    const result = await worker.handleUpdate({
+      update_id: 15,
+      message: {
+        message_id: 11,
+        chat: { id: "chat-1" },
+        text: "/help template=promo",
+      },
+    })
+
+    expect(result).toMatchObject({
+      skipped: false,
+      updateId: 15,
+    })
+    expect(runTelegramLikePayload).toHaveBeenCalledOnce()
+  })
+
   it("skips updates without supported message payloads", async () => {
     const { service, runTelegramLikePayload } = createWorkflowService()
     const worker = new NodeTelegramBotWorker({ workflow: service })
@@ -161,6 +266,13 @@ describe("Telegram bot worker", () => {
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.telegram.org/bottoken-1/getUpdates?offset=19&limit=10&timeout=25&allowed_updates=%5B%22message%22%5D",
     )
+  })
+
+  it("parses supported Telegram bot commands", () => {
+    expect(parseTelegramBotCommand("/start")).toBe("start")
+    expect(parseTelegramBotCommand("/help@TimelineStudioBot more")).toBe("help")
+    expect(parseTelegramBotCommand("/render")).toBeNull()
+    expect(parseTelegramBotCommand("template=promo")).toBeNull()
   })
 
   it("polls one update batch and returns the next offset", async () => {

--- a/src/adapters/node/bot-status.ts
+++ b/src/adapters/node/bot-status.ts
@@ -4,7 +4,7 @@ export interface NodeTelegramStatusPayload {
   chatId: string
   text: string
   replyToMessageId?: string
-  metadata?: BotWorkflowStatusMessage
+  metadata?: unknown
 }
 
 export interface NodeTelegramStatusResult {
@@ -62,25 +62,33 @@ export class NodeBotStatusNotifier implements BotWorkflowStatusSink {
     const chatId = message.chatId ?? this.defaultChatId
     if (!chatId) return
 
+    await this.sendMessage({
+      chatId,
+      text: message.text,
+      ...(message.messageId ? { replyToMessageId: message.messageId } : {}),
+      metadata: message,
+    })
+  }
+
+  async sendMessage(payload: NodeTelegramStatusPayload): Promise<NodeTelegramStatusResult> {
+    const chatId = payload.chatId ?? this.defaultChatId
+    if (!chatId) return {}
+
     if (this.client) {
-      await this.client.sendMessage({
-        chatId,
-        text: message.text,
-        ...(message.messageId ? { replyToMessageId: message.messageId } : {}),
-        metadata: message,
-      })
-      return
+      return this.client.sendMessage({ ...payload, chatId })
     }
 
-    if (!this.botToken) return
+    if (!this.botToken) return {}
 
     const response = await this.fetch(`https://api.telegram.org/bot${this.botToken}/sendMessage`, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
         chat_id: chatId,
-        text: message.text,
-        ...(message.messageId ? { reply_to_message_id: Number(message.messageId) || message.messageId } : {}),
+        text: payload.text,
+        ...(payload.replyToMessageId
+          ? { reply_to_message_id: Number(payload.replyToMessageId) || payload.replyToMessageId }
+          : {}),
       }),
     })
 
@@ -92,6 +100,8 @@ export class NodeBotStatusNotifier implements BotWorkflowStatusSink {
     if (body && body.ok === false) {
       throw new Error(body.description ?? "Telegram sendMessage failed")
     }
+
+    return body?.result?.message_id === undefined ? {} : { messageId: String(body.result.message_id) }
   }
 }
 

--- a/src/adapters/node/index.ts
+++ b/src/adapters/node/index.ts
@@ -61,8 +61,12 @@ export { type NodeRustRenderVideoOptions, NodeRustRenderVideoService } from "./r
 export { type NodeStorageOptions, NodeStorageService } from "./storage"
 export {
   createTelegramLikePayloadFromUpdate,
+  defaultTelegramBotCommandText,
   NodeTelegramBotApiClient,
   type NodeTelegramBotClient,
+  type NodeTelegramBotCommand,
+  type NodeTelegramBotCommandFormatter,
+  type NodeTelegramBotCommandFormatterContext,
   NodeTelegramBotFileOffsetStore,
   type NodeTelegramBotFileOffsetStoreState,
   type NodeTelegramBotOffsetStore,
@@ -74,6 +78,7 @@ export {
   type NodeTelegramBotWorkerRunOptions,
   type NodeTelegramBotWorkerRunResult,
   type NodeTelegramBotWorkerUpdateResult,
+  parseTelegramBotCommand,
   type TelegramBotFetch,
   type TelegramBotFetchResponse,
   type TelegramBotFile,

--- a/src/adapters/node/telegram-bot-worker.ts
+++ b/src/adapters/node/telegram-bot-worker.ts
@@ -3,6 +3,7 @@ import path from "node:path"
 
 import type { BotWorkflowRunResult, TelegramLikeBotFile, TelegramLikeBotPayload } from "@/core/types"
 
+import { NodeBotStatusNotifier, type NodeTelegramStatusClient } from "./bot-status"
 import type { NodeBotWorkflowService, NodeBotWorkflowServiceOptions } from "./bot-workflow"
 
 export interface TelegramBotFile {
@@ -64,6 +65,9 @@ export interface NodeTelegramBotClient {
 export interface NodeTelegramBotWorkerOptions {
   workflow: NodeBotWorkflowService
   client?: NodeTelegramBotClient
+  commandResponder?: NodeTelegramStatusClient
+  commandFormatter?: NodeTelegramBotCommandFormatter
+  disableCommandRouting?: boolean
   botToken?: string
   fetch?: TelegramBotFetch
   workflowOptions?: NodeBotWorkflowServiceOptions
@@ -74,12 +78,25 @@ export interface NodeTelegramBotWorkerHandleOptions {
   workflowOptions?: NodeBotWorkflowServiceOptions
 }
 
+export type NodeTelegramBotCommand = "start" | "help"
+
+export interface NodeTelegramBotCommandFormatterContext {
+  command: NodeTelegramBotCommand
+  payload: TelegramLikeBotPayload
+  update: TelegramBotUpdate
+}
+
+export type NodeTelegramBotCommandFormatter = (context: NodeTelegramBotCommandFormatterContext) => string
+
 export type NodeTelegramBotWorkerUpdateResult =
   | {
       skipped: true
       reason: string
       updateId: number
       update: TelegramBotUpdate
+      command?: NodeTelegramBotCommand
+      payload?: TelegramLikeBotPayload
+      responseText?: string
     }
   | {
       skipped: false
@@ -214,6 +231,27 @@ export class NodeTelegramBotWorker {
       return result
     }
 
+    const command = this.options.disableCommandRouting ? null : parseTelegramBotCommand(payload.text)
+    if (command) {
+      const responseText = (this.options.commandFormatter ?? defaultTelegramBotCommandText)({
+        command,
+        payload,
+        update,
+      })
+      await this.sendCommandResponse(command, payload, responseText)
+      const result: NodeTelegramBotWorkerUpdateResult = {
+        skipped: true,
+        reason: "Telegram bot command handled",
+        updateId: update.update_id,
+        update,
+        command,
+        payload,
+        responseText,
+      }
+      await this.options.onResult?.(result)
+      return result
+    }
+
     const result: NodeTelegramBotWorkerUpdateResult = {
       skipped: false,
       updateId: update.update_id,
@@ -298,6 +336,37 @@ export class NodeTelegramBotWorker {
     }
     return new NodeTelegramBotApiClient(this.options.botToken, { fetch: this.options.fetch })
   }
+
+  private async sendCommandResponse(
+    command: NodeTelegramBotCommand,
+    payload: TelegramLikeBotPayload,
+    text: string,
+  ): Promise<void> {
+    const chatId = payload.chat?.id === undefined ? undefined : String(payload.chat.id)
+    if (!chatId) return
+
+    const responder = this.resolveCommandResponder()
+    await responder?.sendMessage({
+      chatId,
+      text,
+      ...(payload.message_id !== undefined ? { replyToMessageId: String(payload.message_id) } : {}),
+      metadata: {
+        command,
+        source: "telegram-bot-worker",
+      },
+    })
+  }
+
+  private resolveCommandResponder(): NodeTelegramStatusClient | undefined {
+    if (this.options.commandResponder) return this.options.commandResponder
+    if (!this.options.botToken) return undefined
+    return new NodeBotStatusNotifier({
+      telegram: {
+        botToken: this.options.botToken,
+      },
+      fetch: this.options.fetch,
+    })
+  }
 }
 
 export function createTelegramLikePayloadFromUpdate(update: TelegramBotUpdate): TelegramLikeBotPayload | null {
@@ -326,6 +395,32 @@ function telegramFile(file: TelegramBotFile): TelegramLikeBotFile {
     ...(file.mime_type ? { mime_type: file.mime_type } : {}),
     ...(file.file_path ? { file_path: file.file_path } : {}),
   }
+}
+
+export function parseTelegramBotCommand(text: string | undefined): NodeTelegramBotCommand | null {
+  const token = text?.trim().split(/\s+/)[0]?.toLowerCase()
+  if (!token?.startsWith("/")) return null
+
+  const command = token.split("@")[0]
+  switch (command) {
+    case "/start":
+      return "start"
+    case "/help":
+      return "help"
+    default:
+      return null
+  }
+}
+
+export function defaultTelegramBotCommandText(): string {
+  return [
+    "Timeline Studio bot",
+    "Send a video, link, or project with render hints.",
+    "Examples:",
+    "template=promo destination=telegram",
+    'project="./project.json" destination=file output="./out.mp4"',
+    "Options: template, project, destination, output, resolution.",
+  ].join("\n")
 }
 
 function mergeWorkflowOptions(


### PR DESCRIPTION
## Summary
- add Telegram `/start` and `/help` command routing before render workflow handling
- send command responses through an injected responder or the Telegram Bot API token-backed status notifier transport
- return machine-readable command-handled worker results and expose parser/default text helpers
- document B12 in the bot-first workflow roadmap

## Tests
- bun run test -- src/adapters/node/__tests__/bot-status.test.ts src/adapters/node/__tests__/telegram-bot-worker.test.ts
- bun run check:type
- bun run check:workspaces
- bun run check:boundaries:baseline
- bunx biome ci src/adapters/node/bot-status.ts src/adapters/node/__tests__/bot-status.test.ts src/adapters/node/telegram-bot-worker.ts src/adapters/node/__tests__/telegram-bot-worker.test.ts src/adapters/node/index.ts docs/08_tasks/planned/bot-first-workflow.md
- git diff --check

Refs #171
Closes #193
