### PR TITLE
B27: Telegram bot access control allowlist

### DIFF
--- a/docs/08_tasks/planned/bot-first-workflow.md
+++ b/docs/08_tasks/planned/bot-first-workflow.md
@@ -297,6 +297,16 @@ bot message
 - [x] Сохранить поведение команд и explicit `/retry <queueId>`.
 - [x] Документировать replay/idempotency behavior и покрыть worker/CLI tests.
 
+### B27: Telegram bot access control allowlist ([#223](https://github.com/chatman-media/timeline-studio/issues/223))
+
+**Цель:** production bot ограничивает запуск workflows разрешенными Telegram chats/users.
+
+- [x] Добавить worker-level access policy для chat/user ids.
+- [x] Отклонять unauthorized updates до command/draft/workflow handling.
+- [x] Возвращать machine-readable access-denied result и best-effort Telegram response.
+- [x] Сохранить default open behavior без configured policy.
+- [x] Прокинуть allowlists через `bot-worker` CLI/env и документировать runbook.
+
 ## Связанные задачи
 
 - [#150](https://github.com/chatman-media/timeline-studio/issues/150) - Phase F / package boundaries
@@ -326,6 +336,7 @@ bot message
 - [#217](https://github.com/chatman-media/timeline-studio/issues/217) - B24: Telegram bot stale workflow recovery
 - [#219](https://github.com/chatman-media/timeline-studio/issues/219) - B25: Bot workflow status update throttling
 - [#221](https://github.com/chatman-media/timeline-studio/issues/221) - B26: Telegram bot idempotent workflow updates
+- [#223](https://github.com/chatman-media/timeline-studio/issues/223) - B27: Telegram bot access control allowlist
 - [telegram-mini-app.md](./telegram-mini-app.md)
 - [cloud-rendering.md](./cloud-rendering.md)
 - [export-architecture-refactoring.md](./export-architecture-refactoring.md)

--- a/src/adapters/node/__tests__/telegram-bot-worker.test.ts
+++ b/src/adapters/node/__tests__/telegram-bot-worker.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../telegram-bot-job-store"
 import {
   createTelegramLikePayloadFromUpdate,
+  defaultTelegramBotAccessDeniedText,
   defaultTelegramBotCommandText,
   defaultTelegramBotDraftText,
   defaultTelegramBotJobCancelText,
@@ -19,6 +20,7 @@ import {
   defaultTelegramBotQueueRejectedText,
   defaultTelegramBotQueueText,
   defaultTelegramBotUpdateErrorText,
+  isTelegramBotAccessAllowed,
   NodeTelegramBotApiClient,
   NodeTelegramBotFileOffsetStore,
   NodeTelegramBotInMemoryWorkflowQueue,
@@ -560,6 +562,78 @@ describe("Telegram bot worker", () => {
       },
     })
     expect(runTelegramLikePayload).not.toHaveBeenCalled()
+  })
+
+  it("denies updates outside the configured Telegram access policy", async () => {
+    const { service, runTelegramLikePayload } = createWorkflowService(completedResult)
+    const accessDeniedResponder = {
+      sendMessage: vi.fn(async () => ({ messageId: "access-denied-message-1" })),
+    }
+    const onResult = vi.fn()
+    const worker = new NodeTelegramBotWorker({
+      workflow: service,
+      accessPolicy: {
+        allowedChatIds: ["chat-2"],
+        allowedUserIds: ["user-2"],
+      },
+      accessDeniedResponder,
+      onResult,
+    })
+
+    const result = await worker.handleUpdate({
+      update_id: 45,
+      message: {
+        message_id: 31,
+        chat: { id: "chat-1" },
+        from: { id: "user-1" },
+        text: "/help",
+      },
+    })
+
+    expect(result).toMatchObject({
+      skipped: true,
+      reason: "Telegram bot access denied",
+      updateId: 45,
+      accessDenied: true,
+      responseText: defaultTelegramBotAccessDeniedText(),
+    })
+    expect(accessDeniedResponder.sendMessage).toHaveBeenCalledWith({
+      chatId: "chat-1",
+      text: defaultTelegramBotAccessDeniedText(),
+      replyToMessageId: "31",
+      metadata: {
+        accessDenied: true,
+        source: "telegram-bot-worker",
+      },
+    })
+    expect(runTelegramLikePayload).not.toHaveBeenCalled()
+    expect(onResult).toHaveBeenCalledWith(result)
+  })
+
+  it("allows updates from configured Telegram users", async () => {
+    const { service, runTelegramLikePayload } = createWorkflowService(completedResult)
+    const worker = new NodeTelegramBotWorker({
+      workflow: service,
+      accessPolicy: {
+        allowedUserIds: ["user-1"],
+      },
+    })
+
+    const result = await worker.handleUpdate({
+      update_id: 46,
+      message: {
+        message_id: 32,
+        chat: { id: "chat-1" },
+        from: { id: "user-1" },
+        text: "template=promo",
+      },
+    })
+
+    expect(result).toMatchObject({
+      skipped: false,
+      updateId: 46,
+    })
+    expect(runTelegramLikePayload).toHaveBeenCalledOnce()
   })
 
   it("routes start commands through Bot API when a bot token is configured", async () => {
@@ -1280,6 +1354,19 @@ describe("Telegram bot worker", () => {
     expect(parseTelegramBotCommand("template=promo")).toBeNull()
     expect(parseTelegramBotDraftCommand("/render@TimelineStudioBot")).toBe("render")
     expect(parseTelegramBotDraftCommand("/cancel")).toBe("cancel")
+  })
+
+  it("matches Telegram access policies by chat or user id", () => {
+    expect(isTelegramBotAccessAllowed({ chat: { id: "chat-1" } }, undefined)).toBe(true)
+    expect(isTelegramBotAccessAllowed({ chat: { id: "chat-1" } }, { allowedChatIds: ["chat-1"] })).toBe(true)
+    expect(isTelegramBotAccessAllowed({ from: { id: "user-1" } }, { allowedUserIds: ["user-1"] })).toBe(true)
+    expect(
+      isTelegramBotAccessAllowed(
+        { chat: { id: "chat-2" }, from: { id: "user-1" } },
+        { allowedChatIds: ["chat-1"], allowedUserIds: ["user-1"] },
+      ),
+    ).toBe(true)
+    expect(isTelegramBotAccessAllowed({ chat: { id: "chat-2" } }, { allowedChatIds: ["chat-1"] })).toBe(false)
   })
 
   it("stores Telegram updates as conversation drafts until render is requested", async () => {

--- a/src/adapters/node/index.ts
+++ b/src/adapters/node/index.ts
@@ -75,6 +75,7 @@ export {
 } from "./telegram-bot-job-store"
 export {
   createTelegramLikePayloadFromUpdate,
+  defaultTelegramBotAccessDeniedText,
   defaultTelegramBotCommandText,
   defaultTelegramBotDraftText,
   defaultTelegramBotJobCancelText,
@@ -83,6 +84,10 @@ export {
   defaultTelegramBotQueueRejectedText,
   defaultTelegramBotQueueText,
   defaultTelegramBotUpdateErrorText,
+  isTelegramBotAccessAllowed,
+  type NodeTelegramBotAccessDeniedFormatter,
+  type NodeTelegramBotAccessDeniedFormatterContext,
+  type NodeTelegramBotAccessPolicy,
   NodeTelegramBotApiClient,
   type NodeTelegramBotClient,
   type NodeTelegramBotCommand,

--- a/src/adapters/node/telegram-bot-worker.ts
+++ b/src/adapters/node/telegram-bot-worker.ts
@@ -77,6 +77,10 @@ export interface NodeTelegramBotWorkerOptions {
   workflow: NodeBotWorkflowService
   workflowQueue?: NodeTelegramBotWorkflowQueue
   client?: NodeTelegramBotClient
+  accessPolicy?: NodeTelegramBotAccessPolicy
+  accessDeniedResponder?: NodeTelegramStatusClient
+  accessDeniedFormatter?: NodeTelegramBotAccessDeniedFormatter
+  disableAccessDeniedResponses?: boolean
   commandResponder?: NodeTelegramStatusClient
   commandFormatter?: NodeTelegramBotCommandFormatter
   errorResponder?: NodeTelegramStatusClient
@@ -109,6 +113,11 @@ export interface NodeTelegramBotWorkerHandleOptions {
 export type NodeTelegramBotCommand = "start" | "help" | "status" | "cancel" | "retry"
 export type NodeTelegramBotDraftCommand = "render" | "cancel"
 export type NodeTelegramBotDraftAction = "updated" | "cancelled"
+
+export interface NodeTelegramBotAccessPolicy {
+  allowedChatIds?: readonly string[]
+  allowedUserIds?: readonly string[]
+}
 
 export type NodeTelegramBotWorkflowQueueStatus = "queued" | "rejected"
 
@@ -158,6 +167,14 @@ export interface NodeTelegramBotCommandFormatterContext {
 }
 
 export type NodeTelegramBotCommandFormatter = (context: NodeTelegramBotCommandFormatterContext) => string
+
+export interface NodeTelegramBotAccessDeniedFormatterContext {
+  update: TelegramBotUpdate
+  payload: TelegramLikeBotPayload
+  policy: NodeTelegramBotAccessPolicy
+}
+
+export type NodeTelegramBotAccessDeniedFormatter = (context: NodeTelegramBotAccessDeniedFormatterContext) => string
 
 export interface NodeTelegramBotUpdateErrorFormatterContext {
   updateId: number
@@ -245,6 +262,7 @@ export type NodeTelegramBotWorkerUpdateResult =
       retryOf?: string
       duplicateOf?: string
       workflowJob?: NodeTelegramBotWorkflowJobRecord
+      accessDenied?: boolean
     }
   | {
       skipped: false
@@ -521,6 +539,10 @@ export class NodeTelegramBotWorker {
       return result
     }
 
+    if (!isTelegramBotAccessAllowed(payload, this.options.accessPolicy)) {
+      return this.createAccessDeniedResult(update, payload, this.options.accessPolicy)
+    }
+
     const command = this.options.disableCommandRouting ? null : parseTelegramBotCommand(payload.text)
     if (command === "retry") {
       return this.handleRetryCommand(update, payload, options)
@@ -656,6 +678,58 @@ export class NodeTelegramBotWorker {
       ...(payload.message_id !== undefined ? { replyToMessageId: String(payload.message_id) } : {}),
       metadata: {
         command,
+        source: "telegram-bot-worker",
+      },
+    })
+  }
+
+  private async createAccessDeniedResult(
+    update: TelegramBotUpdate,
+    payload: TelegramLikeBotPayload,
+    policy: NodeTelegramBotAccessPolicy | undefined,
+  ): Promise<NodeTelegramBotWorkerUpdateResult> {
+    const responseText = this.options.disableAccessDeniedResponses
+      ? undefined
+      : (this.options.accessDeniedFormatter ?? defaultTelegramBotAccessDeniedText)({
+          update,
+          payload,
+          policy: policy ?? {},
+        })
+    let responseError: string | undefined
+
+    if (responseText) {
+      try {
+        await this.sendAccessDeniedResponse(payload, responseText)
+      } catch (error) {
+        responseError = formatUnknownError(error)
+      }
+    }
+
+    const result: NodeTelegramBotWorkerUpdateResult = {
+      skipped: true,
+      reason: "Telegram bot access denied",
+      updateId: update.update_id,
+      update,
+      payload,
+      accessDenied: true,
+      ...(responseText ? { responseText } : {}),
+      ...(responseError ? { responseError } : {}),
+    }
+    await this.options.onResult?.(result)
+    return result
+  }
+
+  private async sendAccessDeniedResponse(payload: TelegramLikeBotPayload, text: string): Promise<void> {
+    const chatId = payload.chat?.id === undefined ? undefined : String(payload.chat.id)
+    if (!chatId) return
+
+    const responder = this.resolveAccessDeniedResponder()
+    await responder?.sendMessage({
+      chatId,
+      text,
+      ...(payload.message_id !== undefined ? { replyToMessageId: String(payload.message_id) } : {}),
+      metadata: {
+        accessDenied: true,
         source: "telegram-bot-worker",
       },
     })
@@ -1432,6 +1506,17 @@ export class NodeTelegramBotWorker {
     })
   }
 
+  private resolveAccessDeniedResponder(): NodeTelegramStatusClient | undefined {
+    if (this.options.accessDeniedResponder) return this.options.accessDeniedResponder
+    if (!this.options.botToken) return undefined
+    return new NodeBotStatusNotifier({
+      telegram: {
+        botToken: this.options.botToken,
+      },
+      fetch: this.options.fetch,
+    })
+  }
+
   private resolveDraftResponder(): NodeTelegramStatusClient | undefined {
     if (this.options.draftResponder) return this.options.draftResponder
     if (!this.options.botToken) return undefined
@@ -1486,6 +1571,22 @@ export function createTelegramLikePayloadFromUpdate(update: TelegramBotUpdate): 
     ...(message.animation ? { animation: telegramFile(message.animation) } : {}),
     ...(message.photo ? { photo: message.photo.map(telegramFile) } : {}),
   }
+}
+
+export function isTelegramBotAccessAllowed(
+  payload: TelegramLikeBotPayload,
+  policy: NodeTelegramBotAccessPolicy | undefined,
+): boolean {
+  if (!policy) return true
+
+  const allowedChatIds = new Set((policy.allowedChatIds ?? []).map(String))
+  const allowedUserIds = new Set((policy.allowedUserIds ?? []).map(String))
+  if (allowedChatIds.size === 0 && allowedUserIds.size === 0) return true
+
+  const chatId = payload.chat?.id === undefined ? undefined : String(payload.chat.id)
+  const userId = payload.from?.id === undefined ? undefined : String(payload.from.id)
+
+  return Boolean((chatId && allowedChatIds.has(chatId)) || (userId && allowedUserIds.has(userId)))
 }
 
 function telegramFile(file: TelegramBotFile): TelegramLikeBotFile {
@@ -1559,6 +1660,10 @@ export function defaultTelegramBotCommandText(): string {
     "Options: template, project, media/url/input/source, destination, output, resolution.",
     "Commands: /status, /render, /cancel, /cancel <queueId>, /retry <queueId>.",
   ].join("\n")
+}
+
+export function defaultTelegramBotAccessDeniedText(): string {
+  return ["Timeline Studio bot", "This bot is not enabled for this Telegram chat or user."].join("\n")
 }
 
 export function defaultTelegramBotJobStatusText(context: NodeTelegramBotJobStatusFormatterContext): string {

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -127,6 +127,7 @@ bun run src/cli/index.ts bot-worker --poll-once --pretty
 
 # Долгоживущий polling worker с сохранением offset
 TIMELINE_BOT_TELEGRAM_TOKEN=123:token \
+TIMELINE_BOT_ALLOWED_CHAT_IDS=123456789,-1001234567890 \
 TIMELINE_BOT_OFFSET_FILE=.tmp/timeline-bot/offset.json \
 TIMELINE_BOT_DRAFT_DIR=.tmp/timeline-bot/drafts \
 TIMELINE_BOT_JOB_STORE_FILE=.tmp/timeline-bot/jobs.json \
@@ -140,6 +141,7 @@ TIMELINE_BOT_MEDIA_DIR=.tmp/timeline-bot/media \
 bun run src/cli/index.ts bot-worker --poll --rust-render
 ```
 
+Для production задавайте `--allowed-chat-ids` и/или `--allowed-user-ids`, чтобы render workflows могли запускать только разрешенные Telegram chats/users.
 Если задан `--draft-dir` или `TIMELINE_BOT_DRAFT_DIR`, worker включает conversation draft mode:
 обычные сообщения сохраняют media и render hints, `/render` запускает merged workflow, а `/cancel` очищает draft.
 В тексте сообщения можно отправлять bare URL и короткие hints, например `https://cdn.example.com/input.mov 1080p telegram`;
@@ -161,6 +163,8 @@ bun run src/cli/index.ts bot-worker --poll --rust-render
 | `--poll-once` | Получить и обработать один `getUpdates` batch |
 | `--poll` | Запустить continuous polling loop |
 | `--offset-file <path>` | Сохранять Telegram offset между рестартами |
+| `--allowed-chat-ids <ids>` | Comma/space separated Telegram chat ids, которым разрешен bot |
+| `--allowed-user-ids <ids>` | Comma/space separated Telegram user ids, которым разрешен bot |
 | `--draft-dir <path>` | Сохранять bot conversation drafts между сообщениями и рестартами |
 | `--job-store-file <path>` | Сохранять workflow job status/history для `/status` |
 | `--recover-stale-jobs` | Помечать сохраненные queued/running jobs как failed перед стартом worker |
@@ -185,6 +189,8 @@ export FFMPEG_PATH=/usr/local/bin/ffmpeg
 
 # Bot worker runtime defaults
 export TIMELINE_BOT_TELEGRAM_TOKEN=123:token
+export TIMELINE_BOT_ALLOWED_CHAT_IDS=123456789,-1001234567890
+export TIMELINE_BOT_ALLOWED_USER_IDS=111111111,222222222
 export TIMELINE_BOT_OFFSET_FILE=.tmp/timeline-bot/offset.json
 export TIMELINE_BOT_DRAFT_DIR=.tmp/timeline-bot/drafts
 export TIMELINE_BOT_JOB_STORE_FILE=.tmp/timeline-bot/jobs.json

--- a/src/cli/commands/__tests__/bot-worker.test.ts
+++ b/src/cli/commands/__tests__/bot-worker.test.ts
@@ -33,6 +33,8 @@ describe("bot-worker command", () => {
     expect(botWorkerCommand.options.some((option) => option.long === "--poll-once")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--poll")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--telegram-bot-token")).toBe(true)
+    expect(botWorkerCommand.options.some((option) => option.long === "--allowed-chat-ids")).toBe(true)
+    expect(botWorkerCommand.options.some((option) => option.long === "--allowed-user-ids")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--no-status-updates")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--status-chat-id")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--status-min-interval")).toBe(true)
@@ -215,6 +217,8 @@ describe("bot-worker command", () => {
       {
         TELEGRAM_BOT_TOKEN: "token-from-telegram-env",
         TIMELINE_BOT_TELEGRAM_TOKEN: "token-from-timeline-env",
+        TIMELINE_BOT_ALLOWED_CHAT_IDS: "chat-1,chat-2",
+        TIMELINE_BOT_ALLOWED_USER_IDS: "user-1 user-2",
         TIMELINE_BOT_STATUS_CHAT_ID: "chat-1",
         TIMELINE_BOT_STATUS_MIN_INTERVAL: "30000",
         TIMELINE_BOT_STATUS_MIN_PROGRESS_DELTA: "10",
@@ -243,6 +247,8 @@ describe("bot-worker command", () => {
 
     expect(resolved).toMatchObject({
       telegramBotToken: "token-from-timeline-env",
+      allowedChatIds: "chat-1,chat-2",
+      allowedUserIds: "user-1 user-2",
       statusChatId: "chat-1",
       statusMinInterval: "30000",
       statusMinProgressDelta: "10",
@@ -273,6 +279,8 @@ describe("bot-worker command", () => {
     const resolved = resolveBotWorkerCommandOptions(
       {
         telegramBotToken: "token-from-cli",
+        allowedChatIds: "cli-chat",
+        allowedUserIds: "cli-user",
         statusMinInterval: "15000",
         statusMinProgressDelta: "5",
         offsetFile: ".tmp/cli-offset.json",
@@ -288,6 +296,8 @@ describe("bot-worker command", () => {
       },
       {
         TIMELINE_BOT_TELEGRAM_TOKEN: "token-from-env",
+        TIMELINE_BOT_ALLOWED_CHAT_IDS: "env-chat",
+        TIMELINE_BOT_ALLOWED_USER_IDS: "env-user",
         TIMELINE_BOT_STATUS_MIN_INTERVAL: "30000",
         TIMELINE_BOT_STATUS_MIN_PROGRESS_DELTA: "10",
         TIMELINE_BOT_OFFSET_FILE: ".tmp/env-offset.json",
@@ -305,6 +315,8 @@ describe("bot-worker command", () => {
 
     expect(resolved).toMatchObject({
       telegramBotToken: "token-from-cli",
+      allowedChatIds: "cli-chat",
+      allowedUserIds: "cli-user",
       statusMinInterval: "15000",
       statusMinProgressDelta: "5",
       offsetFile: ".tmp/cli-offset.json",

--- a/src/cli/commands/bot-worker.ts
+++ b/src/cli/commands/bot-worker.ts
@@ -17,6 +17,7 @@ import type {
 import {
   initNodeApp,
   NodeBotWorkflowFileDraftStore,
+  type NodeTelegramBotAccessPolicy,
   NodeTelegramBotFileOffsetStore,
   NodeTelegramBotFileWorkflowJobStore,
   NodeTelegramBotInMemoryWorkflowQueue,
@@ -38,6 +39,8 @@ export interface BotWorkerCommandOptions {
   statusFile?: string
   pretty?: boolean
   telegramBotToken?: string
+  allowedChatIds?: string
+  allowedUserIds?: string
   statusUpdates?: boolean
   statusChatId?: string
   statusMinInterval?: string
@@ -78,6 +81,8 @@ export const botWorkerCommand = new Command("bot-worker")
   .option("--status-file <path>", "Write worker result JSON to a file")
   .option("--pretty", "Pretty-print JSON output")
   .option("--telegram-bot-token <token>", "Telegram Bot API token for polling, media, status, and publishing")
+  .option("--allowed-chat-ids <ids>", "Comma/space separated Telegram chat ids allowed to use the bot")
+  .option("--allowed-user-ids <ids>", "Comma/space separated Telegram user ids allowed to use the bot")
   .option("--no-status-updates", "Disable Telegram workflow status messages")
   .option("--status-chat-id <id>", "Fallback Telegram chat id for status updates and publishing")
   .option("--status-min-interval <ms>", "Minimum interval between repeated rendering status messages")
@@ -169,6 +174,7 @@ export async function runBotWorker(options: BotWorkerCommandOptions = {}): Promi
   const worker = new NodeTelegramBotWorker({
     workflow: services.botWorkflow,
     workflowQueue,
+    accessPolicy: createTelegramBotAccessPolicy(resolvedOptions),
     botToken: resolvedOptions.telegramBotToken,
     workflowOptions: {
       intake: {
@@ -229,6 +235,8 @@ export function resolveBotWorkerCommandOptions(
       env.TIMELINE_BOT_TELEGRAM_TOKEN,
       env.TELEGRAM_BOT_TOKEN,
     ),
+    allowedChatIds: firstConfigured(options.allowedChatIds, env.TIMELINE_BOT_ALLOWED_CHAT_IDS),
+    allowedUserIds: firstConfigured(options.allowedUserIds, env.TIMELINE_BOT_ALLOWED_USER_IDS),
     statusChatId: firstConfigured(options.statusChatId, env.TIMELINE_BOT_STATUS_CHAT_ID),
     statusMinInterval: firstConfigured(options.statusMinInterval, env.TIMELINE_BOT_STATUS_MIN_INTERVAL),
     statusMinProgressDelta: firstConfigured(options.statusMinProgressDelta, env.TIMELINE_BOT_STATUS_MIN_PROGRESS_DELTA),
@@ -307,6 +315,17 @@ function createBotStatusOptions(options: BotWorkerCommandOptions) {
       botToken: options.telegramBotToken,
       ...(options.statusChatId ? { defaultChatId: options.statusChatId } : {}),
     },
+  }
+}
+
+function createTelegramBotAccessPolicy(options: BotWorkerCommandOptions): NodeTelegramBotAccessPolicy | undefined {
+  const allowedChatIds = parseIdList(options.allowedChatIds)
+  const allowedUserIds = parseIdList(options.allowedUserIds)
+
+  if (allowedChatIds.length === 0 && allowedUserIds.length === 0) return undefined
+  return {
+    ...(allowedChatIds.length > 0 ? { allowedChatIds } : {}),
+    ...(allowedUserIds.length > 0 ? { allowedUserIds } : {}),
   }
 }
 
@@ -408,6 +427,14 @@ function parseOptionalNonNegativeNumber(value: string | undefined): number | und
   if (!value) return undefined
   const parsed = Number.parseFloat(value)
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined
+}
+
+function parseIdList(value: string | undefined): string[] {
+  if (!value) return []
+  return value
+    .split(/[,\s]+/)
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0)
 }
 
 function firstConfigured<T extends string>(...values: Array<T | undefined>): T | undefined {


### PR DESCRIPTION
## Summary
- add opt-in Telegram access policy support for allowed chat/user ids
- deny unauthorized updates before command/draft/workflow handling with machine-readable access-denied results
- send concise best-effort Telegram access-denied responses
- wire allowlists through `bot-worker` CLI flags and `TIMELINE_BOT_ALLOWED_*` env defaults
- document production access control and mark B27 in the bot-first roadmap

## Tests
- `bun run test -- src/adapters/node/__tests__/telegram-bot-worker.test.ts src/cli/commands/__tests__/bot-worker.test.ts`
- `bun run check:type`
- `bun run check:workspaces`
- `bun run check:boundaries:baseline`
- `bunx biome ci src/adapters/node/telegram-bot-worker.ts src/adapters/node/index.ts src/adapters/node/__tests__/telegram-bot-worker.test.ts src/cli/commands/bot-worker.ts src/cli/commands/__tests__/bot-worker.test.ts`
- `git diff --check`
- `bun run src/cli/index.ts bot-worker --update-file docs/08_tasks/planned/fixtures/telegram-help-update.json --pretty`

Closes #223
Refs #171