### PR TITLE
B22: Telegram bot running render cancellation

### DIFF
--- a/docs/08_tasks/planned/bot-first-workflow.md
+++ b/docs/08_tasks/planned/bot-first-workflow.md
@@ -243,6 +243,18 @@ bot message
 - [x] Оставить running render cancellation вне scope и возвращать not-cancellable response.
 - [x] Документировать command/runbook и покрыть queue/worker/CLI tests.
 
+### B22: Telegram bot running render cancellation ([#213](https://github.com/chatman-media/timeline-studio/issues/213))
+
+**Цель:** пользователь может отменить уже running render job из Telegram через тот же `/cancel <queueId>`, когда worker знает render job id.
+
+- [x] Добавить tracking event sink, который пишет render job id/status в Telegram workflow job store во время выполнения.
+- [x] Экспортировать `NodeBotWorkflowService.cancelRenderJob()` поверх render job port.
+- [x] Расширить `/cancel <queueId>`: pending jobs отменяются через queue, running jobs через render job service.
+- [x] Сохранить chat ownership/status checks перед отменой.
+- [x] Записывать `cancelled` status для running cancellation и не перезаписывать cancelled финальный result как failed.
+- [x] Возвращать clear not-cancellable response, если running job еще не имеет render job id.
+- [x] Документировать behavior и покрыть running cancellation tests.
+
 ## Связанные задачи
 
 - [#150](https://github.com/chatman-media/timeline-studio/issues/150) - Phase F / package boundaries
@@ -267,6 +279,7 @@ bot message
 - [#207](https://github.com/chatman-media/timeline-studio/issues/207) - B19: Telegram bot workflow queue backpressure
 - [#209](https://github.com/chatman-media/timeline-studio/issues/209) - B20: Telegram bot workflow job status store
 - [#211](https://github.com/chatman-media/timeline-studio/issues/211) - B21: Telegram bot queued workflow cancellation
+- [#213](https://github.com/chatman-media/timeline-studio/issues/213) - B22: Telegram bot running render cancellation
 - [telegram-mini-app.md](./telegram-mini-app.md)
 - [cloud-rendering.md](./cloud-rendering.md)
 - [export-architecture-refactoring.md](./export-architecture-refactoring.md)

--- a/src/adapters/node/__tests__/telegram-bot-worker.test.ts
+++ b/src/adapters/node/__tests__/telegram-bot-worker.test.ts
@@ -56,17 +56,39 @@ const completedResult: BotWorkflowRunResult = {
   warnings: [],
 }
 
+const cancelledResult: BotWorkflowRunResult = {
+  ok: true,
+  workflow: { source: "telegram" },
+  renderJob: { source: "bot", output: { format: "mp4" } },
+  result: {
+    job: {
+      id: "job-cancelled-1",
+      status: "cancelled",
+      progress: 25,
+      request: { source: "bot", output: { format: "mp4" } },
+      createdAt: "2026-06-08T08:00:00.000Z",
+      updatedAt: "2026-06-08T08:00:01.000Z",
+      events: [],
+    },
+    events: [],
+  },
+  warnings: [],
+}
+
 function createWorkflowService(result: BotWorkflowRunResult = failedResult) {
   const runTelegramLikePayload = vi.fn(async () => result)
   const runWorkflow = vi.fn(async () => result)
+  const cancelRenderJob = vi.fn(async () => true)
 
   return {
     service: {
       runWorkflow,
       runTelegramLikePayload,
+      cancelRenderJob,
     } as unknown as NodeBotWorkflowService,
     runWorkflow,
     runTelegramLikePayload,
+    cancelRenderJob,
   }
 }
 
@@ -769,20 +791,122 @@ describe("Telegram bot worker", () => {
     })
   })
 
-  it("does not cancel already running workflow jobs", async () => {
+  it("cancels running workflow jobs when render job id is tracked", async () => {
+    let resolveWorkflow!: () => void
+    const cancelRenderJob = vi.fn(async () => true)
+    const runTelegramLikePayload = vi.fn(async (_payload, options) => {
+      await options?.render?.eventSinks?.[0]?.publish(
+        {
+          jobId: "render-job-35",
+          sequence: 0,
+          status: "rendering",
+          progress: 25,
+          timestamp: "2026-06-08T08:00:01.000Z",
+        },
+        {
+          jobId: "render-job-35",
+          status: "rendering",
+          progress: 25,
+          createdAt: "2026-06-08T08:00:00.000Z",
+          updatedAt: "2026-06-08T08:00:01.000Z",
+          eventCount: 1,
+          canCancel: true,
+          canRetry: false,
+        },
+      )
+      return new Promise<BotWorkflowRunResult>((resolve) => {
+        resolveWorkflow = () => resolve(cancelledResult)
+      })
+    })
+    const service = {
+      runWorkflow: vi.fn(),
+      runTelegramLikePayload,
+      cancelRenderJob,
+    } as unknown as NodeBotWorkflowService
+    const workflowQueue = new NodeTelegramBotInMemoryWorkflowQueue()
+    const workflowJobStore = new NodeTelegramBotInMemoryWorkflowJobStore()
+    const commandResponder = {
+      sendMessage: vi.fn(async () => ({ messageId: "cancel-message-1" })),
+    }
+    const worker = new NodeTelegramBotWorker({
+      workflow: service,
+      workflowQueue,
+      workflowJobStore,
+      commandResponder,
+      now: () => "2026-06-08T08:00:00.000Z",
+    })
+
+    await worker.handleUpdate({
+      update_id: 35,
+      message: {
+        message_id: 25,
+        chat: { id: "chat-1" },
+        text: "template=promo",
+      },
+    })
+
+    await vi.waitFor(async () => {
+      await expect(workflowJobStore.readJob("telegram-update-35")).resolves.toMatchObject({
+        id: "telegram-update-35",
+        status: "running",
+        renderJobId: "render-job-35",
+        renderJobStatus: "rendering",
+      })
+    })
+
+    const result = await worker.handleUpdate({
+      update_id: 36,
+      message: {
+        message_id: 26,
+        chat: { id: "chat-1" },
+        text: "/cancel telegram-update-35",
+      },
+    })
+
+    expect(result).toMatchObject({
+      skipped: true,
+      command: "cancel",
+      queueId: "telegram-update-35",
+      cancellation: {
+        id: "telegram-update-35",
+        status: "cancelled",
+      },
+    })
+    expect(cancelRenderJob).toHaveBeenCalledWith("render-job-35")
+    await expect(workflowJobStore.readJob("telegram-update-35")).resolves.toMatchObject({
+      id: "telegram-update-35",
+      status: "cancelled",
+      reason: "Telegram bot running workflow cancelled by user",
+      renderJobId: "render-job-35",
+      renderJobStatus: "cancelled",
+    })
+
+    resolveWorkflow()
+    await workflowQueue.drain()
+
+    await expect(workflowJobStore.readJob("telegram-update-35")).resolves.toMatchObject({
+      id: "telegram-update-35",
+      status: "cancelled",
+      reason: "Bot workflow render cancelled",
+      renderJobId: "job-cancelled-1",
+      renderJobStatus: "cancelled",
+    })
+  })
+
+  it("does not cancel running workflow jobs before render job id is tracked", async () => {
     const { service } = createWorkflowService(completedResult)
     const workflowJobStore = new NodeTelegramBotInMemoryWorkflowJobStore()
     await workflowJobStore.writeJob({
-      id: "telegram-update-35",
+      id: "telegram-update-37",
       status: "running",
-      updateId: 35,
+      updateId: 37,
       chatId: "chat-1",
       createdAt: "2026-06-08T08:00:00.000Z",
       updatedAt: "2026-06-08T08:00:00.000Z",
     })
     const workflowQueue = {
       enqueue: vi.fn(),
-      cancel: vi.fn(async () => ({ id: "telegram-update-35", status: "cancelled" as const })),
+      cancel: vi.fn(async () => ({ id: "telegram-update-37", status: "cancelled" as const })),
     }
     const commandResponder = {
       sendMessage: vi.fn(async () => ({ messageId: "cancel-message-1" })),
@@ -795,27 +919,27 @@ describe("Telegram bot worker", () => {
     })
 
     const result = await worker.handleUpdate({
-      update_id: 36,
+      update_id: 38,
       message: {
-        message_id: 25,
+        message_id: 27,
         chat: { id: "chat-1" },
-        text: "/cancel telegram-update-35",
+        text: "/cancel telegram-update-37",
       },
     })
 
     expect(result).toMatchObject({
       skipped: true,
       command: "cancel",
-      queueId: "telegram-update-35",
+      queueId: "telegram-update-37",
       cancellation: {
-        id: "telegram-update-35",
+        id: "telegram-update-37",
         status: "not_cancellable",
-        reason: "Workflow job is running.",
+        reason: "Running render job id is not available yet.",
       },
     })
     expect(workflowQueue.cancel).not.toHaveBeenCalled()
-    await expect(workflowJobStore.readJob("telegram-update-35")).resolves.toMatchObject({
-      id: "telegram-update-35",
+    await expect(workflowJobStore.readJob("telegram-update-37")).resolves.toMatchObject({
+      id: "telegram-update-37",
       status: "running",
     })
   })

--- a/src/adapters/node/bot-workflow.ts
+++ b/src/adapters/node/bot-workflow.ts
@@ -53,6 +53,10 @@ export class NodeBotWorkflowService {
       eventStream,
     })
   }
+
+  async cancelRenderJob(jobId: string): Promise<boolean> {
+    return this.renderJob.cancelJob(jobId)
+  }
 }
 
 function mergeOptions<T extends object>(defaults: T | undefined, overrides: T | undefined): T | undefined {

--- a/src/adapters/node/telegram-bot-worker.ts
+++ b/src/adapters/node/telegram-bot-worker.ts
@@ -3,6 +3,8 @@ import path from "node:path"
 
 import { createBotWorkflowDraftId, createTelegramLikeBotWorkflow, mergeBotWorkflowDraft } from "@/core/services"
 import type {
+  BotRenderJobEventSink,
+  BotRenderJobSnapshot,
   BotWorkflowDraft,
   BotWorkflowDraftStore,
   BotWorkflowRequest,
@@ -535,10 +537,10 @@ export class NodeTelegramBotWorker {
     if (draftResult) return draftResult
 
     return this.runOrQueueWorkflow(update, payload, {
-      run: () =>
+      run: (workflowOptions) =>
         this.options.workflow.runTelegramLikePayload(
           payload,
-          mergeWorkflowOptions(this.workflowOptions, options.workflowOptions),
+          mergeWorkflowOptions(mergeWorkflowOptions(this.workflowOptions, options.workflowOptions), workflowOptions),
         ),
     })
   }
@@ -719,6 +721,37 @@ export class NodeTelegramBotWorker {
       }
     }
 
+    if (job.status === "running") {
+      if (!job.renderJobId) {
+        return {
+          id: queueId,
+          status: "not_cancellable",
+          reason: "Running render job id is not available yet.",
+        }
+      }
+
+      const cancelled = await this.options.workflow.cancelRenderJob(job.renderJobId)
+      if (!cancelled) {
+        return {
+          id: queueId,
+          status: "not_cancellable",
+          reason: "Running render job could not be cancelled.",
+        }
+      }
+
+      await this.writeWorkflowJobRecord({
+        ...job,
+        status: "cancelled",
+        reason: "Telegram bot running workflow cancelled by user",
+        renderJobStatus: "cancelled",
+        updatedAt: this.now(),
+      })
+      return {
+        id: queueId,
+        status: "cancelled",
+      }
+    }
+
     if (job.status !== "queued") {
       return {
         id: queueId,
@@ -776,10 +809,10 @@ export class NodeTelegramBotWorker {
       return this.runOrQueueWorkflow(update, payload, {
         draftId,
         workflow: draft.workflow,
-        run: () =>
+        run: (workflowOptions) =>
           this.options.workflow.runWorkflow(
             draft.workflow,
-            mergeWorkflowOptions(this.workflowOptions, options.workflowOptions),
+            mergeWorkflowOptions(mergeWorkflowOptions(this.workflowOptions, options.workflowOptions), workflowOptions),
           ),
         onComplete: async (workflowResult) => {
           if (workflowResult.ok) {
@@ -859,7 +892,7 @@ export class NodeTelegramBotWorker {
     update: TelegramBotUpdate,
     payload: TelegramLikeBotPayload,
     options: {
-      run: () => Promise<BotWorkflowRunResult>
+      run: (workflowOptions?: NodeBotWorkflowServiceOptions) => Promise<BotWorkflowRunResult>
       workflow?: BotWorkflowRequest
       draftId?: string
       onComplete?: (result: BotWorkflowRunResult) => void | Promise<void>
@@ -875,10 +908,11 @@ export class NodeTelegramBotWorker {
       payload,
       ...(options.draftId ? { draftId: options.draftId } : {}),
     })
+    const trackingOptions = this.createWorkflowJobTrackingOptions(jobRecord)
     if (!workflowQueue) {
       await this.writeWorkflowJobRecord(jobRecord)
       try {
-        const workflowResult = await options.run()
+        const workflowResult = await options.run(trackingOptions)
         await this.writeWorkflowJobRecord(this.completeWorkflowJobRecord(jobRecord, workflowResult))
         await options.onComplete?.(workflowResult)
         const result: NodeTelegramBotWorkerUpdateResult = {
@@ -919,7 +953,7 @@ export class NodeTelegramBotWorker {
             reason: "Telegram bot workflow running",
           }),
         )
-        return options.run()
+        return options.run(trackingOptions)
       },
       onComplete: async (workflowResult) => {
         result.completion = workflowResult
@@ -1061,6 +1095,27 @@ export class NodeTelegramBotWorker {
     }
   }
 
+  private createWorkflowJobTrackingOptions(
+    record: NodeTelegramBotWorkflowJobRecord,
+  ): NodeBotWorkflowServiceOptions | undefined {
+    if (!this.options.workflowJobStore) return undefined
+
+    const eventSink: BotRenderJobEventSink = {
+      publish: async (_event, snapshot) => {
+        await this.writeWorkflowJobRecord(this.updateWorkflowJobRecordFromSnapshot(record, snapshot))
+      },
+      publishSnapshot: async (snapshot) => {
+        await this.writeWorkflowJobRecord(this.updateWorkflowJobRecordFromSnapshot(record, snapshot))
+      },
+    }
+
+    return {
+      render: {
+        eventSinks: [eventSink],
+      },
+    }
+  }
+
   private updateWorkflowJobRecord(
     record: NodeTelegramBotWorkflowJobRecord,
     patch: Pick<NodeTelegramBotWorkflowJobRecord, "status" | "reason">,
@@ -1069,6 +1124,22 @@ export class NodeTelegramBotWorker {
       ...record,
       ...patch,
       updatedAt: this.now(),
+    }
+  }
+
+  private updateWorkflowJobRecordFromSnapshot(
+    record: NodeTelegramBotWorkflowJobRecord,
+    snapshot: BotRenderJobSnapshot,
+  ): NodeTelegramBotWorkflowJobRecord {
+    return {
+      ...record,
+      status: mapRenderJobStatusToWorkflowJobStatus(snapshot.status),
+      reason: `Render status: ${snapshot.status}`,
+      updatedAt: snapshot.updatedAt,
+      renderJobId: snapshot.jobId,
+      renderJobStatus: snapshot.status,
+      ...(snapshot.artifact ? { artifact: snapshot.artifact } : {}),
+      ...(snapshot.error ? { error: snapshot.error } : {}),
     }
   }
 
@@ -1087,11 +1158,16 @@ export class NodeTelegramBotWorker {
     }
 
     const job = workflowResult.result.job
-    const failed = job.status === "failed" || job.status === "cancelled"
+    const failed = job.status === "failed"
     return {
       ...record,
-      status: failed ? "failed" : "done",
-      reason: failed ? "Bot workflow render failed" : "Bot workflow completed",
+      status: job.status === "cancelled" ? "cancelled" : failed ? "failed" : "done",
+      reason:
+        job.status === "cancelled"
+          ? "Bot workflow render cancelled"
+          : failed
+            ? "Bot workflow render failed"
+            : "Bot workflow completed",
       updatedAt: this.now(),
       renderJobId: job.id,
       renderJobStatus: job.status,
@@ -1335,7 +1411,7 @@ export function defaultTelegramBotJobStatusText(context: NodeTelegramBotJobStatu
 
 export function defaultTelegramBotJobCancelText(context: NodeTelegramBotJobCancelFormatterContext): string {
   if (context.cancellation.status === "cancelled") {
-    return ["Timeline Studio bot", "Queued render job cancelled.", `Queue id: ${context.queueId}`].join("\n")
+    return ["Timeline Studio bot", "Render job cancelled.", `Queue id: ${context.queueId}`].join("\n")
   }
 
   return [
@@ -1399,6 +1475,24 @@ function formatTelegramBotJobStatusLine(record: NodeTelegramBotWorkflowJobRecord
 
 function truncateStatusText(value: string): string {
   return value.length <= 96 ? value : `${value.slice(0, 93)}...`
+}
+
+function mapRenderJobStatusToWorkflowJobStatus(
+  status: BotRenderJobSnapshot["status"],
+): NodeTelegramBotWorkflowJobRecord["status"] {
+  switch (status) {
+    case "done":
+      return "done"
+    case "failed":
+      return "failed"
+    case "cancelled":
+      return "cancelled"
+    case "queued":
+    case "preparing":
+    case "rendering":
+    case "publishing":
+      return "running"
+  }
 }
 
 function mergeWorkflowOptions(

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -145,7 +145,7 @@ bun run src/cli/index.ts bot-worker --poll --rust-render
 Когда workflow поставлен в очередь, bot-worker сразу отправляет queued acknowledgement в исходный чат; финальный progress/result продолжает идти через status updates.
 Если задан `--workflow-queue-limit`, новые render requests сверх pending backlog получают busy response и не запускают workflow.
 Если задан `--job-store-file` или `TIMELINE_BOT_JOB_STORE_FILE`, worker сохраняет историю queued/running/done/failed/rejected/cancelled jobs; команда `/status` показывает последние jobs текущего Telegram chat.
-Команда `/cancel <queueId>` отменяет pending queued job из текущего chat; уже running/done/failed jobs не отменяются этим срезом.
+Команда `/cancel <queueId>` отменяет pending queued job или running render job из текущего chat; done/failed/rejected jobs не отменяются.
 
 **Опции:**
 | Опция | Описание |


### PR DESCRIPTION
## Summary
- add `NodeBotWorkflowService.cancelRenderJob()` over the render job port
- track render job id/status in the Telegram workflow job store through a per-job render event sink
- extend `/cancel <queueId>` to cancel running render jobs when a render job id is known
- keep pending queue cancellation and chat ownership checks intact
- preserve `cancelled` workflow job status for final cancelled render results
- document B22 and the bot-worker `/cancel` behavior

## Tests
- `bun run test -- src/adapters/node/__tests__/telegram-bot-worker.test.ts src/adapters/node/__tests__/bot-workflow.test.ts src/cli/commands/__tests__/bot-worker.test.ts`
- `bun run check:type`
- `bun run check:workspaces`
- `bun run check:boundaries:baseline`
- `bunx biome ci src/adapters/node/bot-workflow.ts src/adapters/node/telegram-bot-worker.ts src/adapters/node/__tests__/telegram-bot-worker.test.ts`
- `git diff --check`
- `bun run src/cli/index.ts bot-worker --update-file docs/08_tasks/planned/fixtures/telegram-help-update.json --pretty`

Closes #213
Refs #171
