### PR TITLE
feat: add production AI project editor adapter

### DIFF
--- a/src/adapters/node/__tests__/ai-project-editor.test.ts
+++ b/src/adapters/node/__tests__/ai-project-editor.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it, vi } from "vitest"
+import { createBotProjectSchemaFromRenderJob, runAIProjectEdit } from "@/core"
+import { createNodeServices, NodeAIProjectEditor, type NodeAIProjectEditorFetch } from "../index"
+
+describe("NodeAIProjectEditor", () => {
+  it("calls an OpenAI-compatible chat endpoint and returns a valid edit result", async () => {
+    const project = createProject()
+    const nextProject = {
+      ...project,
+      metadata: {
+        ...project.metadata,
+        modified_at: "2026-06-09T10:00:00.000Z",
+      },
+    }
+    const fetch = createFetch({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify({
+              nextProject,
+              summary: "Trimmed the intro and kept the rest of the timeline.",
+              changedAreas: ["tracks.0.clips.0"],
+              commands: [
+                {
+                  type: "trim_clip",
+                  targetId: "clip-0",
+                  params: { source_start: 1.5 },
+                  rationale: "User asked to make the intro shorter.",
+                },
+              ],
+              diagnostics: [{ level: "info", message: "Edit applied.", code: "edit_applied" }],
+              metadata: { changedClipCount: 1 },
+            }),
+          },
+          finish_reason: "stop",
+        },
+      ],
+      usage: { prompt_tokens: 10, completion_tokens: 20 },
+    })
+    const editor = new NodeAIProjectEditor({
+      apiKey: "test-key",
+      apiUrl: "https://llm.example/v1/",
+      provider: "test-provider",
+      model: "editor-model",
+      fetch,
+    })
+
+    const result = await runAIProjectEdit(editor, {
+      currentProject: project,
+      sourceMedia: [{ type: "file", value: "/tmp/input.mp4", name: "input.mp4" }],
+      userInstruction: "trim the intro",
+      targetPlatform: "telegram",
+      revisionHistory: [
+        {
+          id: "revision-0",
+          index: 0,
+          instruction: "first cut",
+          summary: "Initial preview",
+          createdAt: "2026-06-09T09:00:00.000Z",
+        },
+      ],
+      metadata: {
+        sessionId: "edit:telegram:chat-1:user-1",
+        currentArtifact: { path: "/tmp/preview.mp4" },
+      },
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      attempts: 1,
+      result: {
+        summary: "Trimmed the intro and kept the rest of the timeline.",
+        changedAreas: ["tracks.0.clips.0"],
+        commands: [expect.objectContaining({ type: "trim_clip", targetId: "clip-0" })],
+        diagnostics: [expect.objectContaining({ level: "info", code: "edit_applied" })],
+        metadata: expect.objectContaining({
+          provider: "test-provider",
+          model: "editor-model",
+          promptId: "ai-project-editor/v1",
+          changedClipCount: 1,
+          usage: { prompt_tokens: 10, completion_tokens: 20 },
+        }),
+      },
+    })
+    expect(fetch).toHaveBeenCalledWith(
+      "https://llm.example/v1/chat/completions",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-key",
+          "Content-Type": "application/json",
+        }),
+      }),
+    )
+    const body = JSON.parse(String(vi.mocked(fetch).mock.calls[0]?.[1]?.body))
+    expect(body).toMatchObject({
+      model: "editor-model",
+      response_format: { type: "json_object" },
+    })
+    expect(body.messages[1].content).toContain("trim the intro")
+    expect(body.messages[1].content).toContain("revision-0")
+    expect(body.messages[1].content).toContain("currentArtifact")
+  })
+
+  it("returns an actionable no-op result when API key config is missing", async () => {
+    const project = createProject()
+    const fetch = createFetch({})
+    const editor = new NodeAIProjectEditor({ fetch, now: () => "2026-06-09T11:00:00.000Z" })
+
+    const result = await runAIProjectEdit(editor, {
+      currentProject: project,
+      sourceMedia: [{ type: "file", value: "/tmp/input.mp4" }],
+      userInstruction: "add captions",
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      result: {
+        nextProject: project,
+        summary: "No AI edit was applied; the current project was preserved.",
+        commands: [expect.objectContaining({ type: "custom" })],
+        diagnostics: [expect.objectContaining({ level: "error", code: "missing_api_key" })],
+        metadata: expect.objectContaining({ noop: true, generatedAt: "2026-06-09T11:00:00.000Z" }),
+      },
+    })
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it("returns an actionable no-op result when provider HTTP fails", async () => {
+    const project = createProject()
+    const fetch = vi.fn(async () => new Response("bad gateway", { status: 502, statusText: "Bad Gateway" }))
+    const editor = new NodeAIProjectEditor({ apiKey: "test-key", fetch })
+
+    const result = await runAIProjectEdit(editor, {
+      currentProject: project,
+      sourceMedia: [{ type: "file", value: "/tmp/input.mp4" }],
+      userInstruction: "make it shorter",
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      result: {
+        nextProject: project,
+        diagnostics: [
+          expect.objectContaining({
+            level: "error",
+            code: "provider_http_error",
+            message: expect.stringContaining("HTTP 502"),
+          }),
+        ],
+      },
+    })
+  })
+
+  it("keeps the current project when provider output is invalid", async () => {
+    const project = createProject()
+    const fetch = createFetch({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify({
+              nextProject: { tracks: [] },
+              summary: "",
+              commands: [],
+              diagnostics: [],
+            }),
+          },
+        },
+      ],
+    })
+    const editor = new NodeAIProjectEditor({ apiKey: "test-key", fetch })
+
+    const result = await runAIProjectEdit(editor, {
+      currentProject: project,
+      sourceMedia: [{ type: "file", value: "/tmp/input.mp4" }],
+      userInstruction: "add title",
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      result: {
+        nextProject: project,
+        diagnostics: [expect.objectContaining({ level: "error", code: "provider_invalid_output" })],
+      },
+    })
+  })
+
+  it("keeps the current project when provider returns invalid JSON", async () => {
+    const project = createProject()
+    const fetch = createFetch({
+      choices: [
+        {
+          message: {
+            content: "not json",
+          },
+        },
+      ],
+    })
+    const editor = new NodeAIProjectEditor({ apiKey: "test-key", fetch })
+
+    const result = await runAIProjectEdit(editor, {
+      currentProject: project,
+      sourceMedia: [{ type: "file", value: "/tmp/input.mp4" }],
+      userInstruction: "add title",
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      result: {
+        nextProject: project,
+        diagnostics: [expect.objectContaining({ level: "error", code: "provider_invalid_json" })],
+      },
+    })
+  })
+
+  it("creates the adapter through node service factories", () => {
+    const services = createNodeServices({
+      autoConnect: false,
+      aiProjectEditor: {
+        apiKey: "test-key",
+        fetch: createFetch({}),
+      },
+    })
+
+    expect(services.aiProjectEditor).toBeInstanceOf(NodeAIProjectEditor)
+  })
+})
+
+function createFetch(payload: unknown): NodeAIProjectEditorFetch {
+  return vi.fn(
+    async () =>
+      new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+  ) as NodeAIProjectEditorFetch
+}
+
+function createProject() {
+  const project = createBotProjectSchemaFromRenderJob({
+    source: "bot",
+    media: [{ type: "file", value: "/tmp/input.mp4", name: "input.mp4" }],
+    output: { format: "mp4", destination: "telegram" },
+  })
+  if (!project) throw new Error("Expected project")
+  return project
+}

