### PR TITLE
B20: Telegram bot workflow job status store

### DIFF
--- a/docs/08_tasks/planned/bot-first-workflow.md
+++ b/docs/08_tasks/planned/bot-first-workflow.md
@@ -220,6 +220,17 @@ bot message
 - [x] Не запускать workflow для rejected updates и учитывать rejected result в CLI failure detection.
 - [x] Документировать backpressure setting и покрыть queue capacity/rejection tests.
 
+### B20: Telegram bot workflow job status store ([#209](https://github.com/chatman-media/timeline-studio/issues/209))
+
+**Цель:** bot-first worker сохраняет machine-readable историю queued/running/done/failed/rejected workflow jobs и отвечает на `/status` без desktop UI.
+
+- [x] Добавить Node workflow job store boundary для Telegram worker.
+- [x] Добавить in-memory и file-backed реализации status/history store.
+- [x] Записывать queued/running/completed/failed/rejected lifecycle для async workflow jobs.
+- [x] Добавить `/status` command routing с recent jobs по текущему chat.
+- [x] Прокинуть job store через `bot-worker` CLI/env config.
+- [x] Документировать `/status` runbook и покрыть worker/store/CLI tests.
+
 ## Связанные задачи
 
 - [#150](https://github.com/chatman-media/timeline-studio/issues/150) - Phase F / package boundaries
@@ -242,6 +253,7 @@ bot message
 - [#203](https://github.com/chatman-media/timeline-studio/issues/203) - B17: Telegram bot async workflow queue
 - [#205](https://github.com/chatman-media/timeline-studio/issues/205) - B18: Telegram bot queued workflow acknowledgements
 - [#207](https://github.com/chatman-media/timeline-studio/issues/207) - B19: Telegram bot workflow queue backpressure
+- [#209](https://github.com/chatman-media/timeline-studio/issues/209) - B20: Telegram bot workflow job status store
 - [telegram-mini-app.md](./telegram-mini-app.md)
 - [cloud-rendering.md](./cloud-rendering.md)
 - [export-architecture-refactoring.md](./export-architecture-refactoring.md)

--- a/src/adapters/node/__tests__/telegram-bot-worker.test.ts
+++ b/src/adapters/node/__tests__/telegram-bot-worker.test.ts
@@ -4,10 +4,12 @@ import path from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { BotWorkflowDraft, BotWorkflowRunResult } from "@/core/types"
 import type { NodeBotWorkflowService } from "../bot-workflow"
+import { NodeTelegramBotFileWorkflowJobStore, NodeTelegramBotInMemoryWorkflowJobStore } from "../telegram-bot-job-store"
 import {
   createTelegramLikePayloadFromUpdate,
   defaultTelegramBotCommandText,
   defaultTelegramBotDraftText,
+  defaultTelegramBotJobStatusText,
   defaultTelegramBotQueueRejectedText,
   defaultTelegramBotQueueText,
   defaultTelegramBotUpdateErrorText,
@@ -279,10 +281,11 @@ describe("Telegram bot worker", () => {
       runTelegramLikePayload,
     } as unknown as NodeBotWorkflowService
     const workflowQueue = new NodeTelegramBotInMemoryWorkflowQueue({ maxPending: 0 })
+    const workflowJobStore = new NodeTelegramBotInMemoryWorkflowJobStore()
     const queueResponder = {
       sendMessage: vi.fn(async () => ({ messageId: "queue-message-1" })),
     }
-    const worker = new NodeTelegramBotWorker({ workflow: service, workflowQueue, queueResponder })
+    const worker = new NodeTelegramBotWorker({ workflow: service, workflowQueue, workflowJobStore, queueResponder })
 
     const first = await worker.handleUpdate({
       update_id: 19,
@@ -334,6 +337,11 @@ describe("Telegram bot worker", () => {
       },
     })
     expect(runTelegramLikePayload).toHaveBeenCalledOnce()
+    await expect(workflowJobStore.readJob("telegram-update-20")).resolves.toMatchObject({
+      id: "telegram-update-20",
+      status: "rejected",
+      reason: "Telegram bot workflow queue is full",
+    })
 
     resolveWorkflow()
     await workflowQueue.drain()
@@ -520,6 +528,96 @@ describe("Telegram bot worker", () => {
     expect(runTelegramLikePayload).not.toHaveBeenCalled()
   })
 
+  it("routes status commands from persisted workflow job state", async () => {
+    let resolveWorkflow!: () => void
+    const runTelegramLikePayload = vi.fn(
+      async () =>
+        new Promise<BotWorkflowRunResult>((resolve) => {
+          resolveWorkflow = () => resolve(completedResult)
+        }),
+    )
+    const service = {
+      runWorkflow: vi.fn(),
+      runTelegramLikePayload,
+    } as unknown as NodeBotWorkflowService
+    const workflowQueue = new NodeTelegramBotInMemoryWorkflowQueue()
+    const workflowJobStore = new NodeTelegramBotInMemoryWorkflowJobStore()
+    const queueResponder = {
+      sendMessage: vi.fn(async () => ({ messageId: "queue-message-1" })),
+    }
+    const commandResponder = {
+      sendMessage: vi.fn(async () => ({ messageId: "status-message-1" })),
+    }
+    const worker = new NodeTelegramBotWorker({
+      workflow: service,
+      workflowQueue,
+      workflowJobStore,
+      queueResponder,
+      commandResponder,
+      now: () => "2026-06-08T08:00:00.000Z",
+    })
+
+    await worker.handleUpdate({
+      update_id: 28,
+      message: {
+        message_id: 19,
+        chat: { id: "chat-1" },
+        text: "template=promo",
+      },
+    })
+
+    await vi.waitFor(async () => {
+      expect((await workflowJobStore.readJob("telegram-update-28"))?.status).toBe("running")
+    })
+
+    const statusUpdate = {
+      update_id: 29,
+      message: {
+        message_id: 20,
+        chat: { id: "chat-1" },
+        text: "/status",
+      },
+    }
+    const runningRecord = await workflowJobStore.readJob("telegram-update-28")
+    if (!runningRecord) throw new Error("Expected workflow job record")
+    const runningText = defaultTelegramBotJobStatusText({
+      jobs: [runningRecord],
+      update: statusUpdate,
+      payload: {
+        chat: { id: "chat-1" },
+        message_id: 20,
+        text: "/status",
+      },
+    })
+    const status = await worker.handleUpdate(statusUpdate)
+
+    expect(status).toMatchObject({
+      skipped: true,
+      command: "status",
+      responseText: runningText,
+    })
+    expect(commandResponder.sendMessage).toHaveBeenCalledWith({
+      chatId: "chat-1",
+      text: runningText,
+      replyToMessageId: "20",
+      metadata: {
+        command: "status",
+        source: "telegram-bot-worker",
+      },
+    })
+    expect(runTelegramLikePayload).toHaveBeenCalledOnce()
+
+    resolveWorkflow()
+    await workflowQueue.drain()
+
+    await expect(workflowJobStore.readJob("telegram-update-28")).resolves.toMatchObject({
+      id: "telegram-update-28",
+      status: "done",
+      renderJobId: "job-1",
+      renderJobStatus: "done",
+    })
+  })
+
   it("can disable command routing for command-like workflow messages", async () => {
     const { service, runTelegramLikePayload } = createWorkflowService()
     const worker = new NodeTelegramBotWorker({
@@ -587,6 +685,7 @@ describe("Telegram bot worker", () => {
   it("parses supported Telegram bot commands", () => {
     expect(parseTelegramBotCommand("/start")).toBe("start")
     expect(parseTelegramBotCommand("/help@TimelineStudioBot more")).toBe("help")
+    expect(parseTelegramBotCommand("/status")).toBe("status")
     expect(parseTelegramBotCommand("/render")).toBeNull()
     expect(parseTelegramBotCommand("template=promo")).toBeNull()
     expect(parseTelegramBotDraftCommand("/render@TimelineStudioBot")).toBe("render")
@@ -982,6 +1081,50 @@ describe("Telegram bot worker", () => {
 
     await expect(store.readOffset()).resolves.toBe(42)
     await expect(fs.readFile(path.join(tempDir, "state", "offset.json"), "utf-8")).resolves.toContain('"offset":42')
+  })
+
+  it("persists and filters Telegram workflow job status records in a file store", async () => {
+    const storePath = path.join(tempDir, "state", "jobs.json")
+    const store = new NodeTelegramBotFileWorkflowJobStore(storePath, { maxJobs: 2 })
+
+    await store.writeJob({
+      id: "telegram-update-1",
+      status: "done",
+      updateId: 1,
+      chatId: "chat-1",
+      createdAt: "2026-06-08T08:00:00.000Z",
+      updatedAt: "2026-06-08T08:00:00.000Z",
+    })
+    await store.writeJob({
+      id: "telegram-update-2",
+      status: "running",
+      updateId: 2,
+      chatId: "chat-2",
+      createdAt: "2026-06-08T08:00:01.000Z",
+      updatedAt: "2026-06-08T08:00:01.000Z",
+    })
+    await store.writeJob({
+      id: "telegram-update-3",
+      status: "failed",
+      updateId: 3,
+      chatId: "chat-1",
+      error: "Render failed",
+      createdAt: "2026-06-08T08:00:02.000Z",
+      updatedAt: "2026-06-08T08:00:02.000Z",
+    })
+
+    await expect(store.listJobs({ chatId: "chat-1" })).resolves.toEqual([
+      expect.objectContaining({
+        id: "telegram-update-3",
+        status: "failed",
+        error: "Render failed",
+      }),
+    ])
+    const reloaded = new NodeTelegramBotFileWorkflowJobStore(storePath)
+    await expect(reloaded.readJob("telegram-update-3")).resolves.toMatchObject({
+      id: "telegram-update-3",
+      status: "failed",
+    })
   })
 
   it("runs bounded polling batches from stored offset and writes the next offset", async () => {

--- a/src/adapters/node/index.ts
+++ b/src/adapters/node/index.ts
@@ -61,9 +61,20 @@ export { NodeRenderJobService, type NodeRenderJobServiceOptions } from "./render
 export { type NodeRustRenderVideoOptions, NodeRustRenderVideoService } from "./rust-render-video"
 export { type NodeStorageOptions, NodeStorageService } from "./storage"
 export {
+  NodeTelegramBotFileWorkflowJobStore,
+  type NodeTelegramBotFileWorkflowJobStoreOptions,
+  type NodeTelegramBotFileWorkflowJobStoreState,
+  NodeTelegramBotInMemoryWorkflowJobStore,
+  type NodeTelegramBotWorkflowJobQuery,
+  type NodeTelegramBotWorkflowJobRecord,
+  type NodeTelegramBotWorkflowJobStatus,
+  type NodeTelegramBotWorkflowJobStore,
+} from "./telegram-bot-job-store"
+export {
   createTelegramLikePayloadFromUpdate,
   defaultTelegramBotCommandText,
   defaultTelegramBotDraftText,
+  defaultTelegramBotJobStatusText,
   defaultTelegramBotQueueRejectedText,
   defaultTelegramBotQueueText,
   defaultTelegramBotUpdateErrorText,
@@ -80,6 +91,8 @@ export {
   type NodeTelegramBotFileOffsetStoreState,
   NodeTelegramBotInMemoryWorkflowQueue,
   type NodeTelegramBotInMemoryWorkflowQueueOptions,
+  type NodeTelegramBotJobStatusFormatter,
+  type NodeTelegramBotJobStatusFormatterContext,
   type NodeTelegramBotOffsetStore,
   type NodeTelegramBotQueueFormatter,
   type NodeTelegramBotQueueFormatterContext,

--- a/src/adapters/node/telegram-bot-job-store.ts
+++ b/src/adapters/node/telegram-bot-job-store.ts
@@ -1,0 +1,167 @@
+import fs from "node:fs/promises"
+import path from "node:path"
+
+import type { BotRenderJobArtifact, BotRenderJobStatus } from "@/core/types"
+
+export type NodeTelegramBotWorkflowJobStatus = "queued" | "running" | "done" | "failed" | "rejected"
+
+export interface NodeTelegramBotWorkflowJobRecord {
+  id: string
+  status: NodeTelegramBotWorkflowJobStatus
+  updateId: number
+  createdAt: string
+  updatedAt: string
+  chatId?: string
+  userId?: string
+  messageId?: string
+  draftId?: string
+  reason?: string
+  error?: string
+  renderJobId?: string
+  renderJobStatus?: BotRenderJobStatus
+  artifact?: BotRenderJobArtifact
+}
+
+export interface NodeTelegramBotWorkflowJobQuery {
+  chatId?: string
+  limit?: number
+}
+
+export interface NodeTelegramBotWorkflowJobStore {
+  readJob(id: string): Promise<NodeTelegramBotWorkflowJobRecord | undefined>
+  writeJob(record: NodeTelegramBotWorkflowJobRecord): Promise<void>
+  listJobs(query?: NodeTelegramBotWorkflowJobQuery): Promise<NodeTelegramBotWorkflowJobRecord[]>
+}
+
+export interface NodeTelegramBotFileWorkflowJobStoreOptions {
+  maxJobs?: number
+}
+
+export interface NodeTelegramBotFileWorkflowJobStoreState {
+  jobs: NodeTelegramBotWorkflowJobRecord[]
+  updatedAt: string
+}
+
+export class NodeTelegramBotInMemoryWorkflowJobStore implements NodeTelegramBotWorkflowJobStore {
+  private readonly jobs = new Map<string, NodeTelegramBotWorkflowJobRecord>()
+
+  async readJob(id: string): Promise<NodeTelegramBotWorkflowJobRecord | undefined> {
+    return this.jobs.get(id)
+  }
+
+  async writeJob(record: NodeTelegramBotWorkflowJobRecord): Promise<void> {
+    this.jobs.set(record.id, record)
+  }
+
+  async listJobs(query: NodeTelegramBotWorkflowJobQuery = {}): Promise<NodeTelegramBotWorkflowJobRecord[]> {
+    return filterAndLimitJobs([...this.jobs.values()], query)
+  }
+}
+
+export class NodeTelegramBotFileWorkflowJobStore implements NodeTelegramBotWorkflowJobStore {
+  private readonly maxJobs: number
+  private writeChain: Promise<void> = Promise.resolve()
+
+  constructor(
+    private readonly filePath: string,
+    options: NodeTelegramBotFileWorkflowJobStoreOptions = {},
+  ) {
+    this.maxJobs = Math.max(1, Math.trunc(options.maxJobs ?? 100))
+  }
+
+  async readJob(id: string): Promise<NodeTelegramBotWorkflowJobRecord | undefined> {
+    await this.writeChain
+    const state = await this.readState()
+    return state.jobs.find((job) => job.id === id)
+  }
+
+  async writeJob(record: NodeTelegramBotWorkflowJobRecord): Promise<void> {
+    const nextWrite = this.writeChain.then(() => this.writeJobUnlocked(record))
+    this.writeChain = nextWrite.catch(() => undefined)
+    await nextWrite
+  }
+
+  async listJobs(query: NodeTelegramBotWorkflowJobQuery = {}): Promise<NodeTelegramBotWorkflowJobRecord[]> {
+    await this.writeChain
+    const state = await this.readState()
+    return filterAndLimitJobs(state.jobs, query)
+  }
+
+  private async writeJobUnlocked(record: NodeTelegramBotWorkflowJobRecord): Promise<void> {
+    const state = await this.readState()
+    const jobs = [record, ...state.jobs.filter((job) => job.id !== record.id)]
+      .sort(compareJobRecords)
+      .slice(0, this.maxJobs)
+
+    await fs.mkdir(path.dirname(this.filePath), { recursive: true })
+    await fs.writeFile(
+      this.filePath,
+      `${JSON.stringify(
+        {
+          jobs,
+          updatedAt: new Date().toISOString(),
+        } satisfies NodeTelegramBotFileWorkflowJobStoreState,
+        null,
+        2,
+      )}\n`,
+    )
+  }
+
+  private async readState(): Promise<NodeTelegramBotFileWorkflowJobStoreState> {
+    let content: string
+    try {
+      content = await fs.readFile(this.filePath, "utf-8")
+    } catch (error) {
+      if (isNotFoundError(error)) {
+        return {
+          jobs: [],
+          updatedAt: new Date(0).toISOString(),
+        }
+      }
+      throw error
+    }
+
+    const parsed = JSON.parse(content) as Partial<NodeTelegramBotFileWorkflowJobStoreState>
+    return {
+      jobs: Array.isArray(parsed.jobs) ? parsed.jobs.filter(isWorkflowJobRecord) : [],
+      updatedAt: typeof parsed.updatedAt === "string" ? parsed.updatedAt : new Date(0).toISOString(),
+    }
+  }
+}
+
+function filterAndLimitJobs(
+  jobs: NodeTelegramBotWorkflowJobRecord[],
+  query: NodeTelegramBotWorkflowJobQuery,
+): NodeTelegramBotWorkflowJobRecord[] {
+  const filtered = query.chatId ? jobs.filter((job) => job.chatId === query.chatId) : jobs
+  const limit = query.limit === undefined ? undefined : Math.max(0, Math.trunc(query.limit))
+  const sorted = [...filtered].sort(compareJobRecords)
+  return limit === undefined ? sorted : sorted.slice(0, limit)
+}
+
+function compareJobRecords(a: NodeTelegramBotWorkflowJobRecord, b: NodeTelegramBotWorkflowJobRecord): number {
+  const updatedDiff = Date.parse(b.updatedAt) - Date.parse(a.updatedAt)
+  if (Number.isFinite(updatedDiff) && updatedDiff !== 0) return updatedDiff
+  if (b.updateId !== a.updateId) return b.updateId - a.updateId
+  return b.id.localeCompare(a.id)
+}
+
+function isWorkflowJobRecord(value: unknown): value is NodeTelegramBotWorkflowJobRecord {
+  if (typeof value !== "object" || value === null) return false
+  const record = value as Partial<NodeTelegramBotWorkflowJobRecord>
+  return (
+    typeof record.id === "string" &&
+    typeof record.updateId === "number" &&
+    typeof record.createdAt === "string" &&
+    typeof record.updatedAt === "string" &&
+    isWorkflowJobStatus(record.status)
+  )
+}
+
+function isWorkflowJobStatus(value: unknown): value is NodeTelegramBotWorkflowJobStatus {
+  return value === "queued" || value === "running" || value === "done" || value === "failed" || value === "rejected"
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT"
+}

--- a/src/adapters/node/telegram-bot-worker.ts
+++ b/src/adapters/node/telegram-bot-worker.ts
@@ -13,6 +13,7 @@ import type {
 
 import { NodeBotStatusNotifier, type NodeTelegramStatusClient } from "./bot-status"
 import type { NodeBotWorkflowService, NodeBotWorkflowServiceOptions } from "./bot-workflow"
+import type { NodeTelegramBotWorkflowJobRecord, NodeTelegramBotWorkflowJobStore } from "./telegram-bot-job-store"
 
 export interface TelegramBotFile {
   file_id?: string
@@ -86,6 +87,9 @@ export interface NodeTelegramBotWorkerOptions {
   draftStore?: BotWorkflowDraftStore
   draftResponder?: NodeTelegramStatusClient
   draftFormatter?: NodeTelegramBotDraftFormatter
+  workflowJobStore?: NodeTelegramBotWorkflowJobStore
+  jobStatusFormatter?: NodeTelegramBotJobStatusFormatter
+  jobStatusLimit?: number
   disableCommandRouting?: boolean
   botToken?: string
   fetch?: TelegramBotFetch
@@ -98,7 +102,7 @@ export interface NodeTelegramBotWorkerHandleOptions {
   workflowOptions?: NodeBotWorkflowServiceOptions
 }
 
-export type NodeTelegramBotCommand = "start" | "help"
+export type NodeTelegramBotCommand = "start" | "help" | "status"
 export type NodeTelegramBotDraftCommand = "render" | "cancel"
 export type NodeTelegramBotDraftAction = "updated" | "cancelled"
 
@@ -180,6 +184,14 @@ export interface NodeTelegramBotQueueRejectedFormatterContext {
 }
 
 export type NodeTelegramBotQueueRejectedFormatter = (context: NodeTelegramBotQueueRejectedFormatterContext) => string
+
+export interface NodeTelegramBotJobStatusFormatterContext {
+  jobs: NodeTelegramBotWorkflowJobRecord[]
+  update: TelegramBotUpdate
+  payload: TelegramLikeBotPayload
+}
+
+export type NodeTelegramBotJobStatusFormatter = (context: NodeTelegramBotJobStatusFormatterContext) => string
 
 export type NodeTelegramBotWorkerUpdateResult =
   | {
@@ -438,6 +450,10 @@ export class NodeTelegramBotWorker {
     }
 
     const command = this.options.disableCommandRouting ? null : parseTelegramBotCommand(payload.text)
+    if (command === "status") {
+      return this.handleStatusCommand(update, payload)
+    }
+
     if (command) {
       const responseText = (this.options.commandFormatter ?? defaultTelegramBotCommandText)({
         command,
@@ -541,6 +557,10 @@ export class NodeTelegramBotWorker {
     return new NodeTelegramBotApiClient(this.options.botToken, { fetch: this.options.fetch })
   }
 
+  private now(): string {
+    return this.options.now?.() ?? new Date().toISOString()
+  }
+
   private async sendCommandResponse(
     command: NodeTelegramBotCommand,
     payload: TelegramLikeBotPayload,
@@ -559,6 +579,36 @@ export class NodeTelegramBotWorker {
         source: "telegram-bot-worker",
       },
     })
+  }
+
+  private async handleStatusCommand(
+    update: TelegramBotUpdate,
+    payload: TelegramLikeBotPayload,
+  ): Promise<NodeTelegramBotWorkerUpdateResult> {
+    const chatId = payload.chat?.id === undefined ? undefined : String(payload.chat.id)
+    const jobs =
+      (await this.options.workflowJobStore?.listJobs({
+        ...(chatId ? { chatId } : {}),
+        limit: this.options.jobStatusLimit ?? 5,
+      })) ?? []
+    const responseText = (this.options.jobStatusFormatter ?? defaultTelegramBotJobStatusText)({
+      jobs,
+      update,
+      payload,
+    })
+
+    await this.sendCommandResponse("status", payload, responseText)
+    const result: NodeTelegramBotWorkerUpdateResult = {
+      skipped: true,
+      reason: "Telegram bot command handled",
+      updateId: update.update_id,
+      update,
+      command: "status",
+      payload,
+      responseText,
+    }
+    await this.options.onResult?.(result)
+    return result
   }
 
   private async handleDraftUpdate(
@@ -680,21 +730,36 @@ export class NodeTelegramBotWorker {
     },
   ): Promise<NodeTelegramBotWorkerUpdateResult> {
     const workflowQueue = this.options.workflowQueue
+    const queueId = createTelegramBotWorkflowQueueId(update)
+    const jobRecord = this.createWorkflowJobRecord({
+      queueId,
+      status: workflowQueue ? "queued" : "running",
+      reason: workflowQueue ? "Telegram bot workflow queued" : "Telegram bot workflow running",
+      update,
+      payload,
+      ...(options.draftId ? { draftId: options.draftId } : {}),
+    })
     if (!workflowQueue) {
-      const workflowResult = await options.run()
-      await options.onComplete?.(workflowResult)
-      const result: NodeTelegramBotWorkerUpdateResult = {
-        skipped: false,
-        updateId: update.update_id,
-        update,
-        payload,
-        result: workflowResult,
+      await this.writeWorkflowJobRecord(jobRecord)
+      try {
+        const workflowResult = await options.run()
+        await this.writeWorkflowJobRecord(this.completeWorkflowJobRecord(jobRecord, workflowResult))
+        await options.onComplete?.(workflowResult)
+        const result: NodeTelegramBotWorkerUpdateResult = {
+          skipped: false,
+          updateId: update.update_id,
+          update,
+          payload,
+          result: workflowResult,
+        }
+        await this.options.onResult?.(result)
+        return result
+      } catch (error) {
+        await this.writeWorkflowJobRecord(this.failWorkflowJobRecord(jobRecord, error))
+        throw error
       }
-      await this.options.onResult?.(result)
-      return result
     }
 
-    const queueId = createTelegramBotWorkflowQueueId(update)
     const result: NodeTelegramBotWorkerUpdateResult = {
       skipped: false,
       queued: true,
@@ -706,13 +771,23 @@ export class NodeTelegramBotWorker {
       ...(options.workflow ? { workflow: options.workflow } : {}),
       ...(options.draftId ? { draftId: options.draftId } : {}),
     }
+    await this.writeWorkflowJobRecord(jobRecord)
     const submission = await workflowQueue.enqueue({
       id: queueId,
       update,
       payload,
-      run: options.run,
+      run: async () => {
+        await this.writeWorkflowJobRecord(
+          this.updateWorkflowJobRecord(jobRecord, {
+            status: "running",
+            reason: "Telegram bot workflow running",
+          }),
+        )
+        return options.run()
+      },
       onComplete: async (workflowResult) => {
         result.completion = workflowResult
+        await this.writeWorkflowJobRecord(this.completeWorkflowJobRecord(jobRecord, workflowResult))
         await options.onComplete?.(workflowResult)
         await this.options.onResult?.({
           skipped: false,
@@ -724,11 +799,18 @@ export class NodeTelegramBotWorker {
       },
       onError: async (error) => {
         result.error = formatUnknownError(error)
+        await this.writeWorkflowJobRecord(this.failWorkflowJobRecord(jobRecord, error))
         await this.createUpdateErrorResult(update, error)
       },
     })
 
     if (submission.status === "rejected") {
+      await this.writeWorkflowJobRecord(
+        this.updateWorkflowJobRecord(jobRecord, {
+          status: "rejected",
+          reason: submission.reason,
+        }),
+      )
       return this.createQueueRejectedResult({
         queueId: submission.id,
         reason: submission.reason,
@@ -818,6 +900,89 @@ export class NodeTelegramBotWorker {
         source: "telegram-bot-worker",
       },
     })
+  }
+
+  private createWorkflowJobRecord(context: {
+    queueId: string
+    status: NodeTelegramBotWorkflowJobRecord["status"]
+    reason: string
+    update: TelegramBotUpdate
+    payload: TelegramLikeBotPayload
+    draftId?: string
+  }): NodeTelegramBotWorkflowJobRecord {
+    const timestamp = this.now()
+    return {
+      id: context.queueId,
+      status: context.status,
+      updateId: context.update.update_id,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      reason: context.reason,
+      ...(context.payload.chat?.id !== undefined ? { chatId: String(context.payload.chat.id) } : {}),
+      ...(context.payload.from?.id !== undefined ? { userId: String(context.payload.from.id) } : {}),
+      ...(context.payload.message_id !== undefined ? { messageId: String(context.payload.message_id) } : {}),
+      ...(context.draftId ? { draftId: context.draftId } : {}),
+    }
+  }
+
+  private updateWorkflowJobRecord(
+    record: NodeTelegramBotWorkflowJobRecord,
+    patch: Pick<NodeTelegramBotWorkflowJobRecord, "status" | "reason">,
+  ): NodeTelegramBotWorkflowJobRecord {
+    return {
+      ...record,
+      ...patch,
+      updatedAt: this.now(),
+    }
+  }
+
+  private completeWorkflowJobRecord(
+    record: NodeTelegramBotWorkflowJobRecord,
+    workflowResult: BotWorkflowRunResult,
+  ): NodeTelegramBotWorkflowJobRecord {
+    if (!workflowResult.ok) {
+      return {
+        ...record,
+        status: "failed",
+        reason: "Bot workflow validation failed",
+        error: workflowResult.errors.map((error) => error.userMessage).join("; "),
+        updatedAt: this.now(),
+      }
+    }
+
+    const job = workflowResult.result.job
+    const failed = job.status === "failed" || job.status === "cancelled"
+    return {
+      ...record,
+      status: failed ? "failed" : "done",
+      reason: failed ? "Bot workflow render failed" : "Bot workflow completed",
+      updatedAt: this.now(),
+      renderJobId: job.id,
+      renderJobStatus: job.status,
+      ...(job.error ? { error: job.error } : {}),
+      ...(job.artifact ? { artifact: job.artifact } : {}),
+    }
+  }
+
+  private failWorkflowJobRecord(
+    record: NodeTelegramBotWorkflowJobRecord,
+    error: unknown,
+  ): NodeTelegramBotWorkflowJobRecord {
+    return {
+      ...record,
+      status: "failed",
+      reason: "Bot workflow execution failed",
+      error: formatUnknownError(error),
+      updatedAt: this.now(),
+    }
+  }
+
+  private async writeWorkflowJobRecord(record: NodeTelegramBotWorkflowJobRecord): Promise<void> {
+    try {
+      await this.options.workflowJobStore?.writeJob(record)
+    } catch {
+      // Job status persistence is observational and must not fail workflow handling.
+    }
   }
 
   private async handlePollingUpdate(
@@ -978,6 +1143,8 @@ export function parseTelegramBotCommand(text: string | undefined): NodeTelegramB
       return "start"
     case "/help":
       return "help"
+    case "/status":
+      return "status"
     default:
       return null
   }
@@ -1007,7 +1174,18 @@ export function defaultTelegramBotCommandText(): string {
     "template=promo destination=telegram",
     'project="./project.json" destination=file output="./out.mp4"',
     "Options: template, project, media/url/input/source, destination, output, resolution.",
+    "Commands: /status, /render, /cancel.",
   ].join("\n")
+}
+
+export function defaultTelegramBotJobStatusText(context: NodeTelegramBotJobStatusFormatterContext): string {
+  if (context.jobs.length === 0) {
+    return ["Timeline Studio bot", "No recent render jobs for this chat.", "Send a video or link to start one."].join(
+      "\n",
+    )
+  }
+
+  return ["Timeline Studio bot", "Recent render jobs:", ...context.jobs.map(formatTelegramBotJobStatusLine)].join("\n")
 }
 
 export function defaultTelegramBotDraftText(context: NodeTelegramBotDraftFormatterContext): string {
@@ -1043,6 +1221,26 @@ export function defaultTelegramBotQueueRejectedText(context: NodeTelegramBotQueu
 
 export function defaultTelegramBotUpdateErrorText(): string {
   return ["Timeline Studio bot", "Could not process this request.", "Try again or send /help."].join("\n")
+}
+
+function formatTelegramBotJobStatusLine(record: NodeTelegramBotWorkflowJobRecord): string {
+  const details: string[] = [record.status]
+  if (record.renderJobStatus && record.renderJobStatus !== record.status) {
+    details.push(`render=${record.renderJobStatus}`)
+  }
+  if (record.artifact?.url) {
+    details.push(record.artifact.url)
+  } else if (record.artifact?.path) {
+    details.push(record.artifact.path)
+  } else if (record.error) {
+    details.push(truncateStatusText(record.error))
+  }
+
+  return `${record.id}: ${details.join(", ")}`
+}
+
+function truncateStatusText(value: string): string {
+  return value.length <= 96 ? value : `${value.slice(0, 93)}...`
 }
 
 function mergeWorkflowOptions(

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -129,6 +129,7 @@ bun run src/cli/index.ts bot-worker --poll-once --pretty
 TIMELINE_BOT_TELEGRAM_TOKEN=123:token \
 TIMELINE_BOT_OFFSET_FILE=.tmp/timeline-bot/offset.json \
 TIMELINE_BOT_DRAFT_DIR=.tmp/timeline-bot/drafts \
+TIMELINE_BOT_JOB_STORE_FILE=.tmp/timeline-bot/jobs.json \
 TIMELINE_BOT_ASYNC_WORKFLOWS=true \
 TIMELINE_BOT_WORKFLOW_CONCURRENCY=1 \
 TIMELINE_BOT_WORKFLOW_QUEUE_LIMIT=20 \
@@ -143,6 +144,7 @@ bun run src/cli/index.ts bot-worker --poll --rust-render
 Для production polling включайте `--async-workflows`: worker быстро ставит render workflow в очередь и продолжает читать Telegram updates.
 Когда workflow поставлен в очередь, bot-worker сразу отправляет queued acknowledgement в исходный чат; финальный progress/result продолжает идти через status updates.
 Если задан `--workflow-queue-limit`, новые render requests сверх pending backlog получают busy response и не запускают workflow.
+Если задан `--job-store-file` или `TIMELINE_BOT_JOB_STORE_FILE`, worker сохраняет историю queued/running/done/failed/rejected jobs; команда `/status` показывает последние jobs текущего Telegram chat.
 
 **Опции:**
 | Опция | Описание |
@@ -152,6 +154,7 @@ bun run src/cli/index.ts bot-worker --poll --rust-render
 | `--poll` | Запустить continuous polling loop |
 | `--offset-file <path>` | Сохранять Telegram offset между рестартами |
 | `--draft-dir <path>` | Сохранять bot conversation drafts между сообщениями и рестартами |
+| `--job-store-file <path>` | Сохранять workflow job status/history для `/status` |
 | `--async-workflows` | Ставить render workflows в очередь во время continuous polling |
 | `--workflow-concurrency <count>` | Максимум параллельных queued workflows |
 | `--workflow-queue-limit <count>` | Максимум ожидающих queued workflows перед busy response |
@@ -173,6 +176,7 @@ export FFMPEG_PATH=/usr/local/bin/ffmpeg
 export TIMELINE_BOT_TELEGRAM_TOKEN=123:token
 export TIMELINE_BOT_OFFSET_FILE=.tmp/timeline-bot/offset.json
 export TIMELINE_BOT_DRAFT_DIR=.tmp/timeline-bot/drafts
+export TIMELINE_BOT_JOB_STORE_FILE=.tmp/timeline-bot/jobs.json
 export TIMELINE_BOT_ASYNC_WORKFLOWS=true
 export TIMELINE_BOT_WORKFLOW_CONCURRENCY=1
 export TIMELINE_BOT_WORKFLOW_QUEUE_LIMIT=20

--- a/src/cli/commands/__tests__/bot-worker.test.ts
+++ b/src/cli/commands/__tests__/bot-worker.test.ts
@@ -36,6 +36,7 @@ describe("bot-worker command", () => {
     expect(botWorkerCommand.options.some((option) => option.long === "--status-chat-id")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--offset-file")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--draft-dir")).toBe(true)
+    expect(botWorkerCommand.options.some((option) => option.long === "--job-store-file")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--async-workflows")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--workflow-concurrency")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--workflow-queue-limit")).toBe(true)
@@ -186,6 +187,7 @@ describe("bot-worker command", () => {
         TIMELINE_BOT_STATUS_CHAT_ID: "chat-1",
         TIMELINE_BOT_OFFSET_FILE: ".tmp/bot-offset.json",
         TIMELINE_BOT_DRAFT_DIR: ".tmp/bot-drafts",
+        TIMELINE_BOT_JOB_STORE_FILE: ".tmp/bot-jobs.json",
         TIMELINE_BOT_ASYNC_WORKFLOWS: "true",
         TIMELINE_BOT_WORKFLOW_CONCURRENCY: "2",
         TIMELINE_BOT_WORKFLOW_QUEUE_LIMIT: "10",
@@ -210,6 +212,7 @@ describe("bot-worker command", () => {
       statusChatId: "chat-1",
       offsetFile: ".tmp/bot-offset.json",
       draftDir: ".tmp/bot-drafts",
+      jobStoreFile: ".tmp/bot-jobs.json",
       asyncWorkflows: true,
       workflowConcurrency: "2",
       workflowQueueLimit: "10",
@@ -235,6 +238,7 @@ describe("bot-worker command", () => {
         telegramBotToken: "token-from-cli",
         offsetFile: ".tmp/cli-offset.json",
         draftDir: ".tmp/cli-drafts",
+        jobStoreFile: ".tmp/cli-jobs.json",
         asyncWorkflows: false,
         workflowConcurrency: "3",
         workflowQueueLimit: "5",
@@ -246,6 +250,7 @@ describe("bot-worker command", () => {
         TIMELINE_BOT_TELEGRAM_TOKEN: "token-from-env",
         TIMELINE_BOT_OFFSET_FILE: ".tmp/env-offset.json",
         TIMELINE_BOT_DRAFT_DIR: ".tmp/env-drafts",
+        TIMELINE_BOT_JOB_STORE_FILE: ".tmp/env-jobs.json",
         TIMELINE_BOT_ASYNC_WORKFLOWS: "true",
         TIMELINE_BOT_WORKFLOW_CONCURRENCY: "1",
         TIMELINE_BOT_WORKFLOW_QUEUE_LIMIT: "10",
@@ -259,6 +264,7 @@ describe("bot-worker command", () => {
       telegramBotToken: "token-from-cli",
       offsetFile: ".tmp/cli-offset.json",
       draftDir: ".tmp/cli-drafts",
+      jobStoreFile: ".tmp/cli-jobs.json",
       asyncWorkflows: false,
       workflowConcurrency: "3",
       workflowQueueLimit: "5",

--- a/src/cli/commands/bot-worker.ts
+++ b/src/cli/commands/bot-worker.ts
@@ -18,6 +18,7 @@ import {
   initNodeApp,
   NodeBotWorkflowFileDraftStore,
   NodeTelegramBotFileOffsetStore,
+  NodeTelegramBotFileWorkflowJobStore,
   NodeTelegramBotInMemoryWorkflowQueue,
   NodeTelegramBotWorker,
 } from "@/adapters/node"
@@ -37,6 +38,7 @@ export interface BotWorkerCommandOptions {
   pollTimeout?: string
   offsetFile?: string
   draftDir?: string
+  jobStoreFile?: string
   asyncWorkflows?: boolean
   workflowConcurrency?: string
   workflowQueueLimit?: string
@@ -73,6 +75,7 @@ export const botWorkerCommand = new Command("bot-worker")
   .option("--poll-timeout <seconds>", "Telegram getUpdates long-poll timeout in seconds", "25")
   .option("--offset-file <path>", "Persist Telegram getUpdates offset between polling runs")
   .option("--draft-dir <path>", "Persist Telegram bot conversation drafts in a directory")
+  .option("--job-store-file <path>", "Persist Telegram workflow job status/history")
   .option("--async-workflows", "Queue Telegram workflow runs during continuous polling")
   .option("--workflow-concurrency <count>", "Maximum queued workflow runs in parallel", "1")
   .option("--workflow-queue-limit <count>", "Maximum pending queued workflows before rejecting new requests")
@@ -155,6 +158,9 @@ export async function runBotWorker(options: BotWorkerCommandOptions = {}): Promi
     draftStore: resolvedOptions.draftDir
       ? new NodeBotWorkflowFileDraftStore(path.resolve(resolvedOptions.draftDir))
       : undefined,
+    workflowJobStore: resolvedOptions.jobStoreFile
+      ? new NodeTelegramBotFileWorkflowJobStore(path.resolve(resolvedOptions.jobStoreFile))
+      : undefined,
   })
 
   if (resolvedOptions.updateFile) {
@@ -204,6 +210,7 @@ export function resolveBotWorkerCommandOptions(
     pollTimeout: firstConfigured(options.pollTimeout, env.TIMELINE_BOT_POLL_TIMEOUT),
     offsetFile: firstConfigured(options.offsetFile, env.TIMELINE_BOT_OFFSET_FILE),
     draftDir: firstConfigured(options.draftDir, env.TIMELINE_BOT_DRAFT_DIR),
+    jobStoreFile: firstConfigured(options.jobStoreFile, env.TIMELINE_BOT_JOB_STORE_FILE),
     workflowConcurrency: firstConfigured(options.workflowConcurrency, env.TIMELINE_BOT_WORKFLOW_CONCURRENCY),
     workflowQueueLimit: firstConfigured(options.workflowQueueLimit, env.TIMELINE_BOT_WORKFLOW_QUEUE_LIMIT),
     maxBatches: firstConfigured(options.maxBatches, env.TIMELINE_BOT_MAX_BATCHES),


### PR DESCRIPTION
## Summary
- add Telegram workflow job store boundary with in-memory and file-backed implementations
- record queued/running/done/failed/rejected workflow lifecycle state from the Telegram worker
- route `/status` to recent persisted jobs for the current Telegram chat
- wire `--job-store-file` / `TIMELINE_BOT_JOB_STORE_FILE` through `bot-worker`
- document B20 and the `/status` polling runbook

## Tests
- `bun run test -- src/adapters/node/__tests__/telegram-bot-worker.test.ts src/cli/commands/__tests__/bot-worker.test.ts`
- `bun run check:type`
- `bun run check:workspaces`
- `bun run check:boundaries:baseline`
- `bunx biome ci src/adapters/node/telegram-bot-job-store.ts src/adapters/node/telegram-bot-worker.ts src/adapters/node/index.ts src/adapters/node/__tests__/telegram-bot-worker.test.ts src/cli/commands/bot-worker.ts src/cli/commands/__tests__/bot-worker.test.ts`
- `git diff --check`
- `bun run src/cli/index.ts bot-worker --update-file docs/08_tasks/planned/fixtures/telegram-help-update.json --pretty`

Closes #209
Refs #171
