### PR TITLE
B25: Bot workflow status update throttling

### DIFF
--- a/docs/08_tasks/planned/bot-first-workflow.md
+++ b/docs/08_tasks/planned/bot-first-workflow.md
@@ -277,6 +277,16 @@ bot message
 - [x] Подключить opt-in recovery к `bot-worker` через CLI/env.
 - [x] Документировать production runbook и покрыть store/CLI tests.
 
+### B25: Bot workflow status update throttling ([#219](https://github.com/chatman-media/timeline-studio/issues/219))
+
+**Цель:** production bot не отправляет каждый render progress event в Telegram и снижает риск chat spam/429.
+
+- [x] Добавить configurable status update policy в core workflow status options.
+- [x] Отправлять первый status, terminal states и lifecycle transitions без задержки.
+- [x] Throttle repeated `rendering` progress по minimum interval/progress delta.
+- [x] Прокинуть policy через `bot-worker` и `bot-workflow` CLI flags/env.
+- [x] Документировать production runbook и покрыть core/CLI tests.
+
 ## Связанные задачи
 
 - [#150](https://github.com/chatman-media/timeline-studio/issues/150) - Phase F / package boundaries
@@ -304,6 +314,7 @@ bot message
 - [#213](https://github.com/chatman-media/timeline-studio/issues/213) - B22: Telegram bot running render cancellation
 - [#215](https://github.com/chatman-media/timeline-studio/issues/215) - B23: Telegram bot workflow retry command
 - [#217](https://github.com/chatman-media/timeline-studio/issues/217) - B24: Telegram bot stale workflow recovery
+- [#219](https://github.com/chatman-media/timeline-studio/issues/219) - B25: Bot workflow status update throttling
 - [telegram-mini-app.md](./telegram-mini-app.md)
 - [cloud-rendering.md](./cloud-rendering.md)
 - [export-architecture-refactoring.md](./export-architecture-refactoring.md)

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -131,6 +131,8 @@ TIMELINE_BOT_OFFSET_FILE=.tmp/timeline-bot/offset.json \
 TIMELINE_BOT_DRAFT_DIR=.tmp/timeline-bot/drafts \
 TIMELINE_BOT_JOB_STORE_FILE=.tmp/timeline-bot/jobs.json \
 TIMELINE_BOT_RECOVER_STALE_JOBS=true \
+TIMELINE_BOT_STATUS_MIN_INTERVAL=30000 \
+TIMELINE_BOT_STATUS_MIN_PROGRESS_DELTA=10 \
 TIMELINE_BOT_ASYNC_WORKFLOWS=true \
 TIMELINE_BOT_WORKFLOW_CONCURRENCY=1 \
 TIMELINE_BOT_WORKFLOW_QUEUE_LIMIT=20 \
@@ -144,6 +146,7 @@ bun run src/cli/index.ts bot-worker --poll --rust-render
 также поддерживаются `media=`, `url=`, `input=` и `source=`.
 Для production polling включайте `--async-workflows`: worker быстро ставит render workflow в очередь и продолжает читать Telegram updates.
 Когда workflow поставлен в очередь, bot-worker сразу отправляет queued acknowledgement в исходный чат; финальный progress/result продолжает идти через status updates.
+Для длинных renders задавайте `--status-min-interval` и/или `--status-min-progress-delta`, чтобы не отправлять каждый progress event в Telegram.
 Если задан `--workflow-queue-limit`, новые render requests сверх pending backlog получают busy response и не запускают workflow.
 Если задан `--job-store-file` или `TIMELINE_BOT_JOB_STORE_FILE`, worker сохраняет историю queued/running/done/failed/rejected/cancelled jobs; команда `/status` показывает последние jobs текущего Telegram chat.
 Если задан `--recover-stale-jobs` или `TIMELINE_BOT_RECOVER_STALE_JOBS=true`, worker перед стартом помечает сохраненные queued/running jobs как failed, чтобы после рестарта они не висели в `/status` и были доступны для `/retry`.
@@ -160,6 +163,8 @@ bun run src/cli/index.ts bot-worker --poll --rust-render
 | `--draft-dir <path>` | Сохранять bot conversation drafts между сообщениями и рестартами |
 | `--job-store-file <path>` | Сохранять workflow job status/history для `/status` |
 | `--recover-stale-jobs` | Помечать сохраненные queued/running jobs как failed перед стартом worker |
+| `--status-min-interval <ms>` | Минимальный интервал между repeated rendering status messages |
+| `--status-min-progress-delta <percent>` | Минимальный progress delta между rendering status messages |
 | `--async-workflows` | Ставить render workflows в очередь во время continuous polling |
 | `--workflow-concurrency <count>` | Максимум параллельных queued workflows |
 | `--workflow-queue-limit <count>` | Максимум ожидающих queued workflows перед busy response |
@@ -183,6 +188,8 @@ export TIMELINE_BOT_OFFSET_FILE=.tmp/timeline-bot/offset.json
 export TIMELINE_BOT_DRAFT_DIR=.tmp/timeline-bot/drafts
 export TIMELINE_BOT_JOB_STORE_FILE=.tmp/timeline-bot/jobs.json
 export TIMELINE_BOT_RECOVER_STALE_JOBS=true
+export TIMELINE_BOT_STATUS_MIN_INTERVAL=30000
+export TIMELINE_BOT_STATUS_MIN_PROGRESS_DELTA=10
 export TIMELINE_BOT_ASYNC_WORKFLOWS=true
 export TIMELINE_BOT_WORKFLOW_CONCURRENCY=1
 export TIMELINE_BOT_WORKFLOW_QUEUE_LIMIT=20

--- a/src/cli/commands/__tests__/bot-worker.test.ts
+++ b/src/cli/commands/__tests__/bot-worker.test.ts
@@ -35,6 +35,8 @@ describe("bot-worker command", () => {
     expect(botWorkerCommand.options.some((option) => option.long === "--telegram-bot-token")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--no-status-updates")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--status-chat-id")).toBe(true)
+    expect(botWorkerCommand.options.some((option) => option.long === "--status-min-interval")).toBe(true)
+    expect(botWorkerCommand.options.some((option) => option.long === "--status-min-progress-delta")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--offset-file")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--draft-dir")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--job-store-file")).toBe(true)
@@ -193,6 +195,8 @@ describe("bot-worker command", () => {
         TELEGRAM_BOT_TOKEN: "token-from-telegram-env",
         TIMELINE_BOT_TELEGRAM_TOKEN: "token-from-timeline-env",
         TIMELINE_BOT_STATUS_CHAT_ID: "chat-1",
+        TIMELINE_BOT_STATUS_MIN_INTERVAL: "30000",
+        TIMELINE_BOT_STATUS_MIN_PROGRESS_DELTA: "10",
         TIMELINE_BOT_OFFSET_FILE: ".tmp/bot-offset.json",
         TIMELINE_BOT_DRAFT_DIR: ".tmp/bot-drafts",
         TIMELINE_BOT_JOB_STORE_FILE: ".tmp/bot-jobs.json",
@@ -219,6 +223,8 @@ describe("bot-worker command", () => {
     expect(resolved).toMatchObject({
       telegramBotToken: "token-from-timeline-env",
       statusChatId: "chat-1",
+      statusMinInterval: "30000",
+      statusMinProgressDelta: "10",
       offsetFile: ".tmp/bot-offset.json",
       draftDir: ".tmp/bot-drafts",
       jobStoreFile: ".tmp/bot-jobs.json",
@@ -246,6 +252,8 @@ describe("bot-worker command", () => {
     const resolved = resolveBotWorkerCommandOptions(
       {
         telegramBotToken: "token-from-cli",
+        statusMinInterval: "15000",
+        statusMinProgressDelta: "5",
         offsetFile: ".tmp/cli-offset.json",
         draftDir: ".tmp/cli-drafts",
         jobStoreFile: ".tmp/cli-jobs.json",
@@ -259,6 +267,8 @@ describe("bot-worker command", () => {
       },
       {
         TIMELINE_BOT_TELEGRAM_TOKEN: "token-from-env",
+        TIMELINE_BOT_STATUS_MIN_INTERVAL: "30000",
+        TIMELINE_BOT_STATUS_MIN_PROGRESS_DELTA: "10",
         TIMELINE_BOT_OFFSET_FILE: ".tmp/env-offset.json",
         TIMELINE_BOT_DRAFT_DIR: ".tmp/env-drafts",
         TIMELINE_BOT_JOB_STORE_FILE: ".tmp/env-jobs.json",
@@ -274,6 +284,8 @@ describe("bot-worker command", () => {
 
     expect(resolved).toMatchObject({
       telegramBotToken: "token-from-cli",
+      statusMinInterval: "15000",
+      statusMinProgressDelta: "5",
       offsetFile: ".tmp/cli-offset.json",
       draftDir: ".tmp/cli-drafts",
       jobStoreFile: ".tmp/cli-jobs.json",

--- a/src/cli/commands/__tests__/bot-workflow.test.ts
+++ b/src/cli/commands/__tests__/bot-workflow.test.ts
@@ -29,6 +29,8 @@ describe("bot-workflow command", () => {
     expect(botWorkflowCommand.options.some((option) => option.long === "--telegram-bot-token")).toBe(true)
     expect(botWorkflowCommand.options.some((option) => option.long === "--send-status-updates")).toBe(true)
     expect(botWorkflowCommand.options.some((option) => option.long === "--status-chat-id")).toBe(true)
+    expect(botWorkflowCommand.options.some((option) => option.long === "--status-min-interval")).toBe(true)
+    expect(botWorkflowCommand.options.some((option) => option.long === "--status-min-progress-delta")).toBe(true)
     expect(botWorkflowCommand.options.some((option) => option.long === "--media-dir")).toBe(true)
     expect(botWorkflowCommand.options.some((option) => option.long === "--download-remote-media")).toBe(true)
     expect(botWorkflowCommand.options.some((option) => option.long === "--rust-render")).toBe(true)

--- a/src/cli/commands/bot-worker.ts
+++ b/src/cli/commands/bot-worker.ts
@@ -23,7 +23,13 @@ import {
   NodeTelegramBotWorker,
   recoverStaleTelegramWorkflowJobs,
 } from "@/adapters/node"
-import type { BotRenderJobDestination, BotWorkflowRunResult } from "@/core/types"
+import type {
+  BotRenderJobDestination,
+  BotWorkflowRunResult,
+  BotWorkflowStatusOptions,
+  BotWorkflowStatusPolicy,
+  BotWorkflowStatusSink,
+} from "@/core/types"
 
 export interface BotWorkerCommandOptions {
   updateFile?: string
@@ -34,6 +40,8 @@ export interface BotWorkerCommandOptions {
   telegramBotToken?: string
   statusUpdates?: boolean
   statusChatId?: string
+  statusMinInterval?: string
+  statusMinProgressDelta?: string
   pollOffset?: string
   pollLimit?: string
   pollTimeout?: string
@@ -72,6 +80,8 @@ export const botWorkerCommand = new Command("bot-worker")
   .option("--telegram-bot-token <token>", "Telegram Bot API token for polling, media, status, and publishing")
   .option("--no-status-updates", "Disable Telegram workflow status messages")
   .option("--status-chat-id <id>", "Fallback Telegram chat id for status updates and publishing")
+  .option("--status-min-interval <ms>", "Minimum interval between repeated rendering status messages")
+  .option("--status-min-progress-delta <percent>", "Minimum progress delta between rendering status messages")
   .option("--poll-offset <id>", "Telegram getUpdates offset")
   .option("--poll-limit <count>", "Telegram getUpdates limit", "100")
   .option("--poll-timeout <seconds>", "Telegram getUpdates long-poll timeout in seconds", "25")
@@ -148,6 +158,7 @@ export async function runBotWorker(options: BotWorkerCommandOptions = {}): Promi
     await recoverStaleTelegramWorkflowJobs(workflowJobStore)
   }
 
+  const workflowStatus = createBotWorkflowStatusOptions(services.botStatus, resolvedOptions)
   const workflowQueue =
     resolvedOptions.poll && resolvedOptions.asyncWorkflows
       ? new NodeTelegramBotInMemoryWorkflowQueue({
@@ -168,6 +179,7 @@ export async function runBotWorker(options: BotWorkerCommandOptions = {}): Promi
         pollIntervalMs: parsePositiveInteger(resolvedOptions.pollInterval, 1000),
         timeoutMs: parsePositiveInteger(resolvedOptions.timeout, 3600000),
       },
+      ...(workflowStatus ? { status: workflowStatus } : {}),
       includeReconnectState: true,
     },
     draftStore: resolvedOptions.draftDir
@@ -218,6 +230,8 @@ export function resolveBotWorkerCommandOptions(
       env.TELEGRAM_BOT_TOKEN,
     ),
     statusChatId: firstConfigured(options.statusChatId, env.TIMELINE_BOT_STATUS_CHAT_ID),
+    statusMinInterval: firstConfigured(options.statusMinInterval, env.TIMELINE_BOT_STATUS_MIN_INTERVAL),
+    statusMinProgressDelta: firstConfigured(options.statusMinProgressDelta, env.TIMELINE_BOT_STATUS_MIN_PROGRESS_DELTA),
     pollOffset: firstConfigured(options.pollOffset, env.TIMELINE_BOT_POLL_OFFSET),
     pollLimit: firstConfigured(options.pollLimit, env.TIMELINE_BOT_POLL_LIMIT),
     pollTimeout: firstConfigured(options.pollTimeout, env.TIMELINE_BOT_POLL_TIMEOUT),
@@ -296,6 +310,29 @@ function createBotStatusOptions(options: BotWorkerCommandOptions) {
   }
 }
 
+function createBotWorkflowStatusOptions(
+  sink: BotWorkflowStatusSink | undefined,
+  options: BotWorkerCommandOptions,
+): BotWorkflowStatusOptions | undefined {
+  if (!sink) return undefined
+  const policy = createBotWorkflowStatusPolicy(options)
+  return {
+    sink,
+    ...(policy ? { policy } : {}),
+  }
+}
+
+function createBotWorkflowStatusPolicy(options: BotWorkerCommandOptions): BotWorkflowStatusPolicy | undefined {
+  const minIntervalMs = parseOptionalNonNegativeNumber(options.statusMinInterval)
+  const minProgressDelta = parseOptionalNonNegativeNumber(options.statusMinProgressDelta)
+
+  if (minIntervalMs === undefined && minProgressDelta === undefined) return undefined
+  return {
+    ...(minIntervalMs !== undefined ? { minIntervalMs } : {}),
+    ...(minProgressDelta !== undefined ? { minProgressDelta } : {}),
+  }
+}
+
 function createBotPublishOptions(options: BotWorkerCommandOptions) {
   if (!options.telegramBotToken) {
     return undefined
@@ -364,6 +401,12 @@ function parseOptionalPositiveInteger(value: string | undefined): number | undef
 function parseOptionalNonNegativeInteger(value: string | undefined): number | undefined {
   if (!value) return undefined
   const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined
+}
+
+function parseOptionalNonNegativeNumber(value: string | undefined): number | undefined {
+  if (!value) return undefined
+  const parsed = Number.parseFloat(value)
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined
 }
 

--- a/src/cli/commands/bot-workflow.ts
+++ b/src/cli/commands/bot-workflow.ts
@@ -10,7 +10,14 @@ import path from "node:path"
 import { Command } from "commander"
 
 import { initNodeApp } from "@/adapters/node"
-import type { BotRenderJobDestination, BotWorkflowRunResult, TelegramLikeBotPayload } from "@/core/types"
+import type {
+  BotRenderJobDestination,
+  BotWorkflowRunResult,
+  BotWorkflowStatusOptions,
+  BotWorkflowStatusPolicy,
+  BotWorkflowStatusSink,
+  TelegramLikeBotPayload,
+} from "@/core/types"
 
 export interface BotWorkflowCommandOptions {
   statusFile?: string
@@ -20,6 +27,8 @@ export interface BotWorkflowCommandOptions {
   telegramBotToken?: string
   sendStatusUpdates?: boolean
   statusChatId?: string
+  statusMinInterval?: string
+  statusMinProgressDelta?: string
   mediaDir?: string
   downloadRemoteMedia?: boolean
   rustRender?: boolean
@@ -39,6 +48,8 @@ export const botWorkflowCommand = new Command("bot-workflow")
   .option("--telegram-bot-token <token>", "Resolve Telegram file ids through the Telegram Bot API")
   .option("--send-status-updates", "Send workflow status updates through the Telegram Bot API")
   .option("--status-chat-id <id>", "Fallback Telegram chat id for status updates")
+  .option("--status-min-interval <ms>", "Minimum interval between repeated rendering status messages")
+  .option("--status-min-progress-delta <percent>", "Minimum progress delta between rendering status messages")
   .option("--media-dir <path>", "Directory for resolved bot media downloads")
   .option("--download-remote-media", "Download remote URL media before rendering")
   .option("--rust-render", "Run rendering through the Rust headless ts-render CLI")
@@ -86,6 +97,7 @@ export async function runBotWorkflowPayloadFile(
       : undefined,
   })
 
+  const workflowStatus = createBotWorkflowStatusOptions(services.botStatus, options)
   return services.botWorkflow.runTelegramLikePayload(payload, {
     intake: {
       defaultDestination: options.defaultDestination,
@@ -95,6 +107,7 @@ export async function runBotWorkflowPayloadFile(
       pollIntervalMs: parsePositiveInteger(options.pollInterval, 1000),
       timeoutMs: parsePositiveInteger(options.timeout, 3600000),
     },
+    ...(workflowStatus ? { status: workflowStatus } : {}),
     includeReconnectState: true,
   })
 }
@@ -127,6 +140,33 @@ function createBotStatusOptions(options: BotWorkflowCommandOptions) {
       botToken: options.telegramBotToken,
       ...(options.statusChatId ? { defaultChatId: options.statusChatId } : {}),
     },
+  }
+}
+
+function createBotWorkflowStatusOptions(
+  sink: BotWorkflowStatusSink | undefined,
+  options: BotWorkflowCommandOptions,
+): BotWorkflowStatusOptions | undefined {
+  if (!sink) return undefined
+  const policy = createBotWorkflowStatusPolicy(options)
+  return {
+    sink,
+    ...(policy ? { policy } : {}),
+  }
+}
+
+function createBotWorkflowStatusPolicy(options: BotWorkflowCommandOptions): BotWorkflowStatusPolicy | undefined {
+  const minIntervalMs = parseOptionalNonNegativeNumber(
+    firstConfigured(options.statusMinInterval, process.env.TIMELINE_BOT_STATUS_MIN_INTERVAL),
+  )
+  const minProgressDelta = parseOptionalNonNegativeNumber(
+    firstConfigured(options.statusMinProgressDelta, process.env.TIMELINE_BOT_STATUS_MIN_PROGRESS_DELTA),
+  )
+
+  if (minIntervalMs === undefined && minProgressDelta === undefined) return undefined
+  return {
+    ...(minIntervalMs !== undefined ? { minIntervalMs } : {}),
+    ...(minProgressDelta !== undefined ? { minProgressDelta } : {}),
   }
 }
 
@@ -168,4 +208,14 @@ function parsePositiveInteger(value: string | undefined, fallback: number): numb
   if (!value) return fallback
   const parsed = Number.parseInt(value, 10)
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+function parseOptionalNonNegativeNumber(value: string | undefined): number | undefined {
+  if (!value) return undefined
+  const parsed = Number.parseFloat(value)
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined
+}
+
+function firstConfigured<T extends string>(...values: Array<T | undefined>): T | undefined {
+  return values.find((value): value is T => value !== undefined && value.trim().length > 0)
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -111,6 +111,7 @@ export type {
   BotWorkflowStatusKind,
   BotWorkflowStatusMessage,
   BotWorkflowStatusOptions,
+  BotWorkflowStatusPolicy,
   BotWorkflowStatusSink,
   BotWorkflowValidationCode,
   BotWorkflowValidationError,

--- a/src/core/services/__tests__/bot-status-updates.test.ts
+++ b/src/core/services/__tests__/bot-status-updates.test.ts
@@ -95,6 +95,27 @@ describe("bot status updates", () => {
     expect(sink.sendStatus).toHaveBeenCalledOnce()
   })
 
+  it("throttles repeated rendering progress while sending status transitions", async () => {
+    const sink = { sendStatus: vi.fn() }
+    const statusSink = createBotWorkflowStatusEventSink(workflow, {
+      sink,
+      policy: {
+        minProgressDelta: 10,
+        minIntervalMs: 60_000,
+      },
+    })
+
+    await statusSink.publish(createRenderEvent("rendering", 10, 1), createRenderSnapshot("rendering", 10, 1))
+    await statusSink.publish(createRenderEvent("rendering", 15, 2), createRenderSnapshot("rendering", 15, 2))
+    await statusSink.publish(createRenderEvent("rendering", 20, 3), createRenderSnapshot("rendering", 20, 3))
+    await statusSink.publish(createRenderEvent("publishing", 20, 4), createRenderSnapshot("publishing", 20, 4))
+
+    expect(sink.sendStatus).toHaveBeenCalledTimes(3)
+    expect(sink.sendStatus).toHaveBeenNthCalledWith(1, expect.objectContaining({ text: "Rendering video: 10%." }))
+    expect(sink.sendStatus).toHaveBeenNthCalledWith(2, expect.objectContaining({ text: "Rendering video: 20%." }))
+    expect(sink.sendStatus).toHaveBeenNthCalledWith(3, expect.objectContaining({ text: "Publishing video." }))
+  })
+
   it("can propagate status delivery failures when explicitly requested", async () => {
     const sink = {
       sendStatus: vi.fn(async () => {
@@ -106,3 +127,32 @@ describe("bot status updates", () => {
     await expect(statusSink.publish(event, snapshot)).rejects.toThrow("telegram unavailable")
   })
 })
+
+function createRenderEvent(status: BotRenderJobEvent["status"], progress: number, sequence: number): BotRenderJobEvent {
+  return {
+    jobId: "job-1",
+    sequence,
+    status,
+    progress,
+    timestamp: `2026-06-08T00:00:0${sequence}.000Z`,
+  }
+}
+
+function createRenderSnapshot(
+  status: BotRenderJobSnapshot["status"],
+  progress: number,
+  sequence: number,
+): BotRenderJobSnapshot {
+  const lastEvent = createRenderEvent(status, progress, sequence)
+  return {
+    jobId: "job-1",
+    status,
+    progress,
+    createdAt: "2026-06-08T00:00:00.000Z",
+    updatedAt: lastEvent.timestamp,
+    eventCount: sequence + 1,
+    lastEvent,
+    canCancel: status !== "done" && status !== "failed" && status !== "cancelled",
+    canRetry: status === "failed" || status === "cancelled",
+  }
+}

--- a/src/core/services/bot-status-updates.ts
+++ b/src/core/services/bot-status-updates.ts
@@ -6,26 +6,31 @@ import type {
   BotWorkflowStatusFormatterContext,
   BotWorkflowStatusMessage,
   BotWorkflowStatusOptions,
+  BotWorkflowStatusPolicy,
   BotWorkflowValidationError,
 } from "../types"
 
 export class BotWorkflowStatusEventSink implements BotRenderJobEventSink {
+  private lastSentMessage?: BotWorkflowStatusMessage
+
   constructor(
     private readonly workflow: BotWorkflowRequest,
     private readonly options: BotWorkflowStatusOptions,
   ) {}
 
   async publish(event: BotRenderJobEvent, snapshot: BotRenderJobSnapshot): Promise<void> {
-    await safeSendStatus(
-      this.options,
-      createBotWorkflowStatusMessage({
-        workflow: this.workflow,
-        event,
-        snapshot,
-        formatter: this.options.formatter,
-        now: this.options.now,
-      }),
-    )
+    const message = createBotWorkflowStatusMessage({
+      workflow: this.workflow,
+      event,
+      snapshot,
+      formatter: this.options.formatter,
+      now: this.options.now,
+    })
+
+    if (!shouldSendBotWorkflowStatusMessage(message, this.lastSentMessage, this.options.policy)) return
+
+    await safeSendStatus(this.options, message)
+    this.lastSentMessage = message
   }
 }
 
@@ -136,4 +141,42 @@ function doneText(snapshot?: BotRenderJobSnapshot): string {
   }
 
   return "Video is ready."
+}
+
+function shouldSendBotWorkflowStatusMessage(
+  message: BotWorkflowStatusMessage,
+  lastSentMessage: BotWorkflowStatusMessage | undefined,
+  policy: BotWorkflowStatusPolicy | undefined,
+): boolean {
+  if (!policy) return true
+  if (!lastSentMessage) return true
+  if (message.status !== lastSentMessage.status) return true
+  if (isTerminalStatus(message.status)) return false
+  if (message.status !== "rendering") return false
+
+  const hasProgressPolicy = typeof policy.minProgressDelta === "number" && Number.isFinite(policy.minProgressDelta)
+  const hasIntervalPolicy = typeof policy.minIntervalMs === "number" && Number.isFinite(policy.minIntervalMs)
+  if (!hasProgressPolicy && !hasIntervalPolicy) return true
+
+  const progressDelta =
+    typeof message.progress === "number" && typeof lastSentMessage.progress === "number"
+      ? Math.abs(message.progress - lastSentMessage.progress)
+      : 0
+  const progressReached = hasProgressPolicy && progressDelta >= Math.max(0, policy.minProgressDelta ?? 0)
+  const intervalReached =
+    hasIntervalPolicy &&
+    timestampDeltaMs(message.timestamp, lastSentMessage.timestamp) >= Math.max(0, policy.minIntervalMs ?? 0)
+
+  return progressReached || intervalReached
+}
+
+function isTerminalStatus(status: BotWorkflowStatusMessage["status"]): boolean {
+  return status === "done" || status === "failed" || status === "cancelled"
+}
+
+function timestampDeltaMs(current: string, previous: string): number {
+  const currentMs = Date.parse(current)
+  const previousMs = Date.parse(previous)
+  if (!Number.isFinite(currentMs) || !Number.isFinite(previousMs)) return 0
+  return currentMs - previousMs
 }

--- a/src/core/types/bot-workflow.ts
+++ b/src/core/types/bot-workflow.ts
@@ -166,9 +166,15 @@ export interface BotWorkflowStatusFormatterContext {
 
 export type BotWorkflowStatusFormatter = (context: BotWorkflowStatusFormatterContext) => string
 
+export interface BotWorkflowStatusPolicy {
+  minIntervalMs?: number
+  minProgressDelta?: number
+}
+
 export interface BotWorkflowStatusOptions {
   sink: BotWorkflowStatusSink
   formatter?: BotWorkflowStatusFormatter
+  policy?: BotWorkflowStatusPolicy
   throwOnError?: boolean
   now?: () => string
 }


### PR DESCRIPTION
## Summary
- add an optional core bot workflow status policy for rendering progress throttling
- send first status and lifecycle transitions immediately while filtering repeated rendering progress by interval/progress delta
- wire status throttling through `bot-worker` and `bot-workflow` CLI flags plus `TIMELINE_BOT_STATUS_*` env defaults
- document production status throttling and mark B25 in the bot-first roadmap

## Tests
- `bun run test -- src/core/services/__tests__/bot-status-updates.test.ts src/core/services/__tests__/bot-workflow-runner.test.ts src/adapters/node/__tests__/bot-workflow.test.ts src/cli/commands/__tests__/bot-worker.test.ts src/cli/commands/__tests__/bot-workflow.test.ts`
- `bun run check:type`
- `bun run check:workspaces`
- `bun run check:boundaries:baseline`
- `bunx biome ci src/core/types/bot-workflow.ts src/core/index.ts src/core/services/bot-status-updates.ts src/core/services/__tests__/bot-status-updates.test.ts src/cli/commands/bot-worker.ts src/cli/commands/bot-workflow.ts src/cli/commands/__tests__/bot-worker.test.ts src/cli/commands/__tests__/bot-workflow.test.ts`
- `git diff --check`
- `bun run src/cli/index.ts bot-worker --update-file docs/08_tasks/planned/fixtures/telegram-help-update.json --pretty`

Closes #219
Refs #171