### PR TITLE
feat: wire Telegram AI review runtime

### DIFF
--- a/src/adapters/node/__tests__/telegram-bot-worker.test.ts
+++ b/src/adapters/node/__tests__/telegram-bot-worker.test.ts
@@ -1241,13 +1241,48 @@ describe("Telegram bot worker", () => {
   })
 
   it("enables approval-gated preview rendering when edit sessions are configured", async () => {
-    const runTelegramLikePayload = vi.fn(async () => completedResult)
+    const project = createProjectSchema()
+    const approvalResult: BotWorkflowRunResult = {
+      ...completedResult,
+      workflow: {
+        source: "telegram",
+        chatId: "chat-1",
+        userId: "user-1",
+        text: "template=promo destination=youtube",
+        media: [{ type: "file", value: "/tmp/input.mp4", name: "input.mp4" }],
+        output: { destination: "youtube" },
+      },
+      renderJob: {
+        source: "bot",
+        media: [{ type: "file", value: "/tmp/input.mp4", name: "input.mp4" }],
+        project: { type: "inline", schema: project },
+        output: { format: "mp4", destination: "file" },
+      },
+      result: {
+        job: {
+          ...completedResult.result.job,
+          artifact: {
+            type: "file",
+            path: "/tmp/preview.mp4",
+            destination: "file",
+            mimeType: "video/mp4",
+          },
+        },
+        events: [],
+      },
+      approvalGate: {
+        enabled: true,
+        previewDestination: "telegram",
+        publishTarget: "youtube",
+      },
+    }
+    const runTelegramLikePayload = vi.fn(async () => approvalResult)
     const service = {
       runWorkflow: vi.fn(),
       runTelegramLikePayload,
       cancelRenderJob: vi.fn(),
     } as unknown as NodeBotWorkflowService
-    const { store: editSessionStore } = createEditSessionStore()
+    const { store: editSessionStore, records } = createEditSessionStore()
     const worker = new NodeTelegramBotWorker({
       workflow: service,
       editSessionStore,
@@ -1274,6 +1309,25 @@ describe("Telegram bot worker", () => {
         },
       }),
     )
+    expect(records.get("edit:telegram:chat-1:user-1")).toMatchObject({
+      status: "preview_ready",
+      currentProjectSchema: project,
+      currentArtifact: {
+        type: "file",
+        path: "/tmp/preview.mp4",
+        destination: "file",
+      },
+      previewDestination: "telegram",
+      publishTarget: "youtube",
+      revisionCounter: 1,
+      revisions: [
+        expect.objectContaining({
+          index: 0,
+          summary: "Initial preview",
+          projectSchema: project,
+        }),
+      ],
+    })
   })
 
   it("publishes an approved edit session once", async () => {

--- a/src/adapters/node/__tests__/telegram-review-preview-renderer.test.ts
+++ b/src/adapters/node/__tests__/telegram-review-preview-renderer.test.ts
@@ -1,0 +1,169 @@
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type { IRenderJobService } from "@/core/ports"
+import type { BotEditRevision, BotEditSession, BotRenderJobRequest, BotRenderJobRunOptions } from "@/core/types"
+import { NodeTelegramRenderJobReviewPreviewRenderer } from "../telegram-review-preview-renderer"
+
+describe("NodeTelegramRenderJobReviewPreviewRenderer", () => {
+  let tempDir: string
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "telegram-review-preview-renderer-"))
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  it("renders an inline project preview through the render job service", async () => {
+    const artifact = {
+      type: "file" as const,
+      path: path.join(tempDir, "session-1-r1.mp4"),
+      destination: "file" as const,
+      mimeType: "video/mp4",
+    }
+    const run = vi.fn(async (_request: BotRenderJobRequest, _options?: BotRenderJobRunOptions) => ({
+      job: {
+        id: "preview-job-1",
+        status: "done" as const,
+        progress: 100,
+        request: _request,
+        artifact,
+        createdAt: "2026-06-09T14:00:00.000Z",
+        updatedAt: "2026-06-09T14:00:01.000Z",
+        events: [],
+      },
+      events: [],
+    }))
+    const renderer = new NodeTelegramRenderJobReviewPreviewRenderer(createRenderJob(run), {
+      outputDir: tempDir,
+      pollIntervalMs: 250,
+      timeoutMs: 5000,
+    })
+    const projectSchema = { version: "1", timeline: { tracks: [] } }
+
+    await expect(
+      renderer.renderPreview({
+        session: createSession(),
+        revision: createRevision(),
+        projectSchema,
+        update: { update_id: 10 },
+        payload: { message_id: 20, chat: { id: "chat-1" } },
+      }),
+    ).resolves.toEqual(artifact)
+
+    expect(run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "bot",
+        media: [{ type: "file", value: "/tmp/input.mp4", name: "input.mp4" }],
+        project: { type: "inline", schema: projectSchema },
+        output: {
+          format: "mp4",
+          path: path.join(tempDir, "edit-telegram-chat-1-user-1-r1.mp4"),
+          destination: "file",
+        },
+        params: {
+          reviewSessionId: "edit:telegram:chat-1:user-1",
+          reviewRevisionId: "revision-1",
+          sourceMessageId: 20,
+        },
+      }),
+      {
+        pollIntervalMs: 250,
+        timeoutMs: 5000,
+      },
+    )
+  })
+
+  it("fails when preview rendering does not produce an artifact", async () => {
+    const run = vi.fn(async (request: BotRenderJobRequest) => ({
+      job: {
+        id: "preview-job-1",
+        status: "done" as const,
+        progress: 100,
+        request,
+        createdAt: "2026-06-09T14:00:00.000Z",
+        updatedAt: "2026-06-09T14:00:01.000Z",
+        events: [],
+      },
+      events: [],
+    }))
+    const renderer = new NodeTelegramRenderJobReviewPreviewRenderer(createRenderJob(run), {
+      outputDir: tempDir,
+    })
+
+    await expect(
+      renderer.renderPreview({
+        session: createSession(),
+        revision: createRevision(),
+        projectSchema: { version: "1" },
+        update: { update_id: 10 },
+        payload: { message_id: 20 },
+      }),
+    ).rejects.toThrow("Preview render completed without an artifact")
+  })
+
+  it("fails with the render job error when preview rendering fails", async () => {
+    const run = vi.fn(async (request: BotRenderJobRequest) => ({
+      job: {
+        id: "preview-job-1",
+        status: "failed" as const,
+        progress: 35,
+        request,
+        error: "render failed",
+        createdAt: "2026-06-09T14:00:00.000Z",
+        updatedAt: "2026-06-09T14:00:01.000Z",
+        events: [],
+      },
+      events: [],
+    }))
+    const renderer = new NodeTelegramRenderJobReviewPreviewRenderer(createRenderJob(run), {
+      outputDir: tempDir,
+    })
+
+    await expect(
+      renderer.renderPreview({
+        session: createSession(),
+        revision: createRevision(),
+        projectSchema: { version: "1" },
+        update: { update_id: 10 },
+        payload: { message_id: 20 },
+      }),
+    ).rejects.toThrow("render failed")
+  })
+})
+
+function createRenderJob(run: IRenderJobService["run"]): IRenderJobService {
+  return {
+    run,
+    getJob: vi.fn(async () => null),
+    cancelJob: vi.fn(async () => false),
+  }
+}
+
+function createSession(): BotEditSession {
+  return {
+    id: "edit:telegram:chat-1:user-1",
+    source: "telegram",
+    status: "editing",
+    chatId: "chat-1",
+    userId: "user-1",
+    media: [{ type: "file", value: "/tmp/input.mp4", name: "input.mp4" }],
+    revisionCounter: 1,
+    revisions: [],
+    createdAt: "2026-06-09T14:00:00.000Z",
+    updatedAt: "2026-06-09T14:00:00.000Z",
+  }
+}
+
+function createRevision(): BotEditRevision {
+  return {
+    id: "revision-1",
+    index: 1,
+    createdAt: "2026-06-09T14:00:00.000Z",
+    updatedAt: "2026-06-09T14:00:00.000Z",
+  }
+}

