### PR TITLE
B14: Telegram bot update error isolation

### DIFF
--- a/docs/08_tasks/planned/bot-first-workflow.md
+++ b/docs/08_tasks/planned/bot-first-workflow.md
@@ -155,6 +155,16 @@ bot message
 - [x] Документировать one-shot smoke и continuous polling worker runbook в CLI README.
 - [x] Покрыть env default precedence и CLI contract tests.
 
+### B14: Telegram bot update error isolation ([#197](https://github.com/chatman-media/timeline-studio/issues/197))
+
+**Цель:** один проблемный Telegram update не должен валить polling worker и заставлять бота переобрабатывать тот же input после рестарта.
+
+- [x] Изолировать update-level exceptions внутри `pollOnce`, сохраняя наружу Bot API `getUpdates` failures.
+- [x] Возвращать machine-readable failed update result в worker JSON output.
+- [x] Продолжать обработку batch и продвигать `nextOffset` после failed update.
+- [x] Отвечать в Telegram chat коротким error message, когда в update есть chat/message metadata.
+- [x] Покрыть polling isolation, error reply delivery и CLI failed-result detection tests.
+
 ## Связанные задачи
 
 - [#150](https://github.com/chatman-media/timeline-studio/issues/150) - Phase F / package boundaries
@@ -171,6 +181,7 @@ bot message
 - [#191](https://github.com/chatman-media/timeline-studio/issues/191) - B11: Telegram bot polling loop state
 - [#193](https://github.com/chatman-media/timeline-studio/issues/193) - B12: Telegram bot command routing
 - [#195](https://github.com/chatman-media/timeline-studio/issues/195) - B13: Bot worker runtime config and smoke runbook
+- [#197](https://github.com/chatman-media/timeline-studio/issues/197) - B14: Telegram bot update error isolation
 - [telegram-mini-app.md](./telegram-mini-app.md)
 - [cloud-rendering.md](./cloud-rendering.md)
 - [export-architecture-refactoring.md](./export-architecture-refactoring.md)

--- a/src/adapters/node/__tests__/telegram-bot-worker.test.ts
+++ b/src/adapters/node/__tests__/telegram-bot-worker.test.ts
@@ -7,6 +7,7 @@ import type { NodeBotWorkflowService } from "../bot-workflow"
 import {
   createTelegramLikePayloadFromUpdate,
   defaultTelegramBotCommandText,
+  defaultTelegramBotUpdateErrorText,
   NodeTelegramBotApiClient,
   NodeTelegramBotFileOffsetStore,
   NodeTelegramBotWorker,
@@ -293,6 +294,100 @@ describe("Telegram bot worker", () => {
     expect(result.updates[0]).toMatchObject({ skipped: false, updateId: 30 })
     expect(result.updates[1]).toMatchObject({ skipped: true, updateId: 32 })
     expect(runTelegramLikePayload).toHaveBeenCalledOnce()
+  })
+
+  it("isolates per-update polling errors, replies, and continues the batch", async () => {
+    const runTelegramLikePayload = vi.fn(async (payload: { text?: string }) => {
+      if (payload.text === "bad") {
+        throw new Error("Media resolver failed")
+      }
+
+      return failedResult
+    })
+    const service = { runTelegramLikePayload } as unknown as NodeBotWorkflowService
+    const client = {
+      getUpdates: vi.fn(async () => [
+        { update_id: 50, message: { message_id: 1, chat: { id: "chat-1" }, text: "bad" } },
+        { update_id: 52, message: { message_id: 2, chat: { id: "chat-1" }, text: "template=promo" } },
+      ]),
+    }
+    const errorResponder = {
+      sendMessage: vi.fn(async () => ({ messageId: "error-message-1" })),
+    }
+    const onResult = vi.fn()
+    const worker = new NodeTelegramBotWorker({ workflow: service, client, errorResponder, onResult })
+
+    const result = await worker.pollOnce({ offset: 50, timeoutSeconds: 1 })
+
+    expect(result.nextOffset).toBe(53)
+    expect(result.updates).toHaveLength(2)
+    expect(result.updates[0]).toMatchObject({
+      skipped: false,
+      failed: true,
+      reason: "Telegram update handling failed",
+      updateId: 50,
+      error: "Media resolver failed",
+      responseText: defaultTelegramBotUpdateErrorText(),
+    })
+    expect(result.updates[1]).toMatchObject({
+      skipped: false,
+      updateId: 52,
+      result: failedResult,
+    })
+    expect(errorResponder.sendMessage).toHaveBeenCalledWith({
+      chatId: "chat-1",
+      text: defaultTelegramBotUpdateErrorText(),
+      replyToMessageId: "1",
+      metadata: {
+        error: true,
+        source: "telegram-bot-worker",
+        updateId: 50,
+      },
+    })
+    expect(runTelegramLikePayload).toHaveBeenCalledTimes(2)
+    expect(onResult).toHaveBeenNthCalledWith(1, result.updates[0])
+    expect(onResult).toHaveBeenNthCalledWith(2, result.updates[1])
+  })
+
+  it("does not let update error response failures abort polling", async () => {
+    const runTelegramLikePayload = vi.fn(async () => {
+      throw new Error("Workflow failed")
+    })
+    const service = { runTelegramLikePayload } as unknown as NodeBotWorkflowService
+    const client = {
+      getUpdates: vi.fn(async () => [
+        { update_id: 60, message: { message_id: 1, chat: { id: "chat-1" }, text: "template=promo" } },
+      ]),
+    }
+    const errorResponder = {
+      sendMessage: vi.fn(async () => {
+        throw new Error("Telegram send failed")
+      }),
+    }
+    const worker = new NodeTelegramBotWorker({ workflow: service, client, errorResponder })
+
+    const result = await worker.pollOnce({ offset: 60 })
+
+    expect(result.nextOffset).toBe(61)
+    expect(result.updates[0]).toMatchObject({
+      skipped: false,
+      failed: true,
+      updateId: 60,
+      error: "Workflow failed",
+      responseError: "Telegram send failed",
+    })
+  })
+
+  it("does not hide Telegram getUpdates failures", async () => {
+    const { service } = createWorkflowService()
+    const client = {
+      getUpdates: vi.fn(async () => {
+        throw new Error("Telegram getUpdates failed")
+      }),
+    }
+    const worker = new NodeTelegramBotWorker({ workflow: service, client })
+
+    await expect(worker.pollOnce({ offset: 70 })).rejects.toThrow("Telegram getUpdates failed")
   })
 
   it("persists Telegram polling offsets in a file store", async () => {

--- a/src/adapters/node/index.ts
+++ b/src/adapters/node/index.ts
@@ -62,6 +62,7 @@ export { type NodeStorageOptions, NodeStorageService } from "./storage"
 export {
   createTelegramLikePayloadFromUpdate,
   defaultTelegramBotCommandText,
+  defaultTelegramBotUpdateErrorText,
   NodeTelegramBotApiClient,
   type NodeTelegramBotClient,
   type NodeTelegramBotCommand,
@@ -70,6 +71,8 @@ export {
   NodeTelegramBotFileOffsetStore,
   type NodeTelegramBotFileOffsetStoreState,
   type NodeTelegramBotOffsetStore,
+  type NodeTelegramBotUpdateErrorFormatter,
+  type NodeTelegramBotUpdateErrorFormatterContext,
   NodeTelegramBotWorker,
   type NodeTelegramBotWorkerHandleOptions,
   type NodeTelegramBotWorkerOptions,

--- a/src/adapters/node/telegram-bot-worker.ts
+++ b/src/adapters/node/telegram-bot-worker.ts
@@ -67,6 +67,9 @@ export interface NodeTelegramBotWorkerOptions {
   client?: NodeTelegramBotClient
   commandResponder?: NodeTelegramStatusClient
   commandFormatter?: NodeTelegramBotCommandFormatter
+  errorResponder?: NodeTelegramStatusClient
+  errorFormatter?: NodeTelegramBotUpdateErrorFormatter
+  disableErrorResponses?: boolean
   disableCommandRouting?: boolean
   botToken?: string
   fetch?: TelegramBotFetch
@@ -88,6 +91,15 @@ export interface NodeTelegramBotCommandFormatterContext {
 
 export type NodeTelegramBotCommandFormatter = (context: NodeTelegramBotCommandFormatterContext) => string
 
+export interface NodeTelegramBotUpdateErrorFormatterContext {
+  updateId: number
+  update: TelegramBotUpdate
+  payload?: TelegramLikeBotPayload
+  error: string
+}
+
+export type NodeTelegramBotUpdateErrorFormatter = (context: NodeTelegramBotUpdateErrorFormatterContext) => string
+
 export type NodeTelegramBotWorkerUpdateResult =
   | {
       skipped: true
@@ -104,6 +116,17 @@ export type NodeTelegramBotWorkerUpdateResult =
       update: TelegramBotUpdate
       payload: TelegramLikeBotPayload
       result: BotWorkflowRunResult
+    }
+  | {
+      skipped: false
+      failed: true
+      reason: string
+      updateId: number
+      update: TelegramBotUpdate
+      payload?: TelegramLikeBotPayload
+      error: string
+      responseText?: string
+      responseError?: string
     }
 
 export interface NodeTelegramBotWorkerPollOptions extends TelegramBotGetUpdatesOptions {
@@ -274,7 +297,7 @@ export class NodeTelegramBotWorker {
     let nextOffset = options.offset
 
     for (const update of updates) {
-      results.push(await this.handleUpdate(update, { workflowOptions }))
+      results.push(await this.handlePollingUpdate(update, { workflowOptions }))
       nextOffset = Math.max(nextOffset ?? 0, update.update_id + 1)
     }
 
@@ -357,8 +380,90 @@ export class NodeTelegramBotWorker {
     })
   }
 
+  private async handlePollingUpdate(
+    update: TelegramBotUpdate,
+    options: NodeTelegramBotWorkerHandleOptions,
+  ): Promise<NodeTelegramBotWorkerUpdateResult> {
+    try {
+      return await this.handleUpdate(update, options)
+    } catch (error) {
+      return this.createUpdateErrorResult(update, error)
+    }
+  }
+
+  private async createUpdateErrorResult(
+    update: TelegramBotUpdate,
+    error: unknown,
+  ): Promise<NodeTelegramBotWorkerUpdateResult> {
+    const payload = createTelegramLikePayloadFromUpdate(update) ?? undefined
+    const errorMessage = formatUnknownError(error)
+    const responseText = this.options.disableErrorResponses
+      ? undefined
+      : (this.options.errorFormatter ?? defaultTelegramBotUpdateErrorText)({
+          updateId: update.update_id,
+          update,
+          ...(payload ? { payload } : {}),
+          error: errorMessage,
+        })
+    let responseError: string | undefined
+
+    if (responseText && payload) {
+      try {
+        await this.sendUpdateErrorResponse(update.update_id, payload, responseText)
+      } catch (responseErrorValue) {
+        responseError = formatUnknownError(responseErrorValue)
+      }
+    }
+
+    const result: NodeTelegramBotWorkerUpdateResult = {
+      skipped: false,
+      failed: true,
+      reason: "Telegram update handling failed",
+      updateId: update.update_id,
+      update,
+      ...(payload ? { payload } : {}),
+      error: errorMessage,
+      ...(responseText ? { responseText } : {}),
+      ...(responseError ? { responseError } : {}),
+    }
+    await this.options.onResult?.(result)
+    return result
+  }
+
+  private async sendUpdateErrorResponse(
+    updateId: number,
+    payload: TelegramLikeBotPayload,
+    text: string,
+  ): Promise<void> {
+    const chatId = payload.chat?.id === undefined ? undefined : String(payload.chat.id)
+    if (!chatId) return
+
+    const responder = this.resolveErrorResponder()
+    await responder?.sendMessage({
+      chatId,
+      text,
+      ...(payload.message_id !== undefined ? { replyToMessageId: String(payload.message_id) } : {}),
+      metadata: {
+        error: true,
+        source: "telegram-bot-worker",
+        updateId,
+      },
+    })
+  }
+
   private resolveCommandResponder(): NodeTelegramStatusClient | undefined {
     if (this.options.commandResponder) return this.options.commandResponder
+    if (!this.options.botToken) return undefined
+    return new NodeBotStatusNotifier({
+      telegram: {
+        botToken: this.options.botToken,
+      },
+      fetch: this.options.fetch,
+    })
+  }
+
+  private resolveErrorResponder(): NodeTelegramStatusClient | undefined {
+    if (this.options.errorResponder) return this.options.errorResponder
     if (!this.options.botToken) return undefined
     return new NodeBotStatusNotifier({
       telegram: {
@@ -423,6 +528,10 @@ export function defaultTelegramBotCommandText(): string {
   ].join("\n")
 }
 
+export function defaultTelegramBotUpdateErrorText(): string {
+  return ["Timeline Studio bot", "Could not process this request.", "Try again or send /help."].join("\n")
+}
+
 function mergeWorkflowOptions(
   defaults: NodeBotWorkflowServiceOptions | undefined,
   overrides: NodeBotWorkflowServiceOptions | undefined,
@@ -453,6 +562,10 @@ function globalFetch(
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function formatUnknownError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
 }
 
 function isNotFoundError(error: unknown): boolean {

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -113,6 +113,7 @@ npx ts-node src/cli/index.ts render project.json output.mp4 --verbose
 ### bot-worker - Telegram bot-first worker
 
 Запуск Telegram worker для bot-first workflow: обработка raw `Update`, один `getUpdates` batch или долгоживущий polling loop.
+В polling-режиме ошибки обработки отдельного update возвращаются как failed-result, отправляют короткий ответ в чат при наличии chat id и не останавливают batch.
 
 ```bash
 # Локальный smoke без Telegram token и без сетевых вызовов

--- a/src/cli/commands/__tests__/bot-worker.test.ts
+++ b/src/cli/commands/__tests__/bot-worker.test.ts
@@ -8,6 +8,7 @@ import path from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import {
   botWorkerCommand,
+  isFailedWorkerResult,
   readTelegramBotUpdate,
   resolveBotWorkerCommandOptions,
   serializeBotWorkerResult,
@@ -83,6 +84,24 @@ describe("bot-worker command", () => {
 
     expect(serializeBotWorkerResult(result)).not.toContain("\n")
     expect(serializeBotWorkerResult(result, true)).toContain("\n")
+  })
+
+  it("treats failed polling update results as failed command results", () => {
+    expect(
+      isFailedWorkerResult({
+        updates: [
+          {
+            skipped: false,
+            failed: true,
+            reason: "Telegram update handling failed",
+            updateId: 1,
+            update: { update_id: 1 },
+            error: "Workflow failed",
+          },
+        ],
+        nextOffset: 2,
+      }),
+    ).toBe(true)
   })
 
   it("resolves bot worker defaults from environment variables", () => {

--- a/src/cli/commands/bot-worker.ts
+++ b/src/cli/commands/bot-worker.ts
@@ -257,7 +257,7 @@ function createBotPublishOptions(options: BotWorkerCommandOptions) {
   }
 }
 
-function isFailedWorkerResult(result: BotWorkerCommandResult): boolean {
+export function isFailedWorkerResult(result: BotWorkerCommandResult): boolean {
   if ("batches" in result) {
     return result.batches.some((batch) => batch.updates.some(isFailedUpdateResult))
   }
@@ -271,6 +271,8 @@ function isFailedWorkerResult(result: BotWorkerCommandResult): boolean {
 
 function isFailedUpdateResult(result: NodeTelegramBotWorkerUpdateResult): boolean {
   if (result.skipped) return false
+  if ("failed" in result && result.failed) return true
+  if (!("result" in result)) return true
   if (!result.result.ok) return true
   return result.result.result.job.status === "failed" || result.result.result.job.status === "cancelled"
 }


### PR DESCRIPTION
## Summary

- isolate per-update exceptions inside Telegram polling so one bad update does not abort the batch
- return machine-readable failed update results, advance `nextOffset`, and send concise Telegram error replies when chat metadata exists
- keep `getUpdates` transport failures visible, update CLI failed-result detection, and mark B14 in the bot-first roadmap

## Tests

- `bun run test -- src/adapters/node/__tests__/telegram-bot-worker.test.ts src/cli/commands/__tests__/bot-worker.test.ts`
- `bun run check:type`
- `bun run check:workspaces`
- `bun run check:boundaries:baseline`
- `bunx biome ci src/adapters/node/telegram-bot-worker.ts src/adapters/node/index.ts src/adapters/node/__tests__/telegram-bot-worker.test.ts src/cli/commands/bot-worker.ts src/cli/commands/__tests__/bot-worker.test.ts`
- `git diff --check`
- `bun run src/cli/index.ts bot-worker --update-file docs/08_tasks/planned/fixtures/telegram-help-update.json --pretty`

Closes #197
Refs #171