--- a/src/adapters/node/ai-project-editor.ts
+++ b/src/adapters/node/ai-project-editor.ts
@@ -1,0 +1,463 @@
+import {
+  type AIProjectEditCommand,
+  type AIProjectEditDiagnostic,
+  type AIProjectEditorRequest,
+  type AIProjectEditorResult,
+  type AIProjectEditRepairContext,
+  cloneProjectSchema,
+  type IAIProjectEditor,
+  validateAIProjectEditResult,
+} from "@/core"
+import type { ProjectSchema } from "@/types/contracts/project-schema"
+
+export type NodeAIProjectEditorFetch = typeof fetch
+
+export interface NodeAIProjectEditorOptions {
+  apiKey?: string
+  apiUrl?: string
+  provider?: string
+  model?: string
+  temperature?: number
+  maxTokens?: number
+  timeoutMs?: number
+  headers?: Record<string, string>
+  responseFormat?: "json_object" | false
+  fetch?: NodeAIProjectEditorFetch
+  now?: () => string
+  promptId?: string
+  maxProjectChars?: number
+}
+
+interface ChatCompletionResponse {
+  choices?: Array<{
+    message?: {
+      content?: string | null
+    }
+    finish_reason?: string | null
+  }>
+  usage?: unknown
+}
+
+interface EditGenerationContext {
+  repair?: AIProjectEditRepairContext
+}
+
+const DEFAULT_API_URL = "https://api.openai.com/v1"
+const DEFAULT_MODEL = "gpt-4o-mini"
+const DEFAULT_PROVIDER = "openai-compatible"
+const DEFAULT_PROMPT_ID = "ai-project-editor/v1"
+const DEFAULT_MAX_PROJECT_CHARS = 60_000
+
+export class NodeAIProjectEditor implements IAIProjectEditor {
+  private readonly apiUrl: string
+  private readonly provider: string
+  private readonly model: string
+  private readonly promptId: string
+
+  constructor(private readonly options: NodeAIProjectEditorOptions = {}) {
+    this.apiUrl = trimTrailingSlash(options.apiUrl ?? DEFAULT_API_URL)
+    this.provider = options.provider ?? DEFAULT_PROVIDER
+    this.model = options.model ?? DEFAULT_MODEL
+    this.promptId = options.promptId ?? DEFAULT_PROMPT_ID
+  }
+
+  async editProject(request: AIProjectEditorRequest): Promise<AIProjectEditorResult> {
+    return this.generateEdit(request)
+  }
+
+  async repairProjectEdit(context: AIProjectEditRepairContext): Promise<AIProjectEditorResult> {
+    return this.generateEdit(context.request, { repair: context })
+  }
+
+  private async generateEdit(
+    request: AIProjectEditorRequest,
+    context: EditGenerationContext = {},
+  ): Promise<AIProjectEditorResult> {
+    const apiKey = this.resolveApiKey()
+    if (!apiKey) {
+      return this.createNoopResult(request, {
+        level: "error",
+        code: "missing_api_key",
+        message: "AI project editor is not configured: API key is missing.",
+      })
+    }
+
+    const fetchImpl = this.options.fetch ?? globalThis.fetch
+    if (!fetchImpl) {
+      return this.createNoopResult(request, {
+        level: "error",
+        code: "missing_fetch",
+        message: "AI project editor cannot run because fetch is not available in this runtime.",
+      })
+    }
+
+    try {
+      const response = await this.callProvider(fetchImpl, apiKey, request, context)
+      if (!response.ok) {
+        const body = await safeReadResponseText(response)
+        return this.createNoopResult(request, {
+          level: "error",
+          code: "provider_http_error",
+          message: `AI project editor provider returned HTTP ${response.status}: ${truncateText(body || response.statusText, 500)}`,
+        })
+      }
+
+      const raw = (await response.json()) as ChatCompletionResponse
+      const content = raw.choices?.[0]?.message?.content?.trim()
+      if (!content) {
+        return this.createNoopResult(request, {
+          level: "error",
+          code: "provider_empty_response",
+          message: "AI project editor provider returned an empty response.",
+        })
+      }
+
+      let parsed: unknown
+      try {
+        parsed = parseJsonObject(content)
+      } catch (error) {
+        return this.createNoopResult(request, {
+          level: "error",
+          code: "provider_invalid_json",
+          message: `AI project editor provider returned invalid JSON: ${formatUnknownError(error)}`,
+        })
+      }
+
+      let normalized: AIProjectEditorResult
+      try {
+        normalized = this.normalizeProviderResult(request, parsed, {
+          finishReason: raw.choices?.[0]?.finish_reason ?? null,
+          usage: raw.usage ?? null,
+          repairAttempt: context.repair?.attempt ?? null,
+        })
+      } catch (error) {
+        return this.createNoopResult(request, {
+          level: "error",
+          code: "provider_invalid_output",
+          message: `AI project editor provider returned invalid output: ${formatUnknownError(error)}`,
+        })
+      }
+
+      const validationErrors = validateAIProjectEditResult(request, normalized)
+      if (validationErrors.length > 0) {
+        return this.createNoopResult(request, {
+          level: "error",
+          code: "provider_invalid_output",
+          message: `AI project editor provider returned invalid output: ${validationErrors
+            .map((error) => `${error.field}: ${error.message}`)
+            .join("; ")}`,
+        })
+      }
+
+      return normalized
+    } catch (error) {
+      return this.createNoopResult(request, {
+        level: "error",
+        code: "provider_request_failed",
+        message: `AI project editor provider request failed: ${formatUnknownError(error)}`,
+      })
+    }
+  }
+
+  private async callProvider(
+    fetchImpl: NodeAIProjectEditorFetch,
+    apiKey: string,
+    request: AIProjectEditorRequest,
+    context: EditGenerationContext,
+  ): Promise<Response> {
+    const controller = this.options.timeoutMs ? new AbortController() : undefined
+    const timeout =
+      controller && this.options.timeoutMs
+        ? setTimeout(() => controller.abort(), Math.max(1, this.options.timeoutMs))
+        : undefined
+
+    try {
+      return await fetchImpl(`${this.apiUrl}/chat/completions`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+          ...(this.options.headers ?? {}),
+        },
+        body: JSON.stringify(this.createProviderRequest(request, context)),
+        ...(controller ? { signal: controller.signal } : {}),
+      })
+    } finally {
+      if (timeout) clearTimeout(timeout)
+    }
+  }
+
+  private createProviderRequest(
+    request: AIProjectEditorRequest,
+    context: EditGenerationContext,
+  ): Record<string, unknown> {
+    const body: Record<string, unknown> = {
+      model: this.model,
+      temperature: this.options.temperature ?? 0.2,
+      max_tokens: this.options.maxTokens ?? 4096,
+      messages: [
+        {
+          role: "system",
+          content: this.systemPrompt(),
+        },
+        {
+          role: "user",
+          content: this.userPrompt(request, context),
+        },
+      ],
+    }
+
+    if (this.options.responseFormat !== false) {
+      body.response_format = { type: this.options.responseFormat ?? "json_object" }
+    }
+
+    return body
+  }
+
+  private systemPrompt(): string {
+    return [
+      "You are Timeline Studio's production AI project editor.",
+      "Return only one JSON object. Do not use markdown.",
+      "The JSON object must match this TypeScript shape:",
+      "{",
+      '  "nextProject": ProjectSchema,',
+      '  "summary": "short user-facing summary",',
+      '  "changedAreas": ["project path or area"],',
+      '  "commands": [{"type": "trim_clip|remove_clip|move_clip|reorder_clips|set_clip_speed|set_clip_volume|add_subtitle|update_subtitle|remove_subtitle|set_project_metadata|set_timeline_duration|custom", "targetId": "...", "trackId": "...", "params": {}, "rationale": "..."}],',
+      '  "diagnostics": [{"level": "info|warning|error", "message": "...", "code": "...", "path": "..."}],',
+      '  "metadata": {"optional": "machine-readable metadata"}',
+      "}",
+      "Rules:",
+      "- Preserve ProjectSchema validity and all unrelated project data.",
+      "- Use only source media paths/URLs provided by the request.",
+      "- Do not invent rendered artifacts or publishing success.",
+      "- If the instruction cannot be fully applied, return the safest valid nextProject and add warning diagnostics.",
+      "- Include at least one machine-readable command that describes the edit.",
+    ].join("\n")
+  }
+
+  private userPrompt(request: AIProjectEditorRequest, context: EditGenerationContext): string {
+    const project = stringifyForPrompt(
+      request.currentProject,
+      this.options.maxProjectChars ?? DEFAULT_MAX_PROJECT_CHARS,
+    )
+    const payload = {
+      promptId: this.promptId,
+      provider: this.provider,
+      model: this.model,
+      instruction: request.userInstruction,
+      targetPlatform: request.targetPlatform ?? null,
+      sourceMedia: request.sourceMedia.map((media) => ({
+        type: media.type,
+        value: media.value,
+        name: media.name ?? null,
+        metadata: media.metadata ?? null,
+      })),
+      revisionHistory: request.revisionHistory ?? [],
+      constraints: request.constraints ?? {},
+      artifactMetadata: request.metadata ?? {},
+      repair: context.repair
+        ? {
+            attempt: context.repair.attempt,
+            validationErrors: context.repair.errors,
+            previousResult: context.repair.result,
+          }
+        : null,
+    }
+
+    return [
+      "Apply this user instruction to the current Timeline Studio ProjectSchema.",
+      "",
+      "Request context:",
+      JSON.stringify(payload, null, 2),
+      "",
+      "Current ProjectSchema JSON:",
+      project,
+    ].join("\n")
+  }
+
+  private normalizeProviderResult(
+    request: AIProjectEditorRequest,
+    value: unknown,
+    metadata: Record<string, unknown>,
+  ): AIProjectEditorResult {
+    if (!isRecord(value)) {
+      throw new Error("AI project editor JSON response must be an object")
+    }
+
+    const nextProject = resolveNextProject(value)
+    const commands = normalizeCommands(value.commands)
+
+    return {
+      nextProject,
+      summary: stringField(value, "summary") ?? "Applied requested edit.",
+      changedAreas: stringArrayField(value, "changedAreas"),
+      commands:
+        commands.length > 0
+          ? commands
+          : [
+              {
+                type: "custom",
+                params: { instruction: request.userInstruction },
+                rationale: "AI provider omitted command details.",
+              },
+            ],
+      diagnostics: normalizeDiagnostics(value.diagnostics),
+      metadata: {
+        provider: this.provider,
+        model: this.model,
+        promptId: this.promptId,
+        ...metadata,
+        ...(isRecord(value.metadata) ? value.metadata : {}),
+      },
+    }
+  }
+
+  private createNoopResult(
+    request: AIProjectEditorRequest,
+    diagnostic: AIProjectEditDiagnostic,
+  ): AIProjectEditorResult {
+    const nextProject = cloneProjectSchema(request.currentProject)
+    return {
+      nextProject,
+      summary: "No AI edit was applied; the current project was preserved.",
+      changedAreas: [],
+      commands: [
+        {
+          type: "custom",
+          params: {
+            instruction: request.userInstruction,
+            noop: true,
+          },
+          rationale: "AI project editor could not safely apply the requested edit.",
+        },
+      ],
+      diagnostics: [diagnostic],
+      metadata: {
+        provider: this.provider,
+        model: this.model,
+        promptId: this.promptId,
+        noop: true,
+        generatedAt: this.options.now?.() ?? new Date().toISOString(),
+      },
+    }
+  }
+
+  private resolveApiKey(): string | undefined {
+    return this.options.apiKey ?? process.env.OPENAI_API_KEY ?? process.env.LLM_API_KEY
+  }
+}
+
+function resolveNextProject(value: Record<string, unknown>): ProjectSchema {
+  if (isRecord(value.nextProject)) return value.nextProject as unknown as ProjectSchema
+  if (isRecord(value.project)) return value.project as unknown as ProjectSchema
+  if (isRecord(value.next_project)) return value.next_project as unknown as ProjectSchema
+  if ("version" in value && "timeline" in value && "tracks" in value) return value as unknown as ProjectSchema
+  throw new Error("AI project editor JSON response is missing nextProject")
+}
+
+function normalizeCommands(value: unknown): AIProjectEditCommand[] {
+  if (!Array.isArray(value)) return []
+
+  return value.filter(isRecord).map((command) => ({
+    type: normalizeCommandType(command.type),
+    ...(typeof command.targetId === "string" ? { targetId: command.targetId } : {}),
+    ...(typeof command.trackId === "string" ? { trackId: command.trackId } : {}),
+    ...(isRecord(command.params) ? { params: command.params } : {}),
+    ...(typeof command.rationale === "string" ? { rationale: command.rationale } : {}),
+  }))
+}
+
+function normalizeCommandType(value: unknown): AIProjectEditCommand["type"] {
+  if (
+    value === "trim_clip" ||
+    value === "remove_clip" ||
+    value === "move_clip" ||
+    value === "reorder_clips" ||
+    value === "set_clip_speed" ||
+    value === "set_clip_volume" ||
+    value === "add_subtitle" ||
+    value === "update_subtitle" ||
+    value === "remove_subtitle" ||
+    value === "set_project_metadata" ||
+    value === "set_timeline_duration"
+  ) {
+    return value
+  }
+
+  return "custom"
+}
+
+function normalizeDiagnostics(value: unknown): AIProjectEditDiagnostic[] {
+  if (!Array.isArray(value)) return []
+
+  return value.filter(isRecord).map((diagnostic) => ({
+    level: normalizeDiagnosticLevel(diagnostic.level),
+    message: typeof diagnostic.message === "string" ? diagnostic.message : "AI project editor diagnostic",
+    ...(typeof diagnostic.code === "string" ? { code: diagnostic.code } : {}),
+    ...(typeof diagnostic.path === "string" ? { path: diagnostic.path } : {}),
+  }))
+}
+
+function normalizeDiagnosticLevel(value: unknown): AIProjectEditDiagnostic["level"] {
+  return value === "warning" || value === "error" || value === "info" ? value : "info"
+}
+
+function parseJsonObject(content: string): unknown {
+  const trimmed = content.trim()
+  const fenced = extractFencedJson(trimmed)
+  const raw = fenced ?? extractBracedJson(trimmed) ?? trimmed
+  return JSON.parse(raw)
+}
+
+function extractFencedJson(value: string): string | undefined {
+  const match = value.match(/```(?:json)?\s*([\s\S]*?)```/)
+  return match?.[1]?.trim()
+}
+
+function extractBracedJson(value: string): string | undefined {
+  const start = value.indexOf("{")
+  const end = value.lastIndexOf("}")
+  if (start === -1 || end === -1 || end <= start) return undefined
+  return value.slice(start, end + 1)
+}
+
+function stringifyForPrompt(value: unknown, maxChars: number): string {
+  const text = JSON.stringify(value, null, 2)
+  if (text.length <= maxChars) return text
+  return `${text.slice(0, maxChars)}\n... truncated ${text.length - maxChars} chars`
+}
+
+function stringField(value: Record<string, unknown>, key: string): string | undefined {
+  const field = value[key]
+  return typeof field === "string" ? field : undefined
+}
+
+function stringArrayField(value: Record<string, unknown>, key: string): string[] {
+  const field = value[key]
+  return Array.isArray(field) ? field.filter((item): item is string => typeof item === "string") : []
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "")
+}
+
+async function safeReadResponseText(response: Response): Promise<string> {
+  try {
+    return await response.text()
+  } catch {
+    return ""
+  }
+}
+
+function truncateText(value: string, maxLength: number): string {
+  return value.length > maxLength ? `${value.slice(0, maxLength)}...` : value
+}
+
+function formatUnknownError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/src/adapters/node/index.ts
+++ b/src/adapters/node/index.ts
@@ -9,6 +9,7 @@ import { type BotFirstCutGeneratorOptions, DefaultBotFirstCutGenerator } from "@
 import { container } from "@/core/container"
 
 import { type NodeAIOptions, NodeAIService } from "./ai"