--- a/src/adapters/node/index.ts
+++ b/src/adapters/node/index.ts
@@ -170,6 +170,10 @@ export {
   type TelegramBotMessage,
   type TelegramBotUpdate,
 } from "./telegram-bot-worker"
+export {
+  NodeTelegramRenderJobReviewPreviewRenderer,
+  type NodeTelegramRenderJobReviewPreviewRendererOptions,
+} from "./telegram-review-preview-renderer"
 export { type NodeVideoOptions, NodeVideoService } from "./video"
 
 export interface NodeAppOptions {

--- a/src/adapters/node/telegram-bot-worker.ts
+++ b/src/adapters/node/telegram-bot-worker.ts
@@ -6,6 +6,7 @@ import {
   createBotEditRevisionId,
   createBotWorkflowDraftId,
   createTelegramLikeBotWorkflow,
+  mergeBotEditSessionWorkflow,
   mergeBotWorkflowDraft,
   runAIProjectEdit,
   validateBotDestinationCapability,
@@ -17,6 +18,7 @@ import type {
   BotPublishResult,
   BotRenderJobArtifact,
   BotRenderJobEventSink,
+  BotRenderJobProjectInput,
   BotRenderJobSnapshot,
   BotWorkflowDraft,
   BotWorkflowDraftStore,
@@ -679,6 +681,7 @@ export class NodeTelegramBotWorker {
             mergeWorkflowOptions(mergeWorkflowOptions(this.workflowOptions, options.workflowOptions), workflowOptions),
           ),
         ),
+      onComplete: (workflowResult) => this.upsertReviewEditSessionFromWorkflowResult(workflowResult),
     })
   }
 
