### PR TITLE
B15: Telegram bot conversation draft state

### DIFF
--- a/docs/08_tasks/planned/bot-first-workflow.md
+++ b/docs/08_tasks/planned/bot-first-workflow.md
@@ -165,6 +165,16 @@ bot message
 - [x] Отвечать в Telegram chat коротким error message, когда в update есть chat/message metadata.
 - [x] Покрыть polling isolation, error reply delivery и CLI failed-result detection tests.
 
+### B15: Telegram bot conversation draft state ([#199](https://github.com/chatman-media/timeline-studio/issues/199))
+
+**Цель:** пользователь может прислать media и render hints несколькими Telegram сообщениями, а бот запускает render только после `/render`.
+
+- [x] Добавить core draft contract и deterministic merge для chat/user session.
+- [x] Добавить Node file-backed draft store для polling worker и рестартов.
+- [x] Добавить opt-in Telegram worker draft mode: save input, `/render`, `/cancel`.
+- [x] Прокинуть draft storage через CLI/env без изменения one-shot режима.
+- [x] Документировать conversation draft runbook и покрыть core/store/worker/CLI tests.
+
 ## Связанные задачи
 
 - [#150](https://github.com/chatman-media/timeline-studio/issues/150) - Phase F / package boundaries
@@ -182,6 +192,7 @@ bot message
 - [#193](https://github.com/chatman-media/timeline-studio/issues/193) - B12: Telegram bot command routing
 - [#195](https://github.com/chatman-media/timeline-studio/issues/195) - B13: Bot worker runtime config and smoke runbook
 - [#197](https://github.com/chatman-media/timeline-studio/issues/197) - B14: Telegram bot update error isolation
+- [#199](https://github.com/chatman-media/timeline-studio/issues/199) - B15: Telegram bot conversation draft state
 - [telegram-mini-app.md](./telegram-mini-app.md)
 - [cloud-rendering.md](./cloud-rendering.md)
 - [export-architecture-refactoring.md](./export-architecture-refactoring.md)

--- a/src/adapters/node/__tests__/bot-workflow-drafts.test.ts
+++ b/src/adapters/node/__tests__/bot-workflow-drafts.test.ts
@@ -1,0 +1,38 @@
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { NodeBotWorkflowFileDraftStore } from "../bot-workflow-drafts"
+
+describe("NodeBotWorkflowFileDraftStore", () => {
+  let tempDir: string
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bot-workflow-drafts-"))
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  it("persists and deletes bot workflow drafts", async () => {
+    const store = new NodeBotWorkflowFileDraftStore(tempDir)
+    const draft = {
+      id: "telegram:chat-1:user-1",
+      updatedAt: "2026-06-08T08:00:00.000Z",
+      workflow: {
+        source: "telegram" as const,
+        chatId: "chat-1",
+        userId: "user-1",
+        media: [{ type: "file" as const, value: "telegram-file-1" }],
+      },
+    }
+
+    await expect(store.readDraft(draft.id)).resolves.toBeUndefined()
+    await store.writeDraft(draft)
+
+    await expect(store.readDraft(draft.id)).resolves.toEqual(draft)
+    await store.deleteDraft(draft.id)
+    await expect(store.readDraft(draft.id)).resolves.toBeUndefined()
+  })
+})

--- a/src/adapters/node/__tests__/telegram-bot-worker.test.ts
+++ b/src/adapters/node/__tests__/telegram-bot-worker.test.ts
@@ -2,16 +2,18 @@ import fs from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import type { BotWorkflowRunResult } from "@/core/types"
+import type { BotWorkflowDraft, BotWorkflowRunResult } from "@/core/types"
 import type { NodeBotWorkflowService } from "../bot-workflow"
 import {
   createTelegramLikePayloadFromUpdate,
   defaultTelegramBotCommandText,
+  defaultTelegramBotDraftText,
   defaultTelegramBotUpdateErrorText,
   NodeTelegramBotApiClient,
   NodeTelegramBotFileOffsetStore,
   NodeTelegramBotWorker,
   parseTelegramBotCommand,
+  parseTelegramBotDraftCommand,
   type TelegramBotUpdate,
 } from "../telegram-bot-worker"
 
@@ -28,13 +30,35 @@ const failedResult: BotWorkflowRunResult = {
   ],
 }
 
-function createWorkflowService() {
-  const runTelegramLikePayload = vi.fn(async () => failedResult)
+const completedResult: BotWorkflowRunResult = {
+  ok: true,
+  workflow: { source: "telegram" },
+  renderJob: { source: "bot", output: { format: "mp4" } },
+  result: {
+    job: {
+      id: "job-1",
+      status: "done",
+      progress: 1,
+      request: { source: "bot", output: { format: "mp4" } },
+      createdAt: "2026-06-08T08:00:00.000Z",
+      updatedAt: "2026-06-08T08:00:00.000Z",
+      events: [],
+    },
+    events: [],
+  },
+  warnings: [],
+}
+
+function createWorkflowService(result: BotWorkflowRunResult = failedResult) {
+  const runTelegramLikePayload = vi.fn(async () => result)
+  const runWorkflow = vi.fn(async () => result)
 
   return {
     service: {
+      runWorkflow,
       runTelegramLikePayload,
     } as unknown as NodeBotWorkflowService,
+    runWorkflow,
     runTelegramLikePayload,
   }
 }
@@ -274,6 +298,210 @@ describe("Telegram bot worker", () => {
     expect(parseTelegramBotCommand("/help@TimelineStudioBot more")).toBe("help")
     expect(parseTelegramBotCommand("/render")).toBeNull()
     expect(parseTelegramBotCommand("template=promo")).toBeNull()
+    expect(parseTelegramBotDraftCommand("/render@TimelineStudioBot")).toBe("render")
+    expect(parseTelegramBotDraftCommand("/cancel")).toBe("cancel")
+  })
+
+  it("stores Telegram updates as conversation drafts until render is requested", async () => {
+    const { service, runWorkflow, runTelegramLikePayload } = createWorkflowService(completedResult)
+    const draftStore = new Map<string, BotWorkflowDraft>()
+    const store = {
+      readDraft: vi.fn(async (id: string) => draftStore.get(id)),
+      writeDraft: vi.fn(async (draft: BotWorkflowDraft) => {
+        draftStore.set(draft.id, draft)
+      }),
+      deleteDraft: vi.fn(async (id: string) => {
+        draftStore.delete(id)
+      }),
+    }
+    const draftResponder = {
+      sendMessage: vi.fn(async () => ({ messageId: "draft-message-1" })),
+    }
+    const worker = new NodeTelegramBotWorker({
+      workflow: service,
+      draftStore: store,
+      draftResponder,
+      now: () => "2026-06-08T08:00:00.000Z",
+    })
+
+    const stored = await worker.handleUpdate({
+      update_id: 21,
+      message: {
+        message_id: 1,
+        chat: { id: "chat-1" },
+        from: { id: "user-1" },
+        video: {
+          file_id: "telegram-file-1",
+          file_unique_id: "unique-file-1",
+          file_name: "clip.mp4",
+        },
+      },
+    })
+
+    expect(stored).toMatchObject({
+      skipped: true,
+      reason: "Telegram bot draft updated",
+      draftAction: "updated",
+      draftId: "telegram:chat-1:user-1",
+      responseText: defaultTelegramBotDraftText({
+        action: "updated",
+        draftId: "telegram:chat-1:user-1",
+        payload: {},
+        update: { update_id: 21 },
+      }),
+    })
+    expect(draftResponder.sendMessage).toHaveBeenCalledWith({
+      chatId: "chat-1",
+      text: defaultTelegramBotDraftText({
+        action: "updated",
+        draftId: "telegram:chat-1:user-1",
+        payload: {},
+        update: { update_id: 21 },
+      }),
+      replyToMessageId: "1",
+      metadata: {
+        draftId: "telegram:chat-1:user-1",
+        source: "telegram-bot-worker",
+      },
+    })
+    expect(runTelegramLikePayload).not.toHaveBeenCalled()
+
+    const rendered = await worker.handleUpdate(
+      {
+        update_id: 22,
+        message: {
+          message_id: 2,
+          chat: { id: "chat-1" },
+          from: { id: "user-1" },
+          text: "/render template=promo destination=telegram",
+        },
+      },
+      {
+        workflowOptions: {
+          render: { timeoutMs: 10 },
+        },
+      },
+    )
+
+    expect(rendered).toMatchObject({
+      skipped: false,
+      updateId: 22,
+      result: completedResult,
+    })
+    expect(runWorkflow).toHaveBeenCalledWith(
+      {
+        source: "telegram",
+        chatId: "chat-1",
+        userId: "user-1",
+        messageId: "2",
+        text: "/render template=promo destination=telegram",
+        media: [
+          {
+            id: "unique-file-1",
+            type: "file",
+            value: "telegram-file-1",
+            name: "clip.mp4",
+            metadata: {
+              telegramFileId: "telegram-file-1",
+              telegramFileUniqueId: "unique-file-1",
+            },
+          },
+        ],
+        raw: {
+          chat: { id: "chat-1" },
+          from: { id: "user-1" },
+          message_id: 2,
+          text: "/render template=promo destination=telegram",
+        },
+      },
+      {
+        render: { timeoutMs: 10 },
+      },
+    )
+    expect(store.deleteDraft).toHaveBeenCalledWith("telegram:chat-1:user-1")
+  })
+
+  it("clears Telegram conversation drafts on cancel", async () => {
+    const { service, runWorkflow } = createWorkflowService()
+    const store = {
+      readDraft: vi.fn(),
+      writeDraft: vi.fn(),
+      deleteDraft: vi.fn(async () => undefined),
+    }
+    const worker = new NodeTelegramBotWorker({ workflow: service, draftStore: store })
+
+    const result = await worker.handleUpdate({
+      update_id: 23,
+      message: {
+        message_id: 3,
+        chat: { id: "chat-1" },
+        from: { id: "user-1" },
+        text: "/cancel",
+      },
+    })
+
+    expect(result).toMatchObject({
+      skipped: true,
+      reason: "Telegram bot draft cancelled",
+      draftAction: "cancelled",
+      draftId: "telegram:chat-1:user-1",
+      responseText: defaultTelegramBotDraftText({
+        action: "cancelled",
+        draftId: "telegram:chat-1:user-1",
+        payload: {},
+        update: { update_id: 23 },
+      }),
+    })
+    expect(store.deleteDraft).toHaveBeenCalledWith("telegram:chat-1:user-1")
+    expect(store.writeDraft).not.toHaveBeenCalled()
+    expect(runWorkflow).not.toHaveBeenCalled()
+  })
+
+  it("keeps Telegram conversation drafts when render validation fails", async () => {
+    const { service, runWorkflow } = createWorkflowService(failedResult)
+    const existingDraft = {
+      id: "telegram:chat-1:user-1",
+      updatedAt: "2026-06-08T08:00:00.000Z",
+      workflow: {
+        source: "telegram" as const,
+        chatId: "chat-1",
+        userId: "user-1",
+        media: [{ type: "file" as const, value: "telegram-file-1" }],
+      },
+    }
+    const store = {
+      readDraft: vi.fn(async () => existingDraft),
+      writeDraft: vi.fn(async () => undefined),
+      deleteDraft: vi.fn(async () => undefined),
+    }
+    const worker = new NodeTelegramBotWorker({ workflow: service, draftStore: store })
+
+    const result = await worker.handleUpdate({
+      update_id: 24,
+      message: {
+        message_id: 4,
+        chat: { id: "chat-1" },
+        from: { id: "user-1" },
+        text: "/render destination=instagram",
+      },
+    })
+
+    expect(result).toMatchObject({
+      skipped: false,
+      updateId: 24,
+      result: failedResult,
+    })
+    expect(runWorkflow).toHaveBeenCalledOnce()
+    expect(store.deleteDraft).not.toHaveBeenCalled()
+    expect(store.writeDraft).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "telegram:chat-1:user-1",
+        workflow: expect.objectContaining({
+          text: "/render destination=instagram",
+          media: [{ type: "file", value: "telegram-file-1" }],
+        }),
+      }),
+    )
   })
 
   it("polls one update batch and returns the next offset", async () => {

--- a/src/adapters/node/bot-workflow-drafts.ts
+++ b/src/adapters/node/bot-workflow-drafts.ts
@@ -1,0 +1,57 @@
+import fs from "node:fs/promises"
+import path from "node:path"
+
+import type { BotWorkflowDraft, BotWorkflowDraftStore } from "@/core/types"
+
+export class NodeBotWorkflowFileDraftStore implements BotWorkflowDraftStore {
+  constructor(private readonly directory: string) {}
+
+  async readDraft(id: string): Promise<BotWorkflowDraft | undefined> {
+    let content: string
+    try {
+      content = await fs.readFile(this.getDraftPath(id), "utf-8")
+    } catch (error) {
+      if (isNotFoundError(error)) return undefined
+      throw error
+    }
+
+    const draft = JSON.parse(content) as BotWorkflowDraft
+    if (!isBotWorkflowDraft(draft)) return undefined
+    return draft
+  }
+
+  async writeDraft(draft: BotWorkflowDraft): Promise<void> {
+    await fs.mkdir(this.directory, { recursive: true })
+    await fs.writeFile(this.getDraftPath(draft.id), `${JSON.stringify(draft, null, 2)}\n`)
+  }
+
+  async deleteDraft(id: string): Promise<void> {
+    await fs.rm(this.getDraftPath(id), { force: true })
+  }
+
+  private getDraftPath(id: string): string {
+    return path.join(this.directory, `${encodeDraftId(id)}.json`)
+  }
+}
+
+function encodeDraftId(id: string): string {
+  return Buffer.from(id, "utf-8").toString("base64url")
+}
+
+function isBotWorkflowDraft(value: unknown): value is BotWorkflowDraft {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "id" in value &&
+    typeof value.id === "string" &&
+    "workflow" in value &&
+    typeof value.workflow === "object" &&
+    value.workflow !== null &&
+    "updatedAt" in value &&
+    typeof value.updatedAt === "string"
+  )
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT"
+}

--- a/src/adapters/node/index.ts
+++ b/src/adapters/node/index.ts
@@ -42,6 +42,7 @@ export {
   type NodeTelegramStatusResult,
 } from "./bot-status"
 export { NodeBotWorkflowService, type NodeBotWorkflowServiceOptions } from "./bot-workflow"
+export { NodeBotWorkflowFileDraftStore } from "./bot-workflow-drafts"
 export { NodeEventService } from "./event"
 export { type NodeLanguageOptions, NodeLanguageService } from "./language"
 export { type NodeMediaOptions, NodeMediaService } from "./media"
@@ -62,12 +63,17 @@ export { type NodeStorageOptions, NodeStorageService } from "./storage"
 export {
   createTelegramLikePayloadFromUpdate,
   defaultTelegramBotCommandText,
+  defaultTelegramBotDraftText,
   defaultTelegramBotUpdateErrorText,
   NodeTelegramBotApiClient,
   type NodeTelegramBotClient,
   type NodeTelegramBotCommand,
   type NodeTelegramBotCommandFormatter,
   type NodeTelegramBotCommandFormatterContext,
+  type NodeTelegramBotDraftAction,
+  type NodeTelegramBotDraftCommand,
+  type NodeTelegramBotDraftFormatter,
+  type NodeTelegramBotDraftFormatterContext,
   NodeTelegramBotFileOffsetStore,
   type NodeTelegramBotFileOffsetStoreState,
   type NodeTelegramBotOffsetStore,
@@ -82,6 +88,7 @@ export {
   type NodeTelegramBotWorkerRunResult,
   type NodeTelegramBotWorkerUpdateResult,
   parseTelegramBotCommand,
+  parseTelegramBotDraftCommand,
   type TelegramBotFetch,
   type TelegramBotFetchResponse,
   type TelegramBotFile,

--- a/src/adapters/node/telegram-bot-worker.ts
+++ b/src/adapters/node/telegram-bot-worker.ts
@@ -1,7 +1,14 @@
 import fs from "node:fs/promises"
 import path from "node:path"
 
-import type { BotWorkflowRunResult, TelegramLikeBotFile, TelegramLikeBotPayload } from "@/core/types"
+import { createBotWorkflowDraftId, createTelegramLikeBotWorkflow, mergeBotWorkflowDraft } from "@/core/services"
+import type {
+  BotWorkflowDraft,
+  BotWorkflowDraftStore,
+  BotWorkflowRunResult,
+  TelegramLikeBotFile,
+  TelegramLikeBotPayload,
+} from "@/core/types"
 
 import { NodeBotStatusNotifier, type NodeTelegramStatusClient } from "./bot-status"
 import type { NodeBotWorkflowService, NodeBotWorkflowServiceOptions } from "./bot-workflow"
@@ -70,10 +77,14 @@ export interface NodeTelegramBotWorkerOptions {
   errorResponder?: NodeTelegramStatusClient
   errorFormatter?: NodeTelegramBotUpdateErrorFormatter
   disableErrorResponses?: boolean
+  draftStore?: BotWorkflowDraftStore
+  draftResponder?: NodeTelegramStatusClient
+  draftFormatter?: NodeTelegramBotDraftFormatter
   disableCommandRouting?: boolean
   botToken?: string
   fetch?: TelegramBotFetch
   workflowOptions?: NodeBotWorkflowServiceOptions
+  now?: () => string
   onResult?: (result: NodeTelegramBotWorkerUpdateResult) => void | Promise<void>
 }
 
@@ -82,6 +93,8 @@ export interface NodeTelegramBotWorkerHandleOptions {
 }
 
 export type NodeTelegramBotCommand = "start" | "help"
+export type NodeTelegramBotDraftCommand = "render" | "cancel"
+export type NodeTelegramBotDraftAction = "updated" | "cancelled"
 
 export interface NodeTelegramBotCommandFormatterContext {
   command: NodeTelegramBotCommand
@@ -100,6 +113,16 @@ export interface NodeTelegramBotUpdateErrorFormatterContext {
 
 export type NodeTelegramBotUpdateErrorFormatter = (context: NodeTelegramBotUpdateErrorFormatterContext) => string
 
+export interface NodeTelegramBotDraftFormatterContext {
+  action: NodeTelegramBotDraftAction
+  draftId: string
+  draft?: BotWorkflowDraft
+  payload: TelegramLikeBotPayload
+  update: TelegramBotUpdate
+}
+
+export type NodeTelegramBotDraftFormatter = (context: NodeTelegramBotDraftFormatterContext) => string
+
 export type NodeTelegramBotWorkerUpdateResult =
   | {
       skipped: true
@@ -107,8 +130,12 @@ export type NodeTelegramBotWorkerUpdateResult =
       updateId: number
       update: TelegramBotUpdate
       command?: NodeTelegramBotCommand
+      draftAction?: NodeTelegramBotDraftAction
+      draftId?: string
+      draft?: BotWorkflowDraft
       payload?: TelegramLikeBotPayload
       responseText?: string
+      responseError?: string
     }
   | {
       skipped: false
@@ -275,6 +302,9 @@ export class NodeTelegramBotWorker {
       return result
     }
 
+    const draftResult = await this.handleDraftUpdate(update, payload, options)
+    if (draftResult) return draftResult
+
     const result: NodeTelegramBotWorkerUpdateResult = {
       skipped: false,
       updateId: update.update_id,
@@ -380,6 +410,117 @@ export class NodeTelegramBotWorker {
     })
   }
 
+  private async handleDraftUpdate(
+    update: TelegramBotUpdate,
+    payload: TelegramLikeBotPayload,
+    options: NodeTelegramBotWorkerHandleOptions,
+  ): Promise<NodeTelegramBotWorkerUpdateResult | null> {
+    const store = this.options.draftStore
+    if (!store) return null
+
+    const workflow = createTelegramLikeBotWorkflow(payload)
+    const draftId = createBotWorkflowDraftId(workflow)
+    const draftCommand = parseTelegramBotDraftCommand(payload.text)
+
+    if (draftCommand === "cancel") {
+      await store.deleteDraft(draftId)
+      return this.createDraftSkippedResult({
+        action: "cancelled",
+        draftId,
+        payload,
+        update,
+      })
+    }
+
+    const existingDraft = await store.readDraft(draftId)
+    const draft = mergeBotWorkflowDraft(existingDraft, workflow, { now: this.options.now })
+
+    if (draftCommand === "render") {
+      const workflowResult = await this.options.workflow.runWorkflow(
+        draft.workflow,
+        mergeWorkflowOptions(this.workflowOptions, options.workflowOptions),
+      )
+      if (workflowResult.ok) {
+        await store.deleteDraft(draftId)
+      } else {
+        await store.writeDraft(draft)
+      }
+
+      const result: NodeTelegramBotWorkerUpdateResult = {
+        skipped: false,
+        updateId: update.update_id,
+        update,
+        payload,
+        result: workflowResult,
+      }
+      await this.options.onResult?.(result)
+      return result
+    }
+
+    await store.writeDraft(draft)
+    return this.createDraftSkippedResult({
+      action: "updated",
+      draftId,
+      draft,
+      payload,
+      update,
+    })
+  }
+
+  private async createDraftSkippedResult(context: {
+    action: NodeTelegramBotDraftAction
+    draftId: string
+    draft?: BotWorkflowDraft
+    payload: TelegramLikeBotPayload
+    update: TelegramBotUpdate
+  }): Promise<NodeTelegramBotWorkerUpdateResult> {
+    const responseText = (this.options.draftFormatter ?? defaultTelegramBotDraftText)({
+      action: context.action,
+      draftId: context.draftId,
+      ...(context.draft ? { draft: context.draft } : {}),
+      payload: context.payload,
+      update: context.update,
+    })
+    let responseError: string | undefined
+
+    try {
+      await this.sendDraftResponse(context.draftId, context.payload, responseText)
+    } catch (error) {
+      responseError = formatUnknownError(error)
+    }
+
+    const result: NodeTelegramBotWorkerUpdateResult = {
+      skipped: true,
+      reason: context.action === "updated" ? "Telegram bot draft updated" : "Telegram bot draft cancelled",
+      updateId: context.update.update_id,
+      update: context.update,
+      draftAction: context.action,
+      draftId: context.draftId,
+      ...(context.draft ? { draft: context.draft } : {}),
+      payload: context.payload,
+      responseText,
+      ...(responseError ? { responseError } : {}),
+    }
+    await this.options.onResult?.(result)
+    return result
+  }
+
+  private async sendDraftResponse(draftId: string, payload: TelegramLikeBotPayload, text: string): Promise<void> {
+    const chatId = payload.chat?.id === undefined ? undefined : String(payload.chat.id)
+    if (!chatId) return
+
+    const responder = this.resolveDraftResponder()
+    await responder?.sendMessage({
+      chatId,
+      text,
+      ...(payload.message_id !== undefined ? { replyToMessageId: String(payload.message_id) } : {}),
+      metadata: {
+        draftId,
+        source: "telegram-bot-worker",
+      },
+    })
+  }
+
   private async handlePollingUpdate(
     update: TelegramBotUpdate,
     options: NodeTelegramBotWorkerHandleOptions,
@@ -462,6 +603,17 @@ export class NodeTelegramBotWorker {
     })
   }
 
+  private resolveDraftResponder(): NodeTelegramStatusClient | undefined {
+    if (this.options.draftResponder) return this.options.draftResponder
+    if (!this.options.botToken) return undefined
+    return new NodeBotStatusNotifier({
+      telegram: {
+        botToken: this.options.botToken,
+      },
+      fetch: this.options.fetch,
+    })
+  }
+
   private resolveErrorResponder(): NodeTelegramStatusClient | undefined {
     if (this.options.errorResponder) return this.options.errorResponder
     if (!this.options.botToken) return undefined
@@ -517,6 +669,21 @@ export function parseTelegramBotCommand(text: string | undefined): NodeTelegramB
   }
 }
 
+export function parseTelegramBotDraftCommand(text: string | undefined): NodeTelegramBotDraftCommand | null {
+  const token = text?.trim().split(/\s+/)[0]?.toLowerCase()
+  if (!token?.startsWith("/")) return null
+
+  const command = token.split("@")[0]
+  switch (command) {
+    case "/render":
+      return "render"
+    case "/cancel":
+      return "cancel"
+    default:
+      return null
+  }
+}
+
 export function defaultTelegramBotCommandText(): string {
   return [
     "Timeline Studio bot",
@@ -525,6 +692,19 @@ export function defaultTelegramBotCommandText(): string {
     "template=promo destination=telegram",
     'project="./project.json" destination=file output="./out.mp4"',
     "Options: template, project, destination, output, resolution.",
+  ].join("\n")
+}
+
+export function defaultTelegramBotDraftText(context: NodeTelegramBotDraftFormatterContext): string {
+  if (context.action === "cancelled") {
+    return ["Timeline Studio bot", "Draft cleared.", "Send a new video, link, or project when ready."].join("\n")
+  }
+
+  return [
+    "Timeline Studio bot",
+    "Saved this input.",
+    "Send more media or hints, then send /render.",
+    "Send /cancel to clear the draft.",
   ].join("\n")
 }
 

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -128,9 +128,13 @@ bun run src/cli/index.ts bot-worker --poll-once --pretty
 # Долгоживущий polling worker с сохранением offset
 TIMELINE_BOT_TELEGRAM_TOKEN=123:token \
 TIMELINE_BOT_OFFSET_FILE=.tmp/timeline-bot/offset.json \
+TIMELINE_BOT_DRAFT_DIR=.tmp/timeline-bot/drafts \
 TIMELINE_BOT_MEDIA_DIR=.tmp/timeline-bot/media \
 bun run src/cli/index.ts bot-worker --poll --rust-render
 ```
+
+Если задан `--draft-dir` или `TIMELINE_BOT_DRAFT_DIR`, worker включает conversation draft mode:
+обычные сообщения сохраняют media и render hints, `/render` запускает merged workflow, а `/cancel` очищает draft.
 
 **Опции:**
 | Опция | Описание |
@@ -139,6 +143,7 @@ bun run src/cli/index.ts bot-worker --poll --rust-render
 | `--poll-once` | Получить и обработать один `getUpdates` batch |
 | `--poll` | Запустить continuous polling loop |
 | `--offset-file <path>` | Сохранять Telegram offset между рестартами |
+| `--draft-dir <path>` | Сохранять bot conversation drafts между сообщениями и рестартами |
 | `--max-batches <count>` | Остановить polling после N batches |
 | `--media-dir <path>` | Папка для скачанных Telegram/remote media |
 | `--telegram-bot-token <token>` | Telegram Bot API token |
@@ -156,6 +161,7 @@ export FFMPEG_PATH=/usr/local/bin/ffmpeg
 # Bot worker runtime defaults
 export TIMELINE_BOT_TELEGRAM_TOKEN=123:token
 export TIMELINE_BOT_OFFSET_FILE=.tmp/timeline-bot/offset.json
+export TIMELINE_BOT_DRAFT_DIR=.tmp/timeline-bot/drafts
 export TIMELINE_BOT_MEDIA_DIR=.tmp/timeline-bot/media
 export TIMELINE_BOT_DEFAULT_DESTINATION=telegram
 export TIMELINE_BOT_RUST_RENDER=true

--- a/src/cli/commands/__tests__/bot-worker.test.ts
+++ b/src/cli/commands/__tests__/bot-worker.test.ts
@@ -35,6 +35,7 @@ describe("bot-worker command", () => {
     expect(botWorkerCommand.options.some((option) => option.long === "--no-status-updates")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--status-chat-id")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--offset-file")).toBe(true)
+    expect(botWorkerCommand.options.some((option) => option.long === "--draft-dir")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--max-batches")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--idle-delay")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--rust-render")).toBe(true)
@@ -112,6 +113,7 @@ describe("bot-worker command", () => {
         TIMELINE_BOT_TELEGRAM_TOKEN: "token-from-timeline-env",
         TIMELINE_BOT_STATUS_CHAT_ID: "chat-1",
         TIMELINE_BOT_OFFSET_FILE: ".tmp/bot-offset.json",
+        TIMELINE_BOT_DRAFT_DIR: ".tmp/bot-drafts",
         TIMELINE_BOT_MEDIA_DIR: ".tmp/media",
         TIMELINE_BOT_POLL_LIMIT: "10",
         TIMELINE_BOT_POLL_TIMEOUT: "20",
@@ -132,6 +134,7 @@ describe("bot-worker command", () => {
       telegramBotToken: "token-from-timeline-env",
       statusChatId: "chat-1",
       offsetFile: ".tmp/bot-offset.json",
+      draftDir: ".tmp/bot-drafts",
       mediaDir: ".tmp/media",
       pollLimit: "10",
       pollTimeout: "20",
@@ -153,6 +156,7 @@ describe("bot-worker command", () => {
       {
         telegramBotToken: "token-from-cli",
         offsetFile: ".tmp/cli-offset.json",
+        draftDir: ".tmp/cli-drafts",
         defaultDestination: "file",
         rustRender: false,
         downloadRemoteMedia: false,
@@ -160,6 +164,7 @@ describe("bot-worker command", () => {
       {
         TIMELINE_BOT_TELEGRAM_TOKEN: "token-from-env",
         TIMELINE_BOT_OFFSET_FILE: ".tmp/env-offset.json",
+        TIMELINE_BOT_DRAFT_DIR: ".tmp/env-drafts",
         TIMELINE_BOT_DEFAULT_DESTINATION: "telegram",
         TIMELINE_BOT_RUST_RENDER: "true",
         TIMELINE_BOT_DOWNLOAD_REMOTE_MEDIA: "true",
@@ -169,6 +174,7 @@ describe("bot-worker command", () => {
     expect(resolved).toMatchObject({
       telegramBotToken: "token-from-cli",
       offsetFile: ".tmp/cli-offset.json",
+      draftDir: ".tmp/cli-drafts",
       defaultDestination: "file",
       rustRender: false,
       downloadRemoteMedia: false,

--- a/src/cli/commands/bot-worker.ts
+++ b/src/cli/commands/bot-worker.ts
@@ -14,7 +14,12 @@ import type {
   NodeTelegramBotWorkerUpdateResult,
   TelegramBotUpdate,
 } from "@/adapters/node"
-import { initNodeApp, NodeTelegramBotFileOffsetStore, NodeTelegramBotWorker } from "@/adapters/node"
+import {
+  initNodeApp,
+  NodeBotWorkflowFileDraftStore,
+  NodeTelegramBotFileOffsetStore,
+  NodeTelegramBotWorker,
+} from "@/adapters/node"
 import type { BotRenderJobDestination } from "@/core/types"
 
 export interface BotWorkerCommandOptions {
@@ -30,6 +35,7 @@ export interface BotWorkerCommandOptions {
   pollLimit?: string
   pollTimeout?: string
   offsetFile?: string
+  draftDir?: string
   maxBatches?: string
   idleDelay?: string
   mediaDir?: string
@@ -62,6 +68,7 @@ export const botWorkerCommand = new Command("bot-worker")
   .option("--poll-limit <count>", "Telegram getUpdates limit", "100")
   .option("--poll-timeout <seconds>", "Telegram getUpdates long-poll timeout in seconds", "25")
   .option("--offset-file <path>", "Persist Telegram getUpdates offset between polling runs")
+  .option("--draft-dir <path>", "Persist Telegram bot conversation drafts in a directory")
   .option("--max-batches <count>", "Stop continuous polling after this many getUpdates batches")
   .option("--idle-delay <ms>", "Delay after an empty continuous polling batch", "1000")
   .option("--media-dir <path>", "Directory for resolved bot media downloads")
@@ -130,6 +137,9 @@ export async function runBotWorker(options: BotWorkerCommandOptions = {}): Promi
       },
       includeReconnectState: true,
     },
+    draftStore: resolvedOptions.draftDir
+      ? new NodeBotWorkflowFileDraftStore(path.resolve(resolvedOptions.draftDir))
+      : undefined,
   })
 
   if (resolvedOptions.updateFile) {
@@ -176,6 +186,7 @@ export function resolveBotWorkerCommandOptions(
     pollLimit: firstConfigured(options.pollLimit, env.TIMELINE_BOT_POLL_LIMIT),
     pollTimeout: firstConfigured(options.pollTimeout, env.TIMELINE_BOT_POLL_TIMEOUT),
     offsetFile: firstConfigured(options.offsetFile, env.TIMELINE_BOT_OFFSET_FILE),
+    draftDir: firstConfigured(options.draftDir, env.TIMELINE_BOT_DRAFT_DIR),
     maxBatches: firstConfigured(options.maxBatches, env.TIMELINE_BOT_MAX_BATCHES),
     idleDelay: firstConfigured(options.idleDelay, env.TIMELINE_BOT_IDLE_DELAY),
     mediaDir: firstConfigured(options.mediaDir, env.TIMELINE_BOT_MEDIA_DIR),

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -35,6 +35,7 @@ export type {
 } from "./ports"
 export type {
   BotRenderJobRetryOptions,
+  BotWorkflowDraftMergeOptions,
   BotWorkflowRunnerOptions,
   LanguageResponse,
   ParsedBotWorkflowText,
@@ -47,6 +48,7 @@ export {
   createBotRenderJobRequest,
   createBotRenderJobRetryRequest,
   createBotRenderJobSnapshot,
+  createBotWorkflowDraftId,
   createBotWorkflowRequestFromTelegramLikePayload,
   createBotWorkflowStatusEventSink,
   createBotWorkflowStatusMessage,
@@ -55,6 +57,8 @@ export {
   defaultBotWorkflowStatusText,
   getAppLanguage,
   InMemoryBotRenderJobEventStream,
+  mergeBotWorkflowDraft,
+  mergeBotWorkflowRequests,
   parseBotWorkflowText,
   resolveBotRenderJobMedia,
   runBotWorkflow,
@@ -93,6 +97,8 @@ export type {
   BotRenderJobSource,
   BotRenderJobStatus,
   BotTemplateSelection,
+  BotWorkflowDraft,
+  BotWorkflowDraftStore,
   BotWorkflowIntakeOptions,
   BotWorkflowIntakeResult,
   BotWorkflowOutput,

--- a/src/core/services/__tests__/bot-workflow-drafts.test.ts
+++ b/src/core/services/__tests__/bot-workflow-drafts.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest"
+import { createBotWorkflowDraftId, mergeBotWorkflowDraft } from "../bot-workflow-drafts"
+
+describe("bot workflow drafts", () => {
+  it("builds deterministic draft ids from source, chat, and user", () => {
+    expect(createBotWorkflowDraftId({ source: "telegram", chatId: "chat-1", userId: "user-1" })).toBe(
+      "telegram:chat-1:user-1",
+    )
+    expect(createBotWorkflowDraftId({ source: "telegram" })).toBe("telegram:no-chat:no-user")
+  })
+
+  it("merges multi-message workflow input into a renderable draft", () => {
+    const first = mergeBotWorkflowDraft(
+      undefined,
+      {
+        source: "telegram",
+        chatId: "chat-1",
+        userId: "user-1",
+        messageId: "message-1",
+        media: [{ type: "file", value: "telegram-file-1", name: "clip.mp4" }],
+      },
+      { now: () => "2026-06-08T08:00:00.000Z" },
+    )
+
+    const second = mergeBotWorkflowDraft(
+      first,
+      {
+        source: "telegram",
+        chatId: "chat-1",
+        userId: "user-1",
+        messageId: "message-2",
+        text: "template=promo destination=telegram tone=fast",
+        output: { resolution: "1080p" },
+      },
+      { now: () => "2026-06-08T08:01:00.000Z" },
+    )
+
+    expect(second).toEqual({
+      id: "telegram:chat-1:user-1",
+      updatedAt: "2026-06-08T08:01:00.000Z",
+      workflow: {
+        source: "telegram",
+        chatId: "chat-1",
+        userId: "user-1",
+        messageId: "message-2",
+        text: "template=promo destination=telegram tone=fast",
+        media: [{ type: "file", value: "telegram-file-1", name: "clip.mp4" }],
+        output: { resolution: "1080p" },
+      },
+    })
+  })
+
+  it("keeps text hints in message order so later hints can override earlier ones", () => {
+    const first = mergeBotWorkflowDraft(undefined, {
+      source: "telegram",
+      chatId: "chat-1",
+      text: "destination=file",
+    })
+
+    const second = mergeBotWorkflowDraft(first, {
+      source: "telegram",
+      chatId: "chat-1",
+      text: "destination=telegram",
+    })
+
+    expect(second.workflow.text).toBe("destination=file destination=telegram")
+  })
+})

--- a/src/core/services/bot-workflow-drafts.ts
+++ b/src/core/services/bot-workflow-drafts.ts
@@ -1,0 +1,87 @@
+import type { BotMediaAttachment, BotTemplateSelection, BotWorkflowDraft, BotWorkflowRequest } from "../types"
+
+export interface BotWorkflowDraftMergeOptions {
+  now?: () => string
+}
+
+export function createBotWorkflowDraftId(workflow: BotWorkflowRequest): string {
+  return [workflow.source, workflow.chatId ?? "no-chat", workflow.userId ?? "no-user"].join(":")
+}
+
+export function mergeBotWorkflowDraft(
+  existing: BotWorkflowDraft | undefined,
+  workflow: BotWorkflowRequest,
+  options: BotWorkflowDraftMergeOptions = {},
+): BotWorkflowDraft {
+  return {
+    id: existing?.id ?? createBotWorkflowDraftId(workflow),
+    workflow: mergeBotWorkflowRequests(existing?.workflow, workflow),
+    updatedAt: options.now?.() ?? new Date().toISOString(),
+  }
+}
+
+export function mergeBotWorkflowRequests(
+  base: BotWorkflowRequest | undefined,
+  next: BotWorkflowRequest,
+): BotWorkflowRequest {
+  if (!base) return next
+
+  const text = mergeText(base.text, next.text)
+  const media = mergeMedia(base.media, next.media)
+  const params = mergeObject(base.params, next.params)
+  const output = mergeObject(base.output, next.output)
+  const template = mergeTemplate(base.template, next.template)
+
+  return {
+    source: next.source,
+    chatId: next.chatId ?? base.chatId,
+    userId: next.userId ?? base.userId,
+    messageId: next.messageId ?? base.messageId,
+    ...(text ? { text } : {}),
+    ...(template ? { template } : {}),
+    ...((next.project ?? base.project) ? { project: next.project ?? base.project } : {}),
+    ...(media.length > 0 ? { media } : {}),
+    ...(params ? { params } : {}),
+    ...(output ? { output } : {}),
+    ...((next.raw ?? base.raw) ? { raw: next.raw ?? base.raw } : {}),
+  }
+}
+
+function mergeTemplate(
+  base: BotTemplateSelection | undefined,
+  next: BotTemplateSelection | undefined,
+): BotTemplateSelection | undefined {
+  if (!base) return next
+  if (!next) return base
+
+  const params = mergeObject(base.params, next.params)
+  return {
+    id: next.id || base.id,
+    version: next.version ?? base.version,
+    ...(params ? { params } : {}),
+    ...((next.project ?? base.project) ? { project: next.project ?? base.project } : {}),
+  }
+}
+
+function mergeText(...values: Array<string | undefined>): string | undefined {
+  const text = values
+    .map((value) => value?.trim())
+    .filter((value): value is string => Boolean(value))
+    .join(" ")
+  return text.length > 0 ? text : undefined
+}
+
+function mergeMedia(
+  base: BotMediaAttachment[] | undefined,
+  next: BotMediaAttachment[] | undefined,
+): BotMediaAttachment[] {
+  return [...(base ?? []), ...(next ?? [])]
+}
+
+function mergeObject<T extends object>(base: T | undefined, next: T | undefined): T | undefined {
+  const merged = {
+    ...(base ?? {}),
+    ...(next ?? {}),
+  } as T
+  return Object.keys(merged).length > 0 ? merged : undefined
+}

--- a/src/core/services/index.ts
+++ b/src/core/services/index.ts
@@ -1,6 +1,7 @@
 export * from "./bot-media-resolver"
 export * from "./bot-project-assembler"
 export * from "./bot-status-updates"
+export * from "./bot-workflow-drafts"
 export * from "./bot-workflow-intake"
 export * from "./bot-workflow-runner"
 export * from "./language"

--- a/src/core/types/bot-workflow.ts
+++ b/src/core/types/bot-workflow.ts
@@ -70,6 +70,18 @@ export interface BotWorkflowRequest {
   raw?: unknown
 }
 
+export interface BotWorkflowDraft {
+  id: string
+  workflow: BotWorkflowRequest
+  updatedAt: string
+}
+
+export interface BotWorkflowDraftStore {
+  readDraft(id: string): Promise<BotWorkflowDraft | undefined>
+  writeDraft(draft: BotWorkflowDraft): Promise<void>
+  deleteDraft(id: string): Promise<void>
+}
+
 export interface BotWorkflowValidationError {
   code: BotWorkflowValidationCode
   field: string


### PR DESCRIPTION
## Summary

- add core bot workflow draft contracts and deterministic merge helpers for chat/user sessions
- add a Node file-backed draft store for polling workers and restarts
- add opt-in Telegram draft mode via `draftStore`: regular messages update the draft, `/render` runs the merged workflow, `/cancel` clears it
- wire `--draft-dir` / `TIMELINE_BOT_DRAFT_DIR` into `bot-worker` without changing the existing one-shot path
- document B15 in the bot-first roadmap and CLI runbook

## Tests

- `bun run test -- src/core/services/__tests__/bot-workflow-drafts.test.ts src/adapters/node/__tests__/bot-workflow-drafts.test.ts src/adapters/node/__tests__/telegram-bot-worker.test.ts src/cli/commands/__tests__/bot-worker.test.ts`
- `bun run check:type`
- `bun run check:workspaces`
- `bun run check:boundaries:baseline`
- `bunx biome ci src/core/types/bot-workflow.ts src/core/services/bot-workflow-drafts.ts src/core/services/index.ts src/core/index.ts src/core/services/__tests__/bot-workflow-drafts.test.ts src/adapters/node/bot-workflow-drafts.ts src/adapters/node/index.ts src/adapters/node/__tests__/bot-workflow-drafts.test.ts src/adapters/node/telegram-bot-worker.ts src/adapters/node/__tests__/telegram-bot-worker.test.ts src/cli/commands/bot-worker.ts src/cli/commands/__tests__/bot-worker.test.ts`
- `git diff --check`
- `bun run src/cli/index.ts bot-worker --update-file docs/08_tasks/planned/fixtures/telegram-help-update.json --pretty`

Closes #199
Refs #171