+import { NodeAIProjectEditor, type NodeAIProjectEditorOptions } from "./ai-project-editor"
 import { type NodeBackendOptions, NodeBackendService } from "./backend"
 import { NodeBotEditSessionFileStore, type NodeBotEditSessionFileStoreOptions } from "./bot-edit-sessions"
 import { NodeBotFeedbackTranscriber, type NodeBotFeedbackTranscriberOptions } from "./bot-feedback-transcriber"
@@ -30,6 +31,11 @@ import { type NodeVideoOptions, NodeVideoService } from "./video"
 
 // Re-exports
 export { type NodeAIOptions, NodeAIService } from "./ai"
+export {
+  NodeAIProjectEditor,
+  type NodeAIProjectEditorFetch,
+  type NodeAIProjectEditorOptions,
+} from "./ai-project-editor"
 export { type NodeBackendOptions, NodeBackendService } from "./backend"
 export {
   NodeBotEditSessionFileStore,
@@ -201,6 +207,8 @@ export interface NodeAppOptions {
   botMediaResolver?: NodeBotMediaResolverOptions | false
   /** Опции для bot-first voice/video-note feedback transcription */
   botFeedbackTranscriber?: Omit<NodeBotFeedbackTranscriberOptions, "ai" | "mediaResolver"> | false
+  /** Опции для production AI project editor */
+  aiProjectEditor?: NodeAIProjectEditorOptions | false
   /** Опции для bot-first status notifier */
   botStatus?: NodeBotStatusNotifierOptions | false
   /** Автоматически подключаться к бэкенду */
@@ -225,6 +233,7 @@ export interface NodeAppServices {
   botEditSessions?: NodeBotEditSessionFileStore
   botMediaResolver?: NodeBotMediaResolver
   botFeedbackTranscriber?: NodeBotFeedbackTranscriber
+  aiProjectEditor?: NodeAIProjectEditor
   botStatus?: NodeBotStatusNotifier
 }
 
@@ -269,6 +278,7 @@ export async function initNodeApp(options: NodeAppOptions = {}): Promise<NodeApp
   const botMediaResolver = createNodeBotMediaResolver(options.botMediaResolver)
   const botEditSessions = createNodeBotEditSessionStore(options.botEditSessions)
   const botFeedbackTranscriber = createNodeBotFeedbackTranscriber(options.botFeedbackTranscriber, ai, botMediaResolver)
+  const aiProjectEditor = createNodeAIProjectEditor(options.aiProjectEditor)
   const botStatus = createNodeBotStatusNotifier(options.botStatus)
   const botFirstCutPlanner = createNodeRustFirstCutPlanner(options.botFirstCutPlanner)
   const botFirstCutGenerator = createNodeBotFirstCutGenerator(options.botFirstCutGenerator, botFirstCutPlanner)
@@ -312,6 +322,7 @@ export async function initNodeApp(options: NodeAppOptions = {}): Promise<NodeApp
     ...(botEditSessions ? { botEditSessions } : {}),
     ...(botMediaResolver ? { botMediaResolver } : {}),
     ...(botFeedbackTranscriber ? { botFeedbackTranscriber } : {}),
+    ...(aiProjectEditor ? { aiProjectEditor } : {}),
     ...(botStatus ? { botStatus } : {}),
   }
 }