@@ -940,6 +943,7 @@ export class NodeTelegramBotWorker {
               retry.job.sourcePayload as TelegramLikeBotPayload,
               this.withReviewApprovalGate(mergeWorkflowOptions(workflowDefaults, workflowOptions)),
             ),
+      onComplete: (workflowResult) => this.upsertReviewEditSessionFromWorkflowResult(workflowResult),
     })
   }
 
@@ -1833,6 +1837,7 @@ export class NodeTelegramBotWorker {
           } else {
             await store.writeDraft(draft)
           }
+          await this.upsertReviewEditSessionFromWorkflowResult(workflowResult)
         },
       })
     }
@@ -1883,6 +1888,53 @@ export class NodeTelegramBotWorker {
     }
     await this.options.onResult?.(result)
     return result
+  }
+
+  private async upsertReviewEditSessionFromWorkflowResult(workflowResult: BotWorkflowRunResult): Promise<void> {
+    const store = this.options.editSessionStore
+    if (!store || !workflowResult.ok || !workflowResult.approvalGate?.enabled) return
+    if (workflowResult.result.job.status !== "done") return
+
+    const projectSchema = readInlineProjectSchema(workflowResult.renderJob.project)
+    const artifact = workflowResult.result.job.artifact
+    if (!projectSchema || !artifact) return
+
+    const timestamp = this.now()
+    const existing = await store.readCurrentSession({
+      source: workflowResult.workflow.source,
+      ...(workflowResult.workflow.chatId ? { chatId: workflowResult.workflow.chatId } : {}),
+      ...(workflowResult.workflow.userId ? { userId: workflowResult.workflow.userId } : {}),
+      activeOnly: true,
+    })
+    const session = mergeBotEditSessionWorkflow(existing, workflowResult.workflow, {
+      now: () => timestamp,
+      status: "preview_ready",
+      currentProjectSchema: projectSchema,
+      currentArtifact: artifact,
+      previewDestination: workflowResult.approvalGate.previewDestination,
+      ...(workflowResult.approvalGate.publishTarget
+        ? { publishTarget: workflowResult.approvalGate.publishTarget }
+        : {}),
+      revision: {
+        projectSchema,
+        artifact,
+        summary: "Initial preview",
+        changedAreas: ["renderJob.project"],
+        diagnostics: ["info: initial_preview: Initial approval-gated preview rendered."],
+        metadata: {
+          source: "telegram-bot-worker",
+          renderJobId: workflowResult.result.job.id,
+          approvalGate: workflowResult.approvalGate,
+        },
+      },
+      metadata: {
+        source: "telegram-bot-worker",
+        renderJobId: workflowResult.result.job.id,
+        approvalGate: workflowResult.approvalGate,
+      },
+    })
+
+    await store.writeSession(session)
   }
 
   private async sendDraftResponse(draftId: string, payload: TelegramLikeBotPayload, text: string): Promise<void> {
@@ -2802,6 +2854,10 @@ function mergeRevisionMetadata(
     ...(base ?? {}),
     ...patch,
   }
+}
+
+function readInlineProjectSchema(project: BotRenderJobProjectInput | undefined): unknown | undefined {
+  return project?.type === "inline" ? project.schema : undefined
 }
 
 function formatAIProjectEditDiagnostic(diagnostic: AIProjectEditorResult["diagnostics"][number]): string {

--- a/src/adapters/node/telegram-review-preview-renderer.ts
+++ b/src/adapters/node/telegram-review-preview-renderer.ts
@@ -1,0 +1,74 @@
+import fs from "node:fs/promises"
+import path from "node:path"
+
+import type { IRenderJobService } from "@/core/ports"
+import type { BotRenderJobArtifact, BotRenderJobRunOptions } from "@/core/types"
+
+import type {
+  NodeTelegramBotReviewPreviewRenderer,
+  NodeTelegramBotReviewPreviewRendererContext,
+} from "./telegram-bot-worker"
+
+export interface NodeTelegramRenderJobReviewPreviewRendererOptions {
+  outputDir: string
+  pollIntervalMs?: number
+  timeoutMs?: number
+}
+
+export class NodeTelegramRenderJobReviewPreviewRenderer implements NodeTelegramBotReviewPreviewRenderer {
+  constructor(
+    private readonly renderJob: IRenderJobService,
+    private readonly options: NodeTelegramRenderJobReviewPreviewRendererOptions,
+  ) {}
+
+  async renderPreview(context: NodeTelegramBotReviewPreviewRendererContext): Promise<BotRenderJobArtifact> {
+    await fs.mkdir(this.options.outputDir, { recursive: true })
+    const outputPath = path.join(
+      this.options.outputDir,
+      `${sanitizeFileSegment(context.session.id)}-r${context.revision.index}.mp4`,
+    )
+    const runOptions = createRenderRunOptions(this.options)
+    const result = await this.renderJob.run(
+      {
+        source: "bot",
+        media: context.session.media,
+        project: {
+          type: "inline",
+          schema: context.projectSchema,
+        },
+        output: {
+          format: "mp4",
+          path: outputPath,
+          destination: "file",
+        },
+        params: {
+          reviewSessionId: context.session.id,
+          reviewRevisionId: context.revision.id,
+          ...(context.payload.message_id ? { sourceMessageId: context.payload.message_id } : {}),
+        },
+      },
+      runOptions,
+    )
+
+    if (result.job.status !== "done") {
+      throw new Error(result.job.error ?? `Preview render ended with status ${result.job.status}`)
+    }
+
+    if (!result.job.artifact) {
+      throw new Error("Preview render completed without an artifact")
+    }
+
+    return result.job.artifact
+  }
+}
+
+function createRenderRunOptions(options: NodeTelegramRenderJobReviewPreviewRendererOptions): BotRenderJobRunOptions {
+  return {
+    ...(options.pollIntervalMs !== undefined ? { pollIntervalMs: options.pollIntervalMs } : {}),
+    ...(options.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
+  }
+}
+
+function sanitizeFileSegment(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "preview"
+}

--- a/src/cli/commands/__tests__/bot-worker.test.ts
+++ b/src/cli/commands/__tests__/bot-worker.test.ts
@@ -49,6 +49,9 @@ describe("bot-worker command", () => {
     expect(botWorkerCommand.options.some((option) => option.long === "--max-batches")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--idle-delay")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--rust-render")).toBe(true)
+    expect(botWorkerCommand.options.some((option) => option.long === "--edit-session-dir")).toBe(true)
+    expect(botWorkerCommand.options.some((option) => option.long === "--ai-editor")).toBe(true)
+    expect(botWorkerCommand.options.some((option) => option.long === "--ai-editor-model")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--default-destination")).toBe(true)
   })
 
@@ -89,6 +92,15 @@ describe("bot-worker command", () => {
     await expect(
       runBotWorker({ updateFile: path.join(tempDir, "update.json"), recoverStaleJobs: true }),
     ).rejects.toThrow("--recover-stale-jobs requires --job-store-file")
+  })
+
+  it("requires an AI editor key when production AI editing is explicitly enabled", async () => {
+    await expect(
+      runBotWorker({
+        updateFile: path.join(tempDir, "update.json"),
+        aiEditor: true,
+      }),
+    ).rejects.toThrow("--ai-editor requires")
   })
 
   it("serializes compact and pretty worker results", () => {
@@ -244,6 +256,14 @@ describe("bot-worker command", () => {
         TIMELINE_BOT_RUST_RENDER_KIND: "timeline-render",
         TIMELINE_BOT_RUST_PUBLISH: "1",
         TIMELINE_BOT_RUST_PUBLISH_COMMAND: "timeline",
+        TIMELINE_BOT_EDIT_SESSION_DIR: ".tmp/edit-sessions",
+        TIMELINE_BOT_AI_EDITOR: "true",
+        TIMELINE_BOT_AI_EDITOR_API_KEY: "editor-key",
+        TIMELINE_BOT_AI_EDITOR_API_URL: "https://llm.example/v1",
+        TIMELINE_BOT_AI_EDITOR_PROVIDER: "openai-compatible",
+        TIMELINE_BOT_AI_EDITOR_MODEL: "editor-model",
+        TIMELINE_BOT_AI_EDITOR_TEMPERATURE: "0.1",
+        TIMELINE_BOT_AI_EDITOR_MAX_TOKENS: "2048",
       },
     )
 
@@ -276,6 +296,14 @@ describe("bot-worker command", () => {
       rustRenderKind: "timeline-render",
       rustPublish: true,
       rustPublishCommand: "timeline",
+      editSessionDir: ".tmp/edit-sessions",
+      aiEditor: true,
+      aiEditorApiKey: "editor-key",
+      aiEditorApiUrl: "https://llm.example/v1",
+      aiEditorProvider: "openai-compatible",
+      aiEditorModel: "editor-model",
+      aiEditorTemperature: "0.1",
+      aiEditorMaxTokens: "2048",
     })
   })
 
@@ -298,6 +326,10 @@ describe("bot-worker command", () => {
         rustRender: false,
         rustPublish: false,
         downloadRemoteMedia: false,
+        editSessionDir: ".tmp/cli-edit-sessions",
+        aiEditor: true,
+        aiEditorApiKey: "cli-editor-key",
+        aiEditorModel: "cli-editor-model",
       },
       {
         TIMELINE_BOT_TELEGRAM_TOKEN: "token-from-env",
@@ -316,6 +348,10 @@ describe("bot-worker command", () => {
         TIMELINE_BOT_RUST_RENDER: "true",
         TIMELINE_BOT_RUST_PUBLISH: "true",
         TIMELINE_BOT_DOWNLOAD_REMOTE_MEDIA: "true",
+        TIMELINE_BOT_EDIT_SESSION_DIR: ".tmp/env-edit-sessions",
+        TIMELINE_BOT_AI_EDITOR: "false",
+        TIMELINE_BOT_AI_EDITOR_API_KEY: "env-editor-key",
+        TIMELINE_BOT_AI_EDITOR_MODEL: "env-editor-model",
       },
     )
 
@@ -336,6 +372,10 @@ describe("bot-worker command", () => {
       rustRender: false,
       rustPublish: false,
       downloadRemoteMedia: false,
+      editSessionDir: ".tmp/cli-edit-sessions",
+      aiEditor: true,
+      aiEditorApiKey: "cli-editor-key",
+      aiEditorModel: "cli-editor-model",
     })
   })
 })

