### PR TITLE
B24: Telegram bot stale workflow recovery

### DIFF
--- a/docs/08_tasks/planned/bot-first-workflow.md
+++ b/docs/08_tasks/planned/bot-first-workflow.md
@@ -267,6 +267,16 @@ bot message
 - [x] Сохранять `retryOf` в new job record/result.
 - [x] Документировать command/runbook и покрыть retry/not-retryable tests.
 
+### B24: Telegram bot stale workflow recovery ([#217](https://github.com/chatman-media/timeline-studio/issues/217))
+
+**Цель:** после рестарта polling worker старые queued/running jobs из persisted store не остаются вечными in-progress и становятся retryable.
+
+- [x] Добавить recovery helper для workflow job store.
+- [x] Помечать stale queued/running records как failed с понятной restart/interruption причиной.
+- [x] Сохранять source payload/workflow context для `/retry`.
+- [x] Подключить opt-in recovery к `bot-worker` через CLI/env.
+- [x] Документировать production runbook и покрыть store/CLI tests.
+
 ## Связанные задачи
 
 - [#150](https://github.com/chatman-media/timeline-studio/issues/150) - Phase F / package boundaries
@@ -293,6 +303,7 @@ bot message
 - [#211](https://github.com/chatman-media/timeline-studio/issues/211) - B21: Telegram bot queued workflow cancellation
 - [#213](https://github.com/chatman-media/timeline-studio/issues/213) - B22: Telegram bot running render cancellation
 - [#215](https://github.com/chatman-media/timeline-studio/issues/215) - B23: Telegram bot workflow retry command
+- [#217](https://github.com/chatman-media/timeline-studio/issues/217) - B24: Telegram bot stale workflow recovery
 - [telegram-mini-app.md](./telegram-mini-app.md)
 - [cloud-rendering.md](./cloud-rendering.md)
 - [export-architecture-refactoring.md](./export-architecture-refactoring.md)

--- a/src/adapters/node/__tests__/telegram-bot-worker.test.ts
+++ b/src/adapters/node/__tests__/telegram-bot-worker.test.ts
@@ -4,7 +4,11 @@ import path from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { BotWorkflowDraft, BotWorkflowRunResult } from "@/core/types"
 import type { NodeBotWorkflowService } from "../bot-workflow"
-import { NodeTelegramBotFileWorkflowJobStore, NodeTelegramBotInMemoryWorkflowJobStore } from "../telegram-bot-job-store"
+import {
+  NodeTelegramBotFileWorkflowJobStore,
+  NodeTelegramBotInMemoryWorkflowJobStore,
+  recoverStaleTelegramWorkflowJobs,
+} from "../telegram-bot-job-store"
 import {
   createTelegramLikePayloadFromUpdate,
   defaultTelegramBotCommandText,
@@ -1671,6 +1675,63 @@ describe("Telegram bot worker", () => {
       status: "failed",
       retryOf: "telegram-update-1",
       sourcePayload: { text: "template=promo destination=telegram" },
+    })
+  })
+
+  it("recovers stale Telegram workflow jobs from a file store", async () => {
+    const storePath = path.join(tempDir, "state", "stale-jobs.json")
+    const store = new NodeTelegramBotFileWorkflowJobStore(storePath)
+
+    await store.writeJob({
+      id: "telegram-update-4",
+      status: "queued",
+      updateId: 4,
+      chatId: "chat-1",
+      sourcePayload: { text: "template=promo" },
+      createdAt: "2026-06-08T08:00:00.000Z",
+      updatedAt: "2026-06-08T08:00:00.000Z",
+    })
+    await store.writeJob({
+      id: "telegram-update-5",
+      status: "running",
+      updateId: 5,
+      chatId: "chat-1",
+      renderJobId: "job-5",
+      sourceWorkflow: { source: "telegram", template: { id: "promo" } },
+      createdAt: "2026-06-08T08:00:01.000Z",
+      updatedAt: "2026-06-08T08:00:01.000Z",
+    })
+    await store.writeJob({
+      id: "telegram-update-6",
+      status: "done",
+      updateId: 6,
+      chatId: "chat-1",
+      createdAt: "2026-06-08T08:00:02.000Z",
+      updatedAt: "2026-06-08T08:00:02.000Z",
+    })
+
+    const result = await recoverStaleTelegramWorkflowJobs(store, {
+      now: () => "2026-06-08T09:00:00.000Z",
+    })
+
+    expect(result.recoveredJobs.map((job) => job.id).sort()).toEqual(["telegram-update-4", "telegram-update-5"])
+    await expect(store.readJob("telegram-update-4")).resolves.toMatchObject({
+      id: "telegram-update-4",
+      status: "failed",
+      reason: "Telegram bot workflow recovered after worker restart",
+      error: "Workflow was interrupted before completion. Send /retry <queueId> to run it again.",
+      updatedAt: "2026-06-08T09:00:00.000Z",
+      sourcePayload: { text: "template=promo" },
+    })
+    await expect(store.readJob("telegram-update-5")).resolves.toMatchObject({
+      id: "telegram-update-5",
+      status: "failed",
+      renderJobId: "job-5",
+      sourceWorkflow: { source: "telegram", template: { id: "promo" } },
+    })
+    await expect(store.readJob("telegram-update-6")).resolves.toMatchObject({
+      id: "telegram-update-6",
+      status: "done",
     })
   })
 

--- a/src/adapters/node/index.ts
+++ b/src/adapters/node/index.ts
@@ -69,6 +69,9 @@ export {
   type NodeTelegramBotWorkflowJobRecord,
   type NodeTelegramBotWorkflowJobStatus,
   type NodeTelegramBotWorkflowJobStore,
+  type RecoverStaleTelegramWorkflowJobsOptions,
+  type RecoverStaleTelegramWorkflowJobsResult,
+  recoverStaleTelegramWorkflowJobs,
 } from "./telegram-bot-job-store"
 export {
   createTelegramLikePayloadFromUpdate,

--- a/src/adapters/node/telegram-bot-job-store.ts
+++ b/src/adapters/node/telegram-bot-job-store.ts
@@ -36,6 +36,16 @@ export interface NodeTelegramBotWorkflowJobStore {
   listJobs(query?: NodeTelegramBotWorkflowJobQuery): Promise<NodeTelegramBotWorkflowJobRecord[]>
 }
 
+export interface RecoverStaleTelegramWorkflowJobsOptions {
+  now?: () => string
+  reason?: string
+  error?: string
+}
+
+export interface RecoverStaleTelegramWorkflowJobsResult {
+  recoveredJobs: NodeTelegramBotWorkflowJobRecord[]
+}
+
 export interface NodeTelegramBotFileWorkflowJobStoreOptions {
   maxJobs?: number
 }
@@ -132,6 +142,33 @@ export class NodeTelegramBotFileWorkflowJobStore implements NodeTelegramBotWorkf
   }
 }
 
+export async function recoverStaleTelegramWorkflowJobs(
+  store: NodeTelegramBotWorkflowJobStore,
+  options: RecoverStaleTelegramWorkflowJobsOptions = {},
+): Promise<RecoverStaleTelegramWorkflowJobsResult> {
+  const timestamp = options.now?.() ?? new Date().toISOString()
+  const reason = options.reason ?? "Telegram bot workflow recovered after worker restart"
+  const error = options.error ?? "Workflow was interrupted before completion. Send /retry <queueId> to run it again."
+  const jobs = await store.listJobs()
+  const recoveredJobs: NodeTelegramBotWorkflowJobRecord[] = []
+
+  for (const job of jobs) {
+    if (!isRecoverableStaleWorkflowJobStatus(job.status)) continue
+
+    const recoveredJob: NodeTelegramBotWorkflowJobRecord = {
+      ...job,
+      status: "failed",
+      reason,
+      error,
+      updatedAt: timestamp,
+    }
+    await store.writeJob(recoveredJob)
+    recoveredJobs.push(recoveredJob)
+  }
+
+  return { recoveredJobs }
+}
+
 function filterAndLimitJobs(
   jobs: NodeTelegramBotWorkflowJobRecord[],
   query: NodeTelegramBotWorkflowJobQuery,
@@ -170,6 +207,10 @@ function isWorkflowJobStatus(value: unknown): value is NodeTelegramBotWorkflowJo
     value === "rejected" ||
     value === "cancelled"
   )
+}
+
+function isRecoverableStaleWorkflowJobStatus(status: NodeTelegramBotWorkflowJobStatus): boolean {
+  return status === "queued" || status === "running"
 }
 
 function isNotFoundError(error: unknown): boolean {

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -130,6 +130,7 @@ TIMELINE_BOT_TELEGRAM_TOKEN=123:token \
 TIMELINE_BOT_OFFSET_FILE=.tmp/timeline-bot/offset.json \
 TIMELINE_BOT_DRAFT_DIR=.tmp/timeline-bot/drafts \
 TIMELINE_BOT_JOB_STORE_FILE=.tmp/timeline-bot/jobs.json \
+TIMELINE_BOT_RECOVER_STALE_JOBS=true \
 TIMELINE_BOT_ASYNC_WORKFLOWS=true \
 TIMELINE_BOT_WORKFLOW_CONCURRENCY=1 \
 TIMELINE_BOT_WORKFLOW_QUEUE_LIMIT=20 \
@@ -145,6 +146,7 @@ bun run src/cli/index.ts bot-worker --poll --rust-render
 Когда workflow поставлен в очередь, bot-worker сразу отправляет queued acknowledgement в исходный чат; финальный progress/result продолжает идти через status updates.
 Если задан `--workflow-queue-limit`, новые render requests сверх pending backlog получают busy response и не запускают workflow.
 Если задан `--job-store-file` или `TIMELINE_BOT_JOB_STORE_FILE`, worker сохраняет историю queued/running/done/failed/rejected/cancelled jobs; команда `/status` показывает последние jobs текущего Telegram chat.
+Если задан `--recover-stale-jobs` или `TIMELINE_BOT_RECOVER_STALE_JOBS=true`, worker перед стартом помечает сохраненные queued/running jobs как failed, чтобы после рестарта они не висели в `/status` и были доступны для `/retry`.
 Команда `/cancel <queueId>` отменяет pending queued job или running render job из текущего chat; done/failed/rejected jobs не отменяются.
 Команда `/retry <queueId>` повторно запускает failed/cancelled job из сохраненного source payload/workflow.
 
@@ -157,6 +159,7 @@ bun run src/cli/index.ts bot-worker --poll --rust-render
 | `--offset-file <path>` | Сохранять Telegram offset между рестартами |
 | `--draft-dir <path>` | Сохранять bot conversation drafts между сообщениями и рестартами |
 | `--job-store-file <path>` | Сохранять workflow job status/history для `/status` |
+| `--recover-stale-jobs` | Помечать сохраненные queued/running jobs как failed перед стартом worker |
 | `--async-workflows` | Ставить render workflows в очередь во время continuous polling |
 | `--workflow-concurrency <count>` | Максимум параллельных queued workflows |
 | `--workflow-queue-limit <count>` | Максимум ожидающих queued workflows перед busy response |
@@ -179,6 +182,7 @@ export TIMELINE_BOT_TELEGRAM_TOKEN=123:token
 export TIMELINE_BOT_OFFSET_FILE=.tmp/timeline-bot/offset.json
 export TIMELINE_BOT_DRAFT_DIR=.tmp/timeline-bot/drafts
 export TIMELINE_BOT_JOB_STORE_FILE=.tmp/timeline-bot/jobs.json
+export TIMELINE_BOT_RECOVER_STALE_JOBS=true
 export TIMELINE_BOT_ASYNC_WORKFLOWS=true
 export TIMELINE_BOT_WORKFLOW_CONCURRENCY=1
 export TIMELINE_BOT_WORKFLOW_QUEUE_LIMIT=20

--- a/src/cli/commands/__tests__/bot-worker.test.ts
+++ b/src/cli/commands/__tests__/bot-worker.test.ts
@@ -11,6 +11,7 @@ import {
   isFailedWorkerResult,
   readTelegramBotUpdate,
   resolveBotWorkerCommandOptions,
+  runBotWorker,
   serializeBotWorkerResult,
 } from "../bot-worker"
 
@@ -37,6 +38,7 @@ describe("bot-worker command", () => {
     expect(botWorkerCommand.options.some((option) => option.long === "--offset-file")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--draft-dir")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--job-store-file")).toBe(true)
+    expect(botWorkerCommand.options.some((option) => option.long === "--recover-stale-jobs")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--async-workflows")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--workflow-concurrency")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--workflow-queue-limit")).toBe(true)
@@ -77,6 +79,12 @@ describe("bot-worker command", () => {
     await expect(readTelegramBotUpdate(updatePath)).rejects.toThrow(
       "Telegram update JSON must include numeric update_id",
     )
+  })
+
+  it("requires a job store file when stale job recovery is enabled", async () => {
+    await expect(
+      runBotWorker({ updateFile: path.join(tempDir, "update.json"), recoverStaleJobs: true }),
+    ).rejects.toThrow("--recover-stale-jobs requires --job-store-file")
   })
 
   it("serializes compact and pretty worker results", () => {
@@ -188,6 +196,7 @@ describe("bot-worker command", () => {
         TIMELINE_BOT_OFFSET_FILE: ".tmp/bot-offset.json",
         TIMELINE_BOT_DRAFT_DIR: ".tmp/bot-drafts",
         TIMELINE_BOT_JOB_STORE_FILE: ".tmp/bot-jobs.json",
+        TIMELINE_BOT_RECOVER_STALE_JOBS: "true",
         TIMELINE_BOT_ASYNC_WORKFLOWS: "true",
         TIMELINE_BOT_WORKFLOW_CONCURRENCY: "2",
         TIMELINE_BOT_WORKFLOW_QUEUE_LIMIT: "10",
@@ -213,6 +222,7 @@ describe("bot-worker command", () => {
       offsetFile: ".tmp/bot-offset.json",
       draftDir: ".tmp/bot-drafts",
       jobStoreFile: ".tmp/bot-jobs.json",
+      recoverStaleJobs: true,
       asyncWorkflows: true,
       workflowConcurrency: "2",
       workflowQueueLimit: "10",
@@ -239,6 +249,7 @@ describe("bot-worker command", () => {
         offsetFile: ".tmp/cli-offset.json",
         draftDir: ".tmp/cli-drafts",
         jobStoreFile: ".tmp/cli-jobs.json",
+        recoverStaleJobs: false,
         asyncWorkflows: false,
         workflowConcurrency: "3",
         workflowQueueLimit: "5",
@@ -251,6 +262,7 @@ describe("bot-worker command", () => {
         TIMELINE_BOT_OFFSET_FILE: ".tmp/env-offset.json",
         TIMELINE_BOT_DRAFT_DIR: ".tmp/env-drafts",
         TIMELINE_BOT_JOB_STORE_FILE: ".tmp/env-jobs.json",
+        TIMELINE_BOT_RECOVER_STALE_JOBS: "true",
         TIMELINE_BOT_ASYNC_WORKFLOWS: "true",
         TIMELINE_BOT_WORKFLOW_CONCURRENCY: "1",
         TIMELINE_BOT_WORKFLOW_QUEUE_LIMIT: "10",
@@ -265,6 +277,7 @@ describe("bot-worker command", () => {
       offsetFile: ".tmp/cli-offset.json",
       draftDir: ".tmp/cli-drafts",
       jobStoreFile: ".tmp/cli-jobs.json",
+      recoverStaleJobs: false,
       asyncWorkflows: false,
       workflowConcurrency: "3",
       workflowQueueLimit: "5",

--- a/src/cli/commands/bot-worker.ts
+++ b/src/cli/commands/bot-worker.ts
@@ -21,6 +21,7 @@ import {
   NodeTelegramBotFileWorkflowJobStore,
   NodeTelegramBotInMemoryWorkflowQueue,
   NodeTelegramBotWorker,
+  recoverStaleTelegramWorkflowJobs,
 } from "@/adapters/node"
 import type { BotRenderJobDestination, BotWorkflowRunResult } from "@/core/types"
 
@@ -39,6 +40,7 @@ export interface BotWorkerCommandOptions {
   offsetFile?: string
   draftDir?: string
   jobStoreFile?: string
+  recoverStaleJobs?: boolean
   asyncWorkflows?: boolean
   workflowConcurrency?: string
   workflowQueueLimit?: string
@@ -76,6 +78,7 @@ export const botWorkerCommand = new Command("bot-worker")
   .option("--offset-file <path>", "Persist Telegram getUpdates offset between polling runs")
   .option("--draft-dir <path>", "Persist Telegram bot conversation drafts in a directory")
   .option("--job-store-file <path>", "Persist Telegram workflow job status/history")
+  .option("--recover-stale-jobs", "Mark persisted queued/running workflow jobs as failed before worker handling")
   .option("--async-workflows", "Queue Telegram workflow runs during continuous polling")
   .option("--workflow-concurrency <count>", "Maximum queued workflow runs in parallel", "1")
   .option("--workflow-queue-limit <count>", "Maximum pending queued workflows before rejecting new requests")
@@ -121,6 +124,10 @@ export async function runBotWorker(options: BotWorkerCommandOptions = {}): Promi
     throw new Error("--telegram-bot-token is required with --poll-once or --poll")
   }
 
+  if (resolvedOptions.recoverStaleJobs && !resolvedOptions.jobStoreFile) {
+    throw new Error("--recover-stale-jobs requires --job-store-file")
+  }
+
   const services = await initNodeApp({
     autoConnect: false,
     botMediaResolver: createBotMediaResolverOptions(resolvedOptions),
@@ -133,6 +140,14 @@ export async function runBotWorker(options: BotWorkerCommandOptions = {}): Promi
         }
       : undefined,
   })
+  const workflowJobStore = resolvedOptions.jobStoreFile
+    ? new NodeTelegramBotFileWorkflowJobStore(path.resolve(resolvedOptions.jobStoreFile))
+    : undefined
+
+  if (resolvedOptions.recoverStaleJobs && workflowJobStore) {
+    await recoverStaleTelegramWorkflowJobs(workflowJobStore)
+  }
+
   const workflowQueue =
     resolvedOptions.poll && resolvedOptions.asyncWorkflows
       ? new NodeTelegramBotInMemoryWorkflowQueue({
@@ -158,9 +173,7 @@ export async function runBotWorker(options: BotWorkerCommandOptions = {}): Promi
     draftStore: resolvedOptions.draftDir
       ? new NodeBotWorkflowFileDraftStore(path.resolve(resolvedOptions.draftDir))
       : undefined,
-    workflowJobStore: resolvedOptions.jobStoreFile
-      ? new NodeTelegramBotFileWorkflowJobStore(path.resolve(resolvedOptions.jobStoreFile))
-      : undefined,
+    workflowJobStore,
   })
 
   if (resolvedOptions.updateFile) {
@@ -211,6 +224,7 @@ export function resolveBotWorkerCommandOptions(
     offsetFile: firstConfigured(options.offsetFile, env.TIMELINE_BOT_OFFSET_FILE),
     draftDir: firstConfigured(options.draftDir, env.TIMELINE_BOT_DRAFT_DIR),
     jobStoreFile: firstConfigured(options.jobStoreFile, env.TIMELINE_BOT_JOB_STORE_FILE),
+    recoverStaleJobs: options.recoverStaleJobs ?? parseBooleanEnv(env.TIMELINE_BOT_RECOVER_STALE_JOBS),
     workflowConcurrency: firstConfigured(options.workflowConcurrency, env.TIMELINE_BOT_WORKFLOW_CONCURRENCY),
     workflowQueueLimit: firstConfigured(options.workflowQueueLimit, env.TIMELINE_BOT_WORKFLOW_QUEUE_LIMIT),
     maxBatches: firstConfigured(options.maxBatches, env.TIMELINE_BOT_MAX_BATCHES),


### PR DESCRIPTION
## Summary
- add a workflow job store recovery helper that marks persisted queued/running jobs as failed after worker interruption
- wire opt-in recovery into `bot-worker` through `--recover-stale-jobs` and `TIMELINE_BOT_RECOVER_STALE_JOBS`
- preserve source payload/workflow context so recovered failed jobs can be retried with `/retry <queueId>`
- document the production runbook and mark B24 in the bot-first roadmap

## Tests
- `bun run test -- src/adapters/node/__tests__/telegram-bot-worker.test.ts src/cli/commands/__tests__/bot-worker.test.ts`
- `bun run check:type`
- `bun run check:workspaces`
- `bun run check:boundaries:baseline`
- `bunx biome ci src/adapters/node/telegram-bot-job-store.ts src/adapters/node/index.ts src/adapters/node/__tests__/telegram-bot-worker.test.ts src/cli/commands/bot-worker.ts src/cli/commands/__tests__/bot-worker.test.ts`
- `git diff --check`
- `bun run src/cli/index.ts bot-worker --update-file docs/08_tasks/planned/fixtures/telegram-help-update.json --pretty`

Closes #217
Refs #171