### PR TITLE
B16: Bot text media and shorthand hints

### DIFF
--- a/docs/08_tasks/planned/bot-first-workflow.md
+++ b/docs/08_tasks/planned/bot-first-workflow.md
@@ -175,6 +175,16 @@ bot message
 - [x] Прокинуть draft storage через CLI/env без изменения one-shot режима.
 - [x] Документировать conversation draft runbook и покрыть core/store/worker/CLI tests.
 
+### B16: Bot text media and shorthand hints ([#201](https://github.com/chatman-media/timeline-studio/issues/201))
+
+**Цель:** бот понимает обычный Telegram текст вроде `https://cdn.example.com/input.mov 1080p telegram`, а не только `key=value` hints.
+
+- [x] Извлекать bare HTTP/HTTPS URLs из bot text как media attachments.
+- [x] Поддержать media aliases `media=`, `url=`, `input=` и `source=`.
+- [x] Поддержать deterministic destination/resolution shorthand tokens без `key=value`.
+- [x] Сохранить существующий structured/key-value behavior и приоритеты.
+- [x] Обновить `/help`, CLI runbook и unit tests для нового intake behavior.
+
 ## Связанные задачи
 
 - [#150](https://github.com/chatman-media/timeline-studio/issues/150) - Phase F / package boundaries
@@ -193,6 +203,7 @@ bot message
 - [#195](https://github.com/chatman-media/timeline-studio/issues/195) - B13: Bot worker runtime config and smoke runbook
 - [#197](https://github.com/chatman-media/timeline-studio/issues/197) - B14: Telegram bot update error isolation
 - [#199](https://github.com/chatman-media/timeline-studio/issues/199) - B15: Telegram bot conversation draft state
+- [#201](https://github.com/chatman-media/timeline-studio/issues/201) - B16: Bot text media and shorthand hints
 - [telegram-mini-app.md](./telegram-mini-app.md)
 - [cloud-rendering.md](./cloud-rendering.md)
 - [export-architecture-refactoring.md](./export-architecture-refactoring.md)

--- a/src/adapters/node/telegram-bot-worker.ts
+++ b/src/adapters/node/telegram-bot-worker.ts
@@ -689,9 +689,10 @@ export function defaultTelegramBotCommandText(): string {
     "Timeline Studio bot",
     "Send a video, link, or project with render hints.",
     "Examples:",
+    "https://cdn.example.com/input.mov 1080p telegram",
     "template=promo destination=telegram",
     'project="./project.json" destination=file output="./out.mp4"',
-    "Options: template, project, destination, output, resolution.",
+    "Options: template, project, media/url/input/source, destination, output, resolution.",
   ].join("\n")
 }
 

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -135,6 +135,8 @@ bun run src/cli/index.ts bot-worker --poll --rust-render
 
 Если задан `--draft-dir` или `TIMELINE_BOT_DRAFT_DIR`, worker включает conversation draft mode:
 обычные сообщения сохраняют media и render hints, `/render` запускает merged workflow, а `/cancel` очищает draft.
+В тексте сообщения можно отправлять bare URL и короткие hints, например `https://cdn.example.com/input.mov 1080p telegram`;
+также поддерживаются `media=`, `url=`, `input=` и `source=`.
 
 **Опции:**
 | Опция | Описание |

--- a/src/core/services/__tests__/bot-workflow-intake.test.ts
+++ b/src/core/services/__tests__/bot-workflow-intake.test.ts
@@ -14,6 +14,16 @@ describe("bot workflow intake", () => {
     expect(parsed).toEqual({
       templateId: "shorts",
       projectPath: "./project.json",
+      media: [
+        {
+          type: "url",
+          value: "https://cdn.example.com/input.mov",
+          name: "input.mov",
+          metadata: {
+            source: "bot-text",
+          },
+        },
+      ],
       output: {
         destination: "telegram",
         resolution: "1080p",
@@ -21,6 +31,50 @@ describe("bot workflow intake", () => {
       params: {
         tone: "fast",
       },
+    })
+  })
+
+  it("parses text URL media and shorthand output hints", () => {
+    const parsed = parseBotWorkflowText("https://cdn.example.com/input.mov 1080. telegram,")
+
+    expect(parsed).toEqual({
+      media: [
+        {
+          type: "url",
+          value: "https://cdn.example.com/input.mov",
+          name: "input.mov",
+          metadata: {
+            source: "bot-text",
+          },
+        },
+      ],
+      output: {
+        destination: "telegram",
+        resolution: "1080p",
+      },
+      params: {},
+    })
+  })
+
+  it("parses explicit media aliases from bot text", () => {
+    const parsed = parseBotWorkflowText("input=https://cdn.example.com/clip%201.mp4 tg 4k")
+
+    expect(parsed).toEqual({
+      media: [
+        {
+          type: "url",
+          value: "https://cdn.example.com/clip%201.mp4",
+          name: "clip 1.mp4",
+          metadata: {
+            source: "bot-text",
+          },
+        },
+      ],
+      output: {
+        destination: "telegram",
+        resolution: "4k",
+      },
+      params: {},
     })
   })
 
@@ -96,6 +150,42 @@ describe("bot workflow intake", () => {
         output: {
           format: "mp4",
           destination: "telegram",
+        },
+      },
+    })
+  })
+
+  it("creates a render job request from text URL media and shorthand hints", () => {
+    const result = createBotRenderJobRequest({
+      source: "telegram",
+      chatId: "chat-1",
+      messageId: "message-1",
+      text: "https://cdn.example.com/input.mov 1080p telegram",
+    })
+
+    expect(result).toEqual({
+      ok: true,
+      warnings: [],
+      renderJob: {
+        source: "bot",
+        media: [
+          {
+            type: "url",
+            value: "https://cdn.example.com/input.mov",
+            name: "input.mov",
+            metadata: {
+              source: "bot-text",
+            },
+          },
+        ],
+        params: {
+          telegramChatId: "chat-1",
+          telegramReplyToMessageId: "message-1",
+        },
+        output: {
+          format: "mp4",
+          destination: "telegram",
+          resolution: "1080p",
         },
       },
     })

--- a/src/core/services/bot-workflow-intake.ts
+++ b/src/core/services/bot-workflow-intake.ts
@@ -12,10 +12,28 @@ import type { BotRenderJobDestination, BotRenderJobMediaInput, BotRenderJobReque
 
 const DESTINATIONS = new Set(["file", "telegram", "youtube", "tiktok", "vimeo"])
 const RESOLUTIONS = new Set(["720p", "1080p", "4k"])
+const DESTINATION_ALIASES: Record<string, BotRenderJobDestination> = {
+  file: "file",
+  telegram: "telegram",
+  tg: "telegram",
+  vimeo: "vimeo",
+  youtube: "youtube",
+  yt: "youtube",
+  tiktok: "tiktok",
+  tt: "tiktok",
+}
+const RESOLUTION_ALIASES: Record<string, BotWorkflowOutput["resolution"]> = {
+  "720": "720p",
+  "720p": "720p",
+  "1080": "1080p",
+  "1080p": "1080p",
+  "4k": "4k",
+}
 
 export interface ParsedBotWorkflowText {
   templateId?: string
   projectPath?: string
+  media: BotMediaAttachment[]
   output: BotWorkflowOutput
   params: Record<string, string>
 }
@@ -29,7 +47,7 @@ export function createBotRenderJobRequest(
   const warnings: BotWorkflowValidationError[] = []
   const templateId = firstNonEmpty(workflow.template?.id, textHints.templateId, options.defaultTemplateId)
   const project = workflow.project ?? workflow.template?.project ?? projectFromText(textHints.projectPath)
-  const media = normalizeMedia(workflow.media ?? [], errors)
+  const media = normalizeMedia([...(workflow.media ?? []), ...textHints.media], errors)
   const params = mergeParams(
     createWorkflowDefaultParams(workflow),
     textHints.params,
@@ -111,21 +129,32 @@ export function createBotWorkflowRequestFromTelegramLikePayload(payload: Telegra
 
 export function parseBotWorkflowText(text = ""): ParsedBotWorkflowText {
   const parsed: ParsedBotWorkflowText = {
+    media: [],
     output: {},
     params: {},
   }
 
   for (const token of tokenizeText(text)) {
-    if (token.startsWith("/")) continue
+    const valueToken = trimCommandValue(token)
+    if (valueToken.startsWith("/")) continue
 
-    const separatorIndex = findKeyValueSeparator(token)
-    if (separatorIndex <= 0) continue
+    const separatorIndex = findKeyValueSeparator(valueToken)
+    if (separatorIndex <= 0) {
+      applyShorthandTextHint(parsed, valueToken)
+      continue
+    }
 
-    const key = normalizeKey(token.slice(0, separatorIndex))
-    const value = trimCommandValue(token.slice(separatorIndex + 1))
+    const key = normalizeKey(valueToken.slice(0, separatorIndex))
+    const value = trimCommandValue(valueToken.slice(separatorIndex + 1))
     if (!value) continue
 
     switch (key) {
+      case "media":
+      case "url":
+      case "input":
+      case "source":
+        parsed.media.push(textUrlToAttachment(value, "text-url"))
+        break
       case "template":
       case "templateid":
         parsed.templateId = value
@@ -342,6 +371,67 @@ function trimCommandValue(value: string): string {
     return trimmed.slice(1, -1).trim()
   }
   return trimmed
+}
+
+function applyShorthandTextHint(parsed: ParsedBotWorkflowText, token: string): void {
+  const textUrl = normalizeTextUrl(token)
+  if (textUrl) {
+    parsed.media.push(textUrlToAttachment(textUrl, "text-url"))
+    return
+  }
+
+  const normalizedToken = normalizeShorthandToken(token)
+  const destination = DESTINATION_ALIASES[normalizedToken]
+  if (destination) {
+    parsed.output.destination = destination
+    return
+  }
+
+  const resolution = RESOLUTION_ALIASES[normalizedToken]
+  if (resolution) {
+    parsed.output.resolution = resolution
+  }
+}
+
+function textUrlToAttachment(value: string, fallbackName: string): BotMediaAttachment {
+  const url = normalizeTextUrl(value) ?? value
+  return {
+    type: isUrl(url) ? "url" : "file",
+    value: url,
+    name: mediaNameFromUrl(url) ?? fallbackName,
+    metadata: {
+      source: "bot-text",
+    },
+  }
+}
+
+function normalizeTextUrl(value: string): string | null {
+  const normalized = value
+    .trim()
+    .replace(/^<+/, "")
+    .replace(/[>,.!?;:)\]]+$/, "")
+  return isUrl(normalized) ? normalized : null
+}
+
+function normalizeShorthandToken(value: string): string {
+  return normalizeKey(
+    value
+      .trim()
+      .replace(/^[<([{}]+/, "")
+      .replace(/[>,.!?;:)\]{}]+$/, ""),
+  )
+}
+
+function mediaNameFromUrl(value: string): string | undefined {
+  if (!isUrl(value)) return undefined
+
+  try {
+    const pathname = new URL(value).pathname
+    const name = pathname.split("/").filter(Boolean).at(-1)
+    return name ? decodeURIComponent(name) : undefined
+  } catch {
+    return undefined
+  }
 }
 
 function isUrl(value: string): boolean {


### PR DESCRIPTION
## Summary

- extract bare HTTP/HTTPS URLs from bot text as media attachments
- support explicit media aliases: `media=`, `url=`, `input=`, and `source=`
- support deterministic destination/resolution shorthand tokens like `telegram`, `tg`, `1080`, `1080p`, and `4k`
- update bot `/help`, CLI runbook, and roadmap B16

## Tests

- `bun run test -- src/core/services/__tests__/bot-workflow-intake.test.ts src/adapters/node/__tests__/telegram-bot-worker.test.ts`
- `bun run check:type`
- `bun run check:workspaces`
- `bun run check:boundaries:baseline`
- `bunx biome ci src/core/services/bot-workflow-intake.ts src/core/services/__tests__/bot-workflow-intake.test.ts src/adapters/node/telegram-bot-worker.ts src/adapters/node/__tests__/telegram-bot-worker.test.ts`
- `git diff --check`
- `bun run src/cli/index.ts bot-worker --update-file docs/08_tasks/planned/fixtures/telegram-help-update.json --pretty`

Closes #201
Refs #171