--- a/src/cli/commands/__tests__/bot-worker.test.ts
+++ b/src/cli/commands/__tests__/bot-worker.test.ts
@@ -52,6 +52,7 @@ describe("bot-worker command", () => {
     expect(botWorkerCommand.options.some((option) => option.long === "--edit-session-dir")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--ai-editor")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--ai-editor-model")).toBe(true)
+    expect(botWorkerCommand.options.some((option) => option.long === "--review-preview-dir")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--default-destination")).toBe(true)
   })
 
@@ -264,6 +265,7 @@ describe("bot-worker command", () => {
         TIMELINE_BOT_AI_EDITOR_MODEL: "editor-model",
         TIMELINE_BOT_AI_EDITOR_TEMPERATURE: "0.1",
         TIMELINE_BOT_AI_EDITOR_MAX_TOKENS: "2048",
+        TIMELINE_BOT_REVIEW_PREVIEW_DIR: ".tmp/review-previews",
       },
     )
 
@@ -304,6 +306,7 @@ describe("bot-worker command", () => {
       aiEditorModel: "editor-model",
       aiEditorTemperature: "0.1",
       aiEditorMaxTokens: "2048",
+      reviewPreviewDir: ".tmp/review-previews",
     })
   })
 
@@ -330,6 +333,7 @@ describe("bot-worker command", () => {
         aiEditor: true,
         aiEditorApiKey: "cli-editor-key",
         aiEditorModel: "cli-editor-model",
+        reviewPreviewDir: ".tmp/cli-review-previews",
       },
       {
         TIMELINE_BOT_TELEGRAM_TOKEN: "token-from-env",
@@ -352,6 +356,7 @@ describe("bot-worker command", () => {
         TIMELINE_BOT_AI_EDITOR: "false",
         TIMELINE_BOT_AI_EDITOR_API_KEY: "env-editor-key",
         TIMELINE_BOT_AI_EDITOR_MODEL: "env-editor-model",
+        TIMELINE_BOT_REVIEW_PREVIEW_DIR: ".tmp/env-review-previews",
       },
     )
 
@@ -376,6 +381,7 @@ describe("bot-worker command", () => {
       aiEditor: true,
       aiEditorApiKey: "cli-editor-key",
       aiEditorModel: "cli-editor-model",
+      reviewPreviewDir: ".tmp/cli-review-previews",
     })
   })
 })

