### PR TITLE
B26: Telegram bot idempotent workflow updates

### DIFF
--- a/docs/08_tasks/planned/bot-first-workflow.md
+++ b/docs/08_tasks/planned/bot-first-workflow.md
@@ -287,6 +287,16 @@ bot message
 - [x] Прокинуть policy через `bot-worker` и `bot-workflow` CLI flags/env.
 - [x] Документировать production runbook и покрыть core/CLI tests.
 
+### B26: Telegram bot idempotent workflow updates ([#221](https://github.com/chatman-media/timeline-studio/issues/221))
+
+**Цель:** повторная доставка того же Telegram update не запускает второй render workflow.
+
+- [x] Проверять existing workflow job record перед стартом/queue non-command workflow.
+- [x] Возвращать machine-readable already-handled result с existing queue id/status.
+- [x] Не вызывать `runTelegramLikePayload`/`runWorkflow` для duplicate updates.
+- [x] Сохранить поведение команд и explicit `/retry <queueId>`.
+- [x] Документировать replay/idempotency behavior и покрыть worker/CLI tests.
+
 ## Связанные задачи
 
 - [#150](https://github.com/chatman-media/timeline-studio/issues/150) - Phase F / package boundaries
@@ -315,6 +325,7 @@ bot message
 - [#215](https://github.com/chatman-media/timeline-studio/issues/215) - B23: Telegram bot workflow retry command
 - [#217](https://github.com/chatman-media/timeline-studio/issues/217) - B24: Telegram bot stale workflow recovery
 - [#219](https://github.com/chatman-media/timeline-studio/issues/219) - B25: Bot workflow status update throttling
+- [#221](https://github.com/chatman-media/timeline-studio/issues/221) - B26: Telegram bot idempotent workflow updates
 - [telegram-mini-app.md](./telegram-mini-app.md)
 - [cloud-rendering.md](./cloud-rendering.md)
 - [export-architecture-refactoring.md](./export-architecture-refactoring.md)

--- a/src/adapters/node/__tests__/telegram-bot-worker.test.ts
+++ b/src/adapters/node/__tests__/telegram-bot-worker.test.ts
@@ -298,6 +298,51 @@ describe("Telegram bot worker", () => {
     expect(runTelegramLikePayload).toHaveBeenCalledOnce()
   })
 
+  it("does not start duplicate workflow updates when a job record already exists", async () => {
+    const { service, runTelegramLikePayload } = createWorkflowService(completedResult)
+    const workflowJobStore = new NodeTelegramBotInMemoryWorkflowJobStore()
+    await workflowJobStore.writeJob({
+      id: "telegram-update-23",
+      status: "running",
+      updateId: 23,
+      chatId: "chat-1",
+      messageId: "19",
+      sourcePayload: { text: "template=promo" },
+      createdAt: "2026-06-08T08:00:00.000Z",
+      updatedAt: "2026-06-08T08:00:00.000Z",
+    })
+    const onResult = vi.fn()
+    const worker = new NodeTelegramBotWorker({ workflow: service, workflowJobStore, onResult })
+
+    const update = {
+      update_id: 23,
+      message: {
+        message_id: 19,
+        chat: { id: "chat-1" },
+        text: "template=promo",
+      },
+    }
+    const result = await worker.handleUpdate(update)
+
+    expect(result).toMatchObject({
+      skipped: true,
+      reason: "Telegram bot workflow already handled",
+      updateId: 23,
+      queueId: "telegram-update-23",
+      duplicateOf: "telegram-update-23",
+      workflowJob: {
+        id: "telegram-update-23",
+        status: "running",
+      },
+    })
+    expect(runTelegramLikePayload).not.toHaveBeenCalled()
+    expect(onResult).toHaveBeenCalledWith(result)
+    await expect(workflowJobStore.readJob("telegram-update-23")).resolves.toMatchObject({
+      id: "telegram-update-23",
+      status: "running",
+    })
+  })
+
   it("rejects queued workflows when the pending queue is full", async () => {
     let resolveWorkflow!: () => void
     const runTelegramLikePayload = vi.fn(

--- a/src/adapters/node/telegram-bot-worker.ts
+++ b/src/adapters/node/telegram-bot-worker.ts
@@ -243,6 +243,8 @@ export type NodeTelegramBotWorkerUpdateResult =
       queueId?: string
       cancellation?: NodeTelegramBotWorkflowQueueCancellation
       retryOf?: string
+      duplicateOf?: string
+      workflowJob?: NodeTelegramBotWorkflowJobRecord
     }
   | {
       skipped: false
@@ -994,6 +996,17 @@ export class NodeTelegramBotWorker {
   ): Promise<NodeTelegramBotWorkerUpdateResult> {
     const workflowQueue = this.options.workflowQueue
     const queueId = createTelegramBotWorkflowQueueId(update)
+    const existingJob = await this.readWorkflowJobRecord(queueId)
+    if (existingJob) {
+      return this.createDuplicateWorkflowJobResult({
+        queueId,
+        update,
+        payload,
+        job: existingJob,
+        ...(options.retryOf ? { retryOf: options.retryOf } : {}),
+      })
+    }
+
     const jobRecord = this.createWorkflowJobRecord({
       queueId,
       status: workflowQueue ? "queued" : "running",
@@ -1111,6 +1124,28 @@ export class NodeTelegramBotWorker {
       } catch (error) {
         result.responseError = formatUnknownError(error)
       }
+    }
+    await this.options.onResult?.(result)
+    return result
+  }
+
+  private async createDuplicateWorkflowJobResult(context: {
+    queueId: string
+    update: TelegramBotUpdate
+    payload: TelegramLikeBotPayload
+    job: NodeTelegramBotWorkflowJobRecord
+    retryOf?: string
+  }): Promise<NodeTelegramBotWorkerUpdateResult> {
+    const result: NodeTelegramBotWorkerUpdateResult = {
+      skipped: true,
+      reason: "Telegram bot workflow already handled",
+      updateId: context.update.update_id,
+      update: context.update,
+      payload: context.payload,
+      queueId: context.queueId,
+      duplicateOf: context.queueId,
+      workflowJob: context.job,
+      ...(context.retryOf ? { retryOf: context.retryOf } : {}),
     }
     await this.options.onResult?.(result)
     return result
@@ -1303,6 +1338,15 @@ export class NodeTelegramBotWorker {
       await this.options.workflowJobStore?.writeJob(record)
     } catch {
       // Job status persistence is observational and must not fail workflow handling.
+    }
+  }
+
+  private async readWorkflowJobRecord(id: string): Promise<NodeTelegramBotWorkflowJobRecord | undefined> {
+    try {
+      return await this.options.workflowJobStore?.readJob(id)
+    } catch {
+      // Job status persistence is observational and must not fail workflow handling.
+      return undefined
     }
   }
 

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -149,6 +149,7 @@ bun run src/cli/index.ts bot-worker --poll --rust-render
 Для длинных renders задавайте `--status-min-interval` и/или `--status-min-progress-delta`, чтобы не отправлять каждый progress event в Telegram.
 Если задан `--workflow-queue-limit`, новые render requests сверх pending backlog получают busy response и не запускают workflow.
 Если задан `--job-store-file` или `TIMELINE_BOT_JOB_STORE_FILE`, worker сохраняет историю queued/running/done/failed/rejected/cancelled jobs; команда `/status` показывает последние jobs текущего Telegram chat.
+При включенном job store повторная доставка уже обработанного Telegram update возвращает existing queue id/job status и не запускает render второй раз.
 Если задан `--recover-stale-jobs` или `TIMELINE_BOT_RECOVER_STALE_JOBS=true`, worker перед стартом помечает сохраненные queued/running jobs как failed, чтобы после рестарта они не висели в `/status` и были доступны для `/retry`.
 Команда `/cancel <queueId>` отменяет pending queued job или running render job из текущего chat; done/failed/rejected jobs не отменяются.
 Команда `/retry <queueId>` повторно запускает failed/cancelled job из сохраненного source payload/workflow.

--- a/src/cli/commands/__tests__/bot-worker.test.ts
+++ b/src/cli/commands/__tests__/bot-worker.test.ts
@@ -138,6 +138,27 @@ describe("bot-worker command", () => {
     ).toBe(false)
   })
 
+  it("does not treat duplicate workflow update results as failed command results", () => {
+    expect(
+      isFailedWorkerResult({
+        skipped: true,
+        reason: "Telegram bot workflow already handled",
+        updateId: 1,
+        update: { update_id: 1 },
+        payload: { text: "template=promo" },
+        queueId: "telegram-update-1",
+        duplicateOf: "telegram-update-1",
+        workflowJob: {
+          id: "telegram-update-1",
+          status: "running",
+          updateId: 1,
+          createdAt: "2026-06-08T08:00:00.000Z",
+          updatedAt: "2026-06-08T08:00:00.000Z",
+        },
+      }),
+    ).toBe(false)
+  })
+
   it("treats rejected polling update results as failed command results", () => {
     expect(
       isFailedWorkerResult({


### PR DESCRIPTION
## Summary
- detect existing Telegram workflow job records before starting/queueing non-command workflow updates
- return a machine-readable already-handled skipped result with existing queue id/job status
- avoid calling workflow runners for duplicate Telegram update replays
- document replay/idempotency behavior in the bot worker runbook and roadmap

## Tests
- `bun run test -- src/adapters/node/__tests__/telegram-bot-worker.test.ts src/cli/commands/__tests__/bot-worker.test.ts`
- `bun run check:type`
- `bun run check:workspaces`
- `bun run check:boundaries:baseline`
- `bunx biome ci src/adapters/node/telegram-bot-worker.ts src/adapters/node/__tests__/telegram-bot-worker.test.ts src/cli/commands/__tests__/bot-worker.test.ts`
- `git diff --check`
- `bun run src/cli/index.ts bot-worker --update-file docs/08_tasks/planned/fixtures/telegram-help-update.json --pretty`

Closes #221
Refs #171