### PR TITLE
feat: add bot worker runtime defaults

### DIFF
--- a/docs/08_tasks/planned/bot-first-workflow.md
+++ b/docs/08_tasks/planned/bot-first-workflow.md
@@ -145,6 +145,16 @@ bot message
 - [x] Оставить возможность отключить command routing для command-like workflow messages.
 - [x] Покрыть command routing, Bot API command response delivery и command parser tests.
 
+### B13: Bot worker runtime config and smoke runbook ([#195](https://github.com/chatman-media/timeline-studio/issues/195))
+
+**Цель:** сделать Telegram bot worker проще запускать и проверять локально без длинных команд и ручных fixtures.
+
+- [x] Добавить env-backed defaults для Telegram token, media dir, offset file, destination, Rust render и polling timings.
+- [x] Сохранить приоритет явных CLI flags над env defaults.
+- [x] Добавить committed Telegram `/help` smoke update fixture.
+- [x] Документировать one-shot smoke и continuous polling worker runbook в CLI README.
+- [x] Покрыть env default precedence и CLI contract tests.
+
 ## Связанные задачи
 
 - [#150](https://github.com/chatman-media/timeline-studio/issues/150) - Phase F / package boundaries
@@ -160,6 +170,7 @@ bot message
 - [#189](https://github.com/chatman-media/timeline-studio/issues/189) - B10: Telegram bot worker entrypoint
 - [#191](https://github.com/chatman-media/timeline-studio/issues/191) - B11: Telegram bot polling loop state
 - [#193](https://github.com/chatman-media/timeline-studio/issues/193) - B12: Telegram bot command routing
+- [#195](https://github.com/chatman-media/timeline-studio/issues/195) - B13: Bot worker runtime config and smoke runbook
 - [telegram-mini-app.md](./telegram-mini-app.md)
 - [cloud-rendering.md](./cloud-rendering.md)
 - [export-architecture-refactoring.md](./export-architecture-refactoring.md)

--- a/docs/08_tasks/planned/fixtures/telegram-help-update.json
+++ b/docs/08_tasks/planned/fixtures/telegram-help-update.json
@@ -1,0 +1,13 @@
+{
+  "update_id": 1000001,
+  "message": {
+    "message_id": 1,
+    "chat": {
+      "id": "smoke-chat"
+    },
+    "from": {
+      "id": "smoke-user"
+    },
+    "text": "/help"
+  }
+}

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -110,6 +110,39 @@ npx ts-node src/cli/index.ts render project.json output.mp4 --verbose
 | `--no-audio` | Отключить аудио |
 | `-v, --verbose` | Подробный вывод |
 
+### bot-worker - Telegram bot-first worker
+
+Запуск Telegram worker для bot-first workflow: обработка raw `Update`, один `getUpdates` batch или долгоживущий polling loop.
+
+```bash
+# Локальный smoke без Telegram token и без сетевых вызовов
+bun run src/cli/index.ts bot-worker \
+  --update-file docs/08_tasks/planned/fixtures/telegram-help-update.json \
+  --pretty
+
+# Один getUpdates batch
+TIMELINE_BOT_TELEGRAM_TOKEN=123:token \
+bun run src/cli/index.ts bot-worker --poll-once --pretty
+
+# Долгоживущий polling worker с сохранением offset
+TIMELINE_BOT_TELEGRAM_TOKEN=123:token \
+TIMELINE_BOT_OFFSET_FILE=.tmp/timeline-bot/offset.json \
+TIMELINE_BOT_MEDIA_DIR=.tmp/timeline-bot/media \
+bun run src/cli/index.ts bot-worker --poll --rust-render
+```
+
+**Опции:**
+| Опция | Описание |
+|-------|----------|
+| `--update-file <path>` | Обработать один raw Telegram `Update` JSON |
+| `--poll-once` | Получить и обработать один `getUpdates` batch |
+| `--poll` | Запустить continuous polling loop |
+| `--offset-file <path>` | Сохранять Telegram offset между рестартами |
+| `--max-batches <count>` | Остановить polling после N batches |
+| `--media-dir <path>` | Папка для скачанных Telegram/remote media |
+| `--telegram-bot-token <token>` | Telegram Bot API token |
+| `--rust-render` | Использовать Rust headless render adapter |
+
 ## Переменные окружения
 
 ```bash
@@ -118,7 +151,16 @@ export OPENAI_API_KEY=sk-...
 
 # Путь к FFmpeg (опционально)
 export FFMPEG_PATH=/usr/local/bin/ffmpeg
+
+# Bot worker runtime defaults
+export TIMELINE_BOT_TELEGRAM_TOKEN=123:token
+export TIMELINE_BOT_OFFSET_FILE=.tmp/timeline-bot/offset.json
+export TIMELINE_BOT_MEDIA_DIR=.tmp/timeline-bot/media
+export TIMELINE_BOT_DEFAULT_DESTINATION=telegram
+export TIMELINE_BOT_RUST_RENDER=true
 ```
+
+`bot-worker` also accepts `TELEGRAM_BOT_TOKEN` as a generic fallback. Explicit CLI flags take priority over `TIMELINE_BOT_*` environment defaults.
 
 ## Примеры использования
 

--- a/src/cli/commands/__tests__/bot-worker.test.ts
+++ b/src/cli/commands/__tests__/bot-worker.test.ts
@@ -6,7 +6,12 @@ import fs from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
-import { botWorkerCommand, readTelegramBotUpdate, serializeBotWorkerResult } from "../bot-worker"
+import {
+  botWorkerCommand,
+  readTelegramBotUpdate,
+  resolveBotWorkerCommandOptions,
+  serializeBotWorkerResult,
+} from "../bot-worker"
 
 describe("bot-worker command", () => {
   let tempDir: string
@@ -78,5 +83,76 @@ describe("bot-worker command", () => {
 
     expect(serializeBotWorkerResult(result)).not.toContain("\n")
     expect(serializeBotWorkerResult(result, true)).toContain("\n")
+  })
+
+  it("resolves bot worker defaults from environment variables", () => {
+    const resolved = resolveBotWorkerCommandOptions(
+      {},
+      {
+        TELEGRAM_BOT_TOKEN: "token-from-telegram-env",
+        TIMELINE_BOT_TELEGRAM_TOKEN: "token-from-timeline-env",
+        TIMELINE_BOT_STATUS_CHAT_ID: "chat-1",
+        TIMELINE_BOT_OFFSET_FILE: ".tmp/bot-offset.json",
+        TIMELINE_BOT_MEDIA_DIR: ".tmp/media",
+        TIMELINE_BOT_POLL_LIMIT: "10",
+        TIMELINE_BOT_POLL_TIMEOUT: "20",
+        TIMELINE_BOT_IDLE_DELAY: "30",
+        TIMELINE_BOT_MAX_BATCHES: "2",
+        TIMELINE_BOT_RENDER_POLL_INTERVAL: "40",
+        TIMELINE_BOT_RENDER_TIMEOUT: "50",
+        TIMELINE_BOT_DEFAULT_DESTINATION: "telegram",
+        TIMELINE_BOT_DEFAULT_OUTPUT: ".tmp/out.mp4",
+        TIMELINE_BOT_DOWNLOAD_REMOTE_MEDIA: "true",
+        TIMELINE_BOT_RUST_RENDER: "1",
+        TIMELINE_BOT_RUST_RENDER_COMMAND: "timeline-render",
+        TIMELINE_BOT_RUST_RENDER_KIND: "timeline-render",
+      },
+    )
+
+    expect(resolved).toMatchObject({
+      telegramBotToken: "token-from-timeline-env",
+      statusChatId: "chat-1",
+      offsetFile: ".tmp/bot-offset.json",
+      mediaDir: ".tmp/media",
+      pollLimit: "10",
+      pollTimeout: "20",
+      idleDelay: "30",
+      maxBatches: "2",
+      pollInterval: "40",
+      timeout: "50",
+      defaultDestination: "telegram",
+      defaultOutput: ".tmp/out.mp4",
+      downloadRemoteMedia: true,
+      rustRender: true,
+      rustRenderCommand: "timeline-render",
+      rustRenderKind: "timeline-render",
+    })
+  })
+
+  it("keeps explicit bot worker CLI options above environment defaults", () => {
+    const resolved = resolveBotWorkerCommandOptions(
+      {
+        telegramBotToken: "token-from-cli",
+        offsetFile: ".tmp/cli-offset.json",
+        defaultDestination: "file",
+        rustRender: false,
+        downloadRemoteMedia: false,
+      },
+      {
+        TIMELINE_BOT_TELEGRAM_TOKEN: "token-from-env",
+        TIMELINE_BOT_OFFSET_FILE: ".tmp/env-offset.json",
+        TIMELINE_BOT_DEFAULT_DESTINATION: "telegram",
+        TIMELINE_BOT_RUST_RENDER: "true",
+        TIMELINE_BOT_DOWNLOAD_REMOTE_MEDIA: "true",
+      },
+    )
+
+    expect(resolved).toMatchObject({
+      telegramBotToken: "token-from-cli",
+      offsetFile: ".tmp/cli-offset.json",
+      defaultDestination: "file",
+      rustRender: false,
+      downloadRemoteMedia: false,
+    })
   })
 })

--- a/src/cli/commands/bot-worker.ts
+++ b/src/cli/commands/bot-worker.ts
@@ -94,60 +94,62 @@ export const botWorkerCommand = new Command("bot-worker")
   })
 
 export async function runBotWorker(options: BotWorkerCommandOptions = {}): Promise<BotWorkerCommandResult> {
-  if (!options.updateFile && !options.pollOnce && !options.poll) {
+  const resolvedOptions = resolveBotWorkerCommandOptions(options)
+
+  if (!resolvedOptions.updateFile && !resolvedOptions.pollOnce && !resolvedOptions.poll) {
     throw new Error("Provide --update-file, --poll-once, or --poll")
   }
 
-  if ((options.pollOnce || options.poll) && !options.telegramBotToken) {
+  if ((resolvedOptions.pollOnce || resolvedOptions.poll) && !resolvedOptions.telegramBotToken) {
     throw new Error("--telegram-bot-token is required with --poll-once or --poll")
   }
 
   const services = await initNodeApp({
     autoConnect: false,
-    botMediaResolver: createBotMediaResolverOptions(options),
-    botStatus: createBotStatusOptions(options),
-    publish: createBotPublishOptions(options),
-    rustRender: options.rustRender
+    botMediaResolver: createBotMediaResolverOptions(resolvedOptions),
+    botStatus: createBotStatusOptions(resolvedOptions),
+    publish: createBotPublishOptions(resolvedOptions),
+    rustRender: resolvedOptions.rustRender
       ? {
-          command: options.rustRenderCommand,
-          commandKind: options.rustRenderKind,
+          command: resolvedOptions.rustRenderCommand,
+          commandKind: resolvedOptions.rustRenderKind,
         }
       : undefined,
   })
   const worker = new NodeTelegramBotWorker({
     workflow: services.botWorkflow,
-    botToken: options.telegramBotToken,
+    botToken: resolvedOptions.telegramBotToken,
     workflowOptions: {
       intake: {
-        defaultDestination: options.defaultDestination,
-        defaultOutputPath: options.defaultOutput,
+        defaultDestination: resolvedOptions.defaultDestination,
+        defaultOutputPath: resolvedOptions.defaultOutput,
       },
       render: {
-        pollIntervalMs: parsePositiveInteger(options.pollInterval, 1000),
-        timeoutMs: parsePositiveInteger(options.timeout, 3600000),
+        pollIntervalMs: parsePositiveInteger(resolvedOptions.pollInterval, 1000),
+        timeoutMs: parsePositiveInteger(resolvedOptions.timeout, 3600000),
       },
       includeReconnectState: true,
     },
   })
 
-  if (options.updateFile) {
-    return worker.handleUpdate(await readTelegramBotUpdate(options.updateFile))
+  if (resolvedOptions.updateFile) {
+    return worker.handleUpdate(await readTelegramBotUpdate(resolvedOptions.updateFile))
   }
 
-  const offset = parseOptionalPositiveInteger(options.pollOffset)
-  const limit = parsePositiveInteger(options.pollLimit, 100)
-  const timeoutSeconds = parsePositiveInteger(options.pollTimeout, 25)
+  const offset = parseOptionalPositiveInteger(resolvedOptions.pollOffset)
+  const limit = parsePositiveInteger(resolvedOptions.pollLimit, 100)
+  const timeoutSeconds = parsePositiveInteger(resolvedOptions.pollTimeout, 25)
 
-  if (options.poll) {
+  if (resolvedOptions.poll) {
     return worker.runPolling({
       offset,
       limit,
       timeoutSeconds,
-      offsetStore: options.offsetFile
-        ? new NodeTelegramBotFileOffsetStore(path.resolve(options.offsetFile))
+      offsetStore: resolvedOptions.offsetFile
+        ? new NodeTelegramBotFileOffsetStore(path.resolve(resolvedOptions.offsetFile))
         : undefined,
-      maxBatches: parseOptionalPositiveInteger(options.maxBatches),
-      idleDelayMs: parsePositiveInteger(options.idleDelay, 1000),
+      maxBatches: parseOptionalPositiveInteger(resolvedOptions.maxBatches),
+      idleDelayMs: parsePositiveInteger(resolvedOptions.idleDelay, 1000),
     })
   }
 
@@ -156,6 +158,39 @@ export async function runBotWorker(options: BotWorkerCommandOptions = {}): Promi
     limit,
     timeoutSeconds,
   })
+}
+
+export function resolveBotWorkerCommandOptions(
+  options: BotWorkerCommandOptions,
+  env: Record<string, string | undefined> = process.env,
+): BotWorkerCommandOptions {
+  return {
+    ...options,
+    telegramBotToken: firstConfigured(
+      options.telegramBotToken,
+      env.TIMELINE_BOT_TELEGRAM_TOKEN,
+      env.TELEGRAM_BOT_TOKEN,
+    ),
+    statusChatId: firstConfigured(options.statusChatId, env.TIMELINE_BOT_STATUS_CHAT_ID),
+    pollOffset: firstConfigured(options.pollOffset, env.TIMELINE_BOT_POLL_OFFSET),
+    pollLimit: firstConfigured(options.pollLimit, env.TIMELINE_BOT_POLL_LIMIT),
+    pollTimeout: firstConfigured(options.pollTimeout, env.TIMELINE_BOT_POLL_TIMEOUT),
+    offsetFile: firstConfigured(options.offsetFile, env.TIMELINE_BOT_OFFSET_FILE),
+    maxBatches: firstConfigured(options.maxBatches, env.TIMELINE_BOT_MAX_BATCHES),
+    idleDelay: firstConfigured(options.idleDelay, env.TIMELINE_BOT_IDLE_DELAY),
+    mediaDir: firstConfigured(options.mediaDir, env.TIMELINE_BOT_MEDIA_DIR),
+    pollInterval: firstConfigured(options.pollInterval, env.TIMELINE_BOT_RENDER_POLL_INTERVAL),
+    timeout: firstConfigured(options.timeout, env.TIMELINE_BOT_RENDER_TIMEOUT),
+    rustRenderCommand: firstConfigured(options.rustRenderCommand, env.TIMELINE_BOT_RUST_RENDER_COMMAND),
+    rustRenderKind: firstConfigured(options.rustRenderKind, normalizeRustRenderKind(env.TIMELINE_BOT_RUST_RENDER_KIND)),
+    defaultDestination: firstConfigured(
+      options.defaultDestination,
+      normalizeDestination(env.TIMELINE_BOT_DEFAULT_DESTINATION),
+    ),
+    defaultOutput: firstConfigured(options.defaultOutput, env.TIMELINE_BOT_DEFAULT_OUTPUT),
+    downloadRemoteMedia: options.downloadRemoteMedia ?? parseBooleanEnv(env.TIMELINE_BOT_DOWNLOAD_REMOTE_MEDIA),
+    rustRender: options.rustRender ?? parseBooleanEnv(env.TIMELINE_BOT_RUST_RENDER),
+  }
 }
 
 export async function readTelegramBotUpdate(updateFile: string): Promise<TelegramBotUpdate> {
@@ -261,4 +296,49 @@ function parseOptionalPositiveInteger(value: string | undefined): number | undef
   if (!value) return undefined
   const parsed = Number.parseInt(value, 10)
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined
+}
+
+function firstConfigured<T extends string>(...values: Array<T | undefined>): T | undefined {
+  return values.find((value): value is T => value !== undefined && value.trim().length > 0)
+}
+
+function parseBooleanEnv(value: string | undefined): boolean | undefined {
+  if (!value) return undefined
+  switch (value.trim().toLowerCase()) {
+    case "1":
+    case "true":
+    case "yes":
+    case "on":
+      return true
+    case "0":
+    case "false":
+    case "no":
+    case "off":
+      return false
+    default:
+      return undefined
+  }
+}
+
+function normalizeDestination(value: string | undefined): BotRenderJobDestination | undefined {
+  switch (value?.trim()) {
+    case "file":
+    case "telegram":
+    case "youtube":
+    case "tiktok":
+    case "vimeo":
+      return value.trim() as BotRenderJobDestination
+    default:
+      return undefined
+  }
+}
+
+function normalizeRustRenderKind(value: string | undefined): BotWorkerCommandOptions["rustRenderKind"] {
+  switch (value?.trim()) {
+    case "timeline":
+    case "timeline-render":
+      return value.trim() as BotWorkerCommandOptions["rustRenderKind"]
+    default:
+      return undefined
+  }
 }


### PR DESCRIPTION
## Summary
- add env-backed runtime defaults for bot-worker Telegram token, media/offset paths, polling, render, destination, and Rust render options
- keep explicit CLI flags above environment defaults and cover precedence in tests
- add a committed `/help` Telegram update smoke fixture and document one-shot smoke plus continuous polling runbook
- document B13 in the bot-first workflow roadmap

## Tests
- bun run test -- src/cli/commands/__tests__/bot-worker.test.ts
- bun run src/cli/index.ts bot-worker --update-file docs/08_tasks/planned/fixtures/telegram-help-update.json --pretty
- bun run check:type
- bun run check:workspaces
- bun run check:boundaries:baseline
- bunx biome ci src/cli/commands/bot-worker.ts src/cli/commands/__tests__/bot-worker.test.ts src/cli/README.md docs/08_tasks/planned/bot-first-workflow.md docs/08_tasks/planned/fixtures/telegram-help-update.json
- git diff --check

Refs #171
Closes #195