--- a/src/cli/commands/bot-worker.ts
+++ b/src/cli/commands/bot-worker.ts
@@ -23,6 +23,7 @@ import {
   NodeTelegramBotFileWorkflowJobStore,
   NodeTelegramBotInMemoryWorkflowQueue,
   NodeTelegramBotWorker,
+  NodeTelegramRenderJobReviewPreviewRenderer,
   recoverStaleTelegramWorkflowJobs,
 } from "@/adapters/node"
 import type {
@@ -75,6 +76,7 @@ export interface BotWorkerCommandOptions {
   aiEditorModel?: string
   aiEditorTemperature?: string
   aiEditorMaxTokens?: string
+  reviewPreviewDir?: string
   defaultDestination?: BotRenderJobDestination
   defaultOutput?: string
 }
@@ -127,6 +129,7 @@ export const botWorkerCommand = new Command("bot-worker")
   .option("--ai-editor-model <model>", "Model for the AI project editor")
   .option("--ai-editor-temperature <number>", "Temperature for the AI project editor")
   .option("--ai-editor-max-tokens <count>", "Max completion tokens for the AI project editor")
+  .option("--review-preview-dir <path>", "Directory for rendered Telegram AI review preview artifacts")
   .option("--default-destination <destination>", "Fallback destination when update has no destination hint")
   .option("--default-output <path>", "Fallback output path when update has no output hint")
   .action(async (options: BotWorkerCommandOptions) => {
@@ -211,6 +214,7 @@ export async function runBotWorker(options: BotWorkerCommandOptions = {}): Promi
     editSessionStore: services.botEditSessions,
     aiProjectEditor: services.aiProjectEditor,
     feedbackTranscriber: services.botFeedbackTranscriber,
+    previewRenderer: createBotReviewPreviewRenderer(services.renderJob, resolvedOptions),
     publishService: services.publish,
     previewResponder: services.botStatus,
     reviewResponder: services.botStatus,
@@ -308,6 +312,7 @@ export function resolveBotWorkerCommandOptions(
     aiEditorModel: firstConfigured(options.aiEditorModel, env.TIMELINE_BOT_AI_EDITOR_MODEL),
     aiEditorTemperature: firstConfigured(options.aiEditorTemperature, env.TIMELINE_BOT_AI_EDITOR_TEMPERATURE),
     aiEditorMaxTokens: firstConfigured(options.aiEditorMaxTokens, env.TIMELINE_BOT_AI_EDITOR_MAX_TOKENS),
+    reviewPreviewDir: firstConfigured(options.reviewPreviewDir, env.TIMELINE_BOT_REVIEW_PREVIEW_DIR),
     defaultDestination: firstConfigured(
       options.defaultDestination,
       normalizeDestination(env.TIMELINE_BOT_DEFAULT_DESTINATION),
@@ -395,6 +400,19 @@ function createBotAIProjectEditorOptions(options: BotWorkerCommandOptions): Node
       ? { maxTokens: parseOptionalPositiveInteger(options.aiEditorMaxTokens) }
       : {}),
   }
+}
+
+function createBotReviewPreviewRenderer(
+  renderJob: Awaited<ReturnType<typeof initNodeApp>>["renderJob"],
+  options: BotWorkerCommandOptions,
+) {
+  if (!options.editSessionDir) return undefined
+
+  return new NodeTelegramRenderJobReviewPreviewRenderer(renderJob, {
+    outputDir: path.resolve(options.reviewPreviewDir ?? path.join(options.editSessionDir, "previews")),
+    pollIntervalMs: parsePositiveInteger(options.pollInterval, 1000),
+    timeoutMs: parsePositiveInteger(options.timeout, 3600000),
+  })
 }
 
 function createBotStatusOptions(options: BotWorkerCommandOptions) {

--- a/src/cli/commands/bot-worker.ts
+++ b/src/cli/commands/bot-worker.ts
@@ -9,6 +9,7 @@ import fs from "node:fs/promises"
 import path from "node:path"
 import { Command } from "commander"
 import type {
+  NodeAIProjectEditorOptions,
   NodeTelegramBotWorkerPollResult,
   NodeTelegramBotWorkerRunResult,
   NodeTelegramBotWorkerUpdateResult,
@@ -66,6 +67,14 @@ export interface BotWorkerCommandOptions {
   rustRenderKind?: "timeline" | "timeline-render"
   rustPublish?: boolean
   rustPublishCommand?: string
+  editSessionDir?: string
+  aiEditor?: boolean
+  aiEditorApiKey?: string
+  aiEditorApiUrl?: string
+  aiEditorProvider?: string
+  aiEditorModel?: string
+  aiEditorTemperature?: string
+  aiEditorMaxTokens?: string
   defaultDestination?: BotRenderJobDestination
   defaultOutput?: string
 }
@@ -110,6 +119,14 @@ export const botWorkerCommand = new Command("bot-worker")
   .option("--rust-render-kind <kind>", "Rust render command kind: timeline or timeline-render")
   .option("--rust-publish", "Run bot publishing through the Rust timeline publish CLI")
   .option("--rust-publish-command <path>", "Path/name for the Rust timeline publish command")
+  .option("--edit-session-dir <path>", "Persist Telegram AI review edit sessions in a directory")
+  .option("--ai-editor", "Enable the production AI project editor for review feedback")
+  .option("--ai-editor-api-key <key>", "API key for the AI project editor")
+  .option("--ai-editor-api-url <url>", "OpenAI-compatible base URL for the AI project editor")
+  .option("--ai-editor-provider <provider>", "Provider label for AI project editor metadata")
+  .option("--ai-editor-model <model>", "Model for the AI project editor")
+  .option("--ai-editor-temperature <number>", "Temperature for the AI project editor")
+  .option("--ai-editor-max-tokens <count>", "Max completion tokens for the AI project editor")
   .option("--default-destination <destination>", "Fallback destination when update has no destination hint")
   .option("--default-output <path>", "Fallback output path when update has no output hint")
   .action(async (options: BotWorkerCommandOptions) => {
@@ -147,8 +164,18 @@ export async function runBotWorker(options: BotWorkerCommandOptions = {}): Promi
     throw new Error("--recover-stale-jobs requires --job-store-file")
   }
 
+  if (resolvedOptions.aiEditor && !resolvedOptions.aiEditorApiKey) {
+    throw new Error(
+      "--ai-editor requires --ai-editor-api-key, TIMELINE_BOT_AI_EDITOR_API_KEY, OPENAI_API_KEY, or LLM_API_KEY",
+    )
+  }
+
   const services = await initNodeApp({
     autoConnect: false,
+    ai: createBotAIOptions(resolvedOptions),
+    aiProjectEditor: createBotAIProjectEditorOptions(resolvedOptions),
+    botEditSessions: createBotEditSessionStoreOptions(resolvedOptions),
+    botFeedbackTranscriber: resolvedOptions.editSessionDir ? {} : false,
     botMediaResolver: createBotMediaResolverOptions(resolvedOptions),
     botStatus: createBotStatusOptions(resolvedOptions),
     publish: createBotPublishOptions(resolvedOptions),
@@ -181,7 +208,12 @@ export async function runBotWorker(options: BotWorkerCommandOptions = {}): Promi
     workflowQueue,
     accessPolicy: createTelegramBotAccessPolicy(resolvedOptions),
     botToken: resolvedOptions.telegramBotToken,
+    editSessionStore: services.botEditSessions,
+    aiProjectEditor: services.aiProjectEditor,
+    feedbackTranscriber: services.botFeedbackTranscriber,
     publishService: services.publish,
+    previewResponder: services.botStatus,
+    reviewResponder: services.botStatus,
     workflowOptions: {
       intake: {
         defaultDestination: resolvedOptions.defaultDestination,
@@ -263,6 +295,19 @@ export function resolveBotWorkerCommandOptions(
     rustRenderCommand: firstConfigured(options.rustRenderCommand, env.TIMELINE_BOT_RUST_RENDER_COMMAND),
     rustRenderKind: firstConfigured(options.rustRenderKind, normalizeRustRenderKind(env.TIMELINE_BOT_RUST_RENDER_KIND)),
     rustPublishCommand: firstConfigured(options.rustPublishCommand, env.TIMELINE_BOT_RUST_PUBLISH_COMMAND),
+    editSessionDir: firstConfigured(options.editSessionDir, env.TIMELINE_BOT_EDIT_SESSION_DIR),
+    aiEditor: options.aiEditor ?? parseBooleanEnv(env.TIMELINE_BOT_AI_EDITOR),
+    aiEditorApiKey: firstConfigured(
+      options.aiEditorApiKey,
+      env.TIMELINE_BOT_AI_EDITOR_API_KEY,
+      env.OPENAI_API_KEY,
+      env.LLM_API_KEY,
+    ),
+    aiEditorApiUrl: firstConfigured(options.aiEditorApiUrl, env.TIMELINE_BOT_AI_EDITOR_API_URL),
+    aiEditorProvider: firstConfigured(options.aiEditorProvider, env.TIMELINE_BOT_AI_EDITOR_PROVIDER),
+    aiEditorModel: firstConfigured(options.aiEditorModel, env.TIMELINE_BOT_AI_EDITOR_MODEL),
+    aiEditorTemperature: firstConfigured(options.aiEditorTemperature, env.TIMELINE_BOT_AI_EDITOR_TEMPERATURE),
+    aiEditorMaxTokens: firstConfigured(options.aiEditorMaxTokens, env.TIMELINE_BOT_AI_EDITOR_MAX_TOKENS),
     defaultDestination: firstConfigured(
       options.defaultDestination,
       normalizeDestination(env.TIMELINE_BOT_DEFAULT_DESTINATION),
@@ -309,6 +354,45 @@ function createBotMediaResolverOptions(options: BotWorkerCommandOptions) {
             botToken: options.telegramBotToken,
           },
         }
+      : {}),
+  }
+}
+
+function createBotAIOptions(options: BotWorkerCommandOptions) {
+  if (!options.aiEditorApiKey) return undefined
+  return {
+    openaiApiKey: options.aiEditorApiKey,
+  }
+}
+
+function createBotEditSessionStoreOptions(options: BotWorkerCommandOptions) {
+  if (!options.editSessionDir) return false
+  return {
+    directory: path.resolve(options.editSessionDir),
+  }
+}
+
+function createBotAIProjectEditorOptions(options: BotWorkerCommandOptions): NodeAIProjectEditorOptions | false {
+  const hasConfig = Boolean(
+    options.aiEditorApiKey ||
+      options.aiEditorApiUrl ||
+      options.aiEditorProvider ||
+      options.aiEditorModel ||
+      options.aiEditorTemperature ||
+      options.aiEditorMaxTokens,
+  )
+  if (!options.aiEditor && !hasConfig) return false
+
+  return {
+    ...(options.aiEditorApiKey ? { apiKey: options.aiEditorApiKey } : {}),
+    ...(options.aiEditorApiUrl ? { apiUrl: options.aiEditorApiUrl } : {}),
+    ...(options.aiEditorProvider ? { provider: options.aiEditorProvider } : {}),
+    ...(options.aiEditorModel ? { model: options.aiEditorModel } : {}),
+    ...(parseOptionalNonNegativeNumber(options.aiEditorTemperature) !== undefined
+      ? { temperature: parseOptionalNonNegativeNumber(options.aiEditorTemperature) }
+      : {}),
+    ...(parseOptionalPositiveInteger(options.aiEditorMaxTokens) !== undefined
+      ? { maxTokens: parseOptionalPositiveInteger(options.aiEditorMaxTokens) }
       : {}),
   }
 }


### PR DESCRIPTION
## Summary
- port the #250 Telegram AI review runtime wiring onto main
- add bot-worker CLI/env options for edit session storage, production AI editor configuration, and review preview output directory
- wire NodeTelegramBotWorker to edit sessions, AI editor, feedback transcriber, Rust publish, Telegram review/status responders, and a render-job-backed review preview renderer
- persist a preview_ready edit session from successful approval-gated preview renders so Telegram review can continue from the generated artifact
- render follow-up AI revision previews through the existing renderJob service, using Rust render when --rust-render is enabled

## Context
#250 was merged into the stacked base branch, not main. This PR carries that runtime wiring onto the current main branch and extends it with production preview rendering for AI review revisions.

## Checks
- npx tsc --noEmit --pretty false
- npx vitest run src/adapters/node/__tests__/telegram-review-preview-renderer.test.ts src/cli/commands/__tests__/bot-worker.test.ts src/adapters/node/__tests__/telegram-bot-worker.test.ts
- npx biome check src/adapters/node/telegram-review-preview-renderer.ts src/adapters/node/__tests__/telegram-review-preview-renderer.test.ts src/adapters/node/index.ts src/cli/commands/bot-worker.ts src/cli/commands/__tests__/bot-worker.test.ts
- git diff --check

Part of #243