@@ -336,6 +347,7 @@ export function createNodeServices(options: NodeAppOptions = {}): NodeAppService
   const botStatus = createNodeBotStatusNotifier(options.botStatus)
   const botFirstCutPlanner = createNodeRustFirstCutPlanner(options.botFirstCutPlanner)
   const botFirstCutGenerator = createNodeBotFirstCutGenerator(options.botFirstCutGenerator, botFirstCutPlanner)
+  const aiProjectEditor = createNodeAIProjectEditor(options.aiProjectEditor)
   const botWorkflow = new NodeBotWorkflowService(renderJob, {
     ...options.botWorkflow,
     mediaResolver: options.botWorkflow?.mediaResolver ?? botMediaResolver,
@@ -361,8 +373,14 @@ export function createNodeServices(options: NodeAppOptions = {}): NodeAppService
     ...(botEditSessions ? { botEditSessions } : {}),
     ...(botMediaResolver ? { botMediaResolver } : {}),
     ...(botFeedbackTranscriber ? { botFeedbackTranscriber } : {}),
+    ...(aiProjectEditor ? { aiProjectEditor } : {}),
     ...(botStatus ? { botStatus } : {}),
   }
+}
+
+function createNodeAIProjectEditor(options?: NodeAIProjectEditorOptions | false): NodeAIProjectEditor | undefined {
+  if (options === undefined || options === false) return undefined
+  return new NodeAIProjectEditor(options)
 }
 
 function createNodeRustFirstCutPlanner(

--- a/src/features/timeline/hooks/state/__tests__/use-timeline.test.tsx
+++ b/src/features/timeline/hooks/state/__tests__/use-timeline.test.tsx
@@ -116,6 +116,165 @@ vi.mock("@/features/timeline/providers/timeline-providers", () => ({
   TimelinePlaybackProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   TimelineTracksProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   TimelineClipsProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useTimelineProject: vi.fn(() => ({
+    project: null,
+    isLoading: false,
+    hasUnsavedChanges: false,
+    createProject: async (name: string) => {
+      await mockExecuteCommand({
+        type: "CreateProject",
+        params: { name, template: "default" },
+      })
+      return mockCreateProject(name)
+    },
+    saveProject: async (projectPath?: string) => {
+      await mockExecuteCommand({
+        type: "SaveProject",
+        params: { path: projectPath },
+      })
+      return mockSaveProject(projectPath)
+    },
+    loadProject: mockLoadProject,
+    backend: null,
+  })),
+  useTimelinePlayback: vi.fn(() => ({
+    isPlaying: false,
+    currentTime: 0,
+    playbackRate: 1,
+    duration: 0,
+    play: mockPlay,
+    pause: mockPause,
+    stop: mockStop,
+    seek: mockSeek,
+    setPlaybackRate: mockSetPlaybackRate,
+  })),
+  useTimelineTracks: vi.fn(() => ({
+    tracks: [],
+    activeTrackId: null,
+    addTrack: vi.fn(async (type: any, name?: string, sectionId?: string) => {
+      await mockExecuteCommand({
+        type: "AddTrack",
+        params: {
+          name: name || `${type} Track`,
+          track_type: type.toUpperCase(),
+          index: null,
+        },
+      })
+      mockAddTrack(type, name, sectionId)
+    }),
+    removeTrack: vi.fn(async (trackId: string) => {
+      await mockExecuteCommand({
+        type: "DeleteTrack",
+        params: { track_id: trackId },
+      })
+      mockRemoveTrack(trackId)
+    }),
+    updateTrack: vi.fn(async (trackId: string, updates: any) => {
+      mockUpdateTrack(trackId, updates)
+    }),
+    reorderTracks: mockReorderTracks,
+    setActiveTrack: mockSetActiveTrack,
+  })),
+  useTimelineClips: vi.fn(() => ({
+    clips: [],
+    addClip: vi.fn(async (trackId: string, mediaFile: any, time: number) => {
+      await mockExecuteCommand({
+        type: "AddClip",
+        params: { track_id: trackId, media_id: mediaFile.id, time },
+      })
+      mockAddClip(trackId, mediaFile, time)
+    }),
+    removeClip: vi.fn(async (clipId: string) => {
+      await mockExecuteCommand({
+        type: "DeleteClip",
+        params: { clip_id: clipId },
+      })
+      mockRemoveClip(clipId)
+    }),
+    moveClip: vi.fn(async (clipId: string, trackId: string, time: number) => {
+      await mockExecuteCommand({
+        type: "MoveClip",
+        params: { clip_id: clipId, track_id: trackId, time },
+      })
+      mockMoveClip(clipId, trackId, time)
+    }),
+    trimClip: vi.fn(async (clipId: string, startTime: number, endTime: number) => {
+      await mockExecuteCommand({
+        type: "TrimClip",
+        params: { clip_id: clipId, start: startTime, end: endTime },
+      })
+      mockTrimClip(clipId, startTime, endTime)
+    }),
+    splitClip: mockSplitClip,
+    updateClip: vi.fn(async (clipId: string, updates: any) => {
+      await mockExecuteCommand({
+        type: "UpdateClip",
+        params: { clip_id: clipId, updates },
+      })
+      mockUpdateClip(clipId, updates)
+    }),
+    batchUpdateClips: mockBatchUpdateClips,
+  })),
+  useTimelineSelection: vi.fn(() => {
+    const [, forceUpdate] = React.useReducer((x) => x + 1, 0)
+    React.useEffect(() => {
+      forceUpdateCallback = forceUpdate
+      return () => {
+        forceUpdateCallback = null
+      }
+    }, [])
+
+    return {
+      selectedClipIds: mockSelectedClipIds,
+      selectedTrackIds: mockSelectedTrackIds,
+      clipboardClips: mockClipboardClips,
+      selectClips: vi.fn((clipIds: string[]) => {
+        mockSelectedClipIds = clipIds
+        forceUpdateCallback?.()
+      }),
+      selectTracks: vi.fn((trackIds: string[]) => {
+        mockSelectedTrackIds = trackIds
+        forceUpdateCallback?.()
+      }),
+      clearSelection: vi.fn(() => {
+        mockSelectedClipIds = []
+        mockSelectedTrackIds = []
+        forceUpdateCallback?.()
+      }),
+      copyClips: vi.fn(() => {
+        mockClipboardClips = [...mockSelectedClipIds]
+        forceUpdateCallback?.()
+      }),
+      cutClips: vi.fn(async () => {
+        mockClipboardClips = [...mockSelectedClipIds]
+        mockSelectedClipIds = []
+        forceUpdateCallback?.()
+      }),
+      pasteClips: vi.fn(async () => {
+        forceUpdateCallback?.()
+      }),
+      deleteSelected: vi.fn(async () => {
+        mockSelectedClipIds = []
+        mockSelectedTrackIds = []
+        forceUpdateCallback?.()
+      }),
+    }
+  }),
+  useTimelineEffects: vi.fn(() => ({
+    applyEffect: mockApplyEffect,
+    removeEffect: mockRemoveEffect,
+    applyFilter: mockApplyFilter,
+    removeFilter: mockRemoveFilter,
+    applyTransition: mockApplyTransition,
+    removeTransition: mockRemoveTransition,
+  })),
+  useTimelineMarkers: vi.fn(() => ({
+    markers: [],
+    addMarker: vi.fn(),
+    removeMarker: vi.fn(),
+    updateMarker: vi.fn(),
+    getMarkerAt: vi.fn(() => null),
+  })),
 }))
 
 // Create mock functions that can be tracked
@@ -377,7 +536,6 @@ vi.mock("@xstate/react", () => ({
 // Используем vi.mocked чтобы получить доступ к мокам
 import * as backendSyncModule from "@/adapters/tauri"
 import type { MediaFile, MediaType } from "@/domains/media-management"
-import { TimelineProviders } from "@/test/test-utils"
 import { useTimeline } from "../use-timeline"
 
 const backendSyncMocks = (backendSyncModule as any).__mocks
@@ -392,9 +550,7 @@ const {
 } = backendSyncMocks
 
 const wrapper = ({ children }: { children: React.ReactNode }) => (
-  <TimelineProviders data-oid="041.mok">
-    <SelectionStateProvider data-oid="yxqz_80">{children}</SelectionStateProvider>
-  </TimelineProviders>
+  <SelectionStateProvider data-oid="yxqz_80">{children}</SelectionStateProvider>
 )
 
 describe("useTimeline", () => {


### PR DESCRIPTION
## Summary
- add NodeAIProjectEditor as an OpenAI-compatible production adapter behind IAIProjectEditor
- include provider/model/API URL/fetch/runtime config, structured prompts with ProjectSchema, media context, revision history, target platform, and artifact metadata
- preserve the current project with actionable diagnostics for missing config, HTTP failures, invalid JSON, and invalid provider output
- expose the adapter through node exports and createNodeServices/initNodeApp factories

Closes #241.

## Verification
- npx tsc --noEmit --pretty false
- npx vitest run src/adapters/node/__tests__/ai-project-editor.test.ts src/core/services/__tests__/ai-project-editor.test.ts src/adapters/node/__tests__/telegram-ai-review-workflow-smoke.test.ts
- npx biome check src/adapters/node/ai-project-editor.ts src/adapters/node/__tests__/ai-project-editor.test.ts src/adapters/node/index.ts
- git diff --check