### PR TITLE
Add bot AI headless CI smoke

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -34,6 +34,15 @@ Timeline Studio использует набор оптимизированных
 - Проверка CSS и PostCSS файлов
 - Быстрая валидация
 
+#### `bot-ai-headless.yml` - Bot/AI headless smoke
+**Назначение**: Быстрая проверка Telegram bot-first, AI review, Rust adapter glue и CLI headless контрактов
+**Триггеры**: Push в main, Pull Requests с изменениями в `src/core`, `src/adapters/node`, `src/cli`, bot fixtures или smoke scripts
+**Платформы**: Ubuntu
+**Ключевые особенности**:
+- Запускает `bun run test:bot-ai` с отдельным Vitest config и JUnit отчетом `test-results/bot-ai-junit.xml`
+- Запускает `bun run smoke:ai-review:rust` как skip-safe диагностику Rust render/publish adapter wiring
+- Дает отдельный PR check, чтобы full frontend suite failures не скрывали bot/AI regressions
+
 #### `check-all.yml` - Полная проверка
 **Назначение**: Комплексная проверка всего проекта
 **Триггеры**: Push в main/develop, Pull Requests

--- a/.github/workflows/bot-ai-headless.yml
+++ b/.github/workflows/bot-ai-headless.yml
@@ -1,0 +1,80 @@
+name: Bot AI Headless
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - ".github/workflows/bot-ai-headless.yml"
+      - "docs/08_tasks/planned/fixtures/**"
+      - "package.json"
+      - "package-lock.json"
+      - "bun.lock"
+      - "vitest.config.ts"
+      - "vitest.bot-ai.config.ts"
+      - "scripts/smoke-ai-review-rust.ts"
+      - "src/core/**"
+      - "src/adapters/node/**"
+      - "src/adapters/mock/**"
+      - "src/cli/**"
+      - "src/types/contracts/project-schema.ts"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bot-ai-headless:
+    name: Bot/AI Headless Tests
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-bot-ai-${{ hashFiles('bun.lock', 'package-lock.json', 'package.json', 'packages/*/package.json', 'apps/*/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-bot-ai-
+            ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        env:
+          ONNXRUNTIME_DOWNLOAD_TIMEOUT: "600000"
+        run: bun install --frozen-lockfile || bun install
+
+      - name: Create test results directory
+        run: mkdir -p test-results
+
+      - name: Run bot/AI headless tests
+        run: bun run test:bot-ai
+        env:
+          CI: true
+          NODE_OPTIONS: --max-old-space-size=4096
+
+      - name: Run Rust AI review smoke diagnostics
+        run: bun run smoke:ai-review:rust
+        env:
+          CI: true
+          AI_REVIEW_RUST_SMOKE_KEEP_TEMP: "0"
+
+      - name: Upload bot/AI test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bot-ai-test-results
+          path: test-results/
+          retention-days: 30

--- a/docs/08_tasks/planned/ai-module-node-rust-orchestration.md
+++ b/docs/08_tasks/planned/ai-module-node-rust-orchestration.md
@@ -186,9 +186,9 @@ new NodeTelegramBotWorker({
 
 **GitHub:** [#245](https://github.com/chatman-media/timeline-studio/issues/245)
 
-- [ ] Add dedicated bot/AI test command or CI job.
-- [ ] Keep full frontend suite failures from blocking visibility into headless bot regressions.
-- [ ] Track current unrelated failures: timeline hook mock drift, Vitest worker memory, Windows Biome install.
+- [x] Add dedicated bot/AI test command or CI job.
+- [x] Keep full frontend suite failures from blocking visibility into headless bot regressions.
+- [x] Track current unrelated failures: timeline hook mock drift, Vitest worker memory, Windows Biome install.
 
 ### B46: AI review runtime observability and runbook
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "version:from-package": "VERSION_STRATEGY=package node scripts/ci/version-sync.mjs",
     "test": "NODE_OPTIONS='--max-old-space-size=8192' vitest run",
     "test:app": "NODE_OPTIONS='--max-old-space-size=8192' vitest run src/features",
+    "test:bot-ai": "NODE_OPTIONS='--max-old-space-size=4096' vitest run --config vitest.bot-ai.config.ts",
     "test:watch": "NODE_OPTIONS='--max-old-space-size=8192' vitest",
     "test:coverage": "NODE_OPTIONS='--max-old-space-size=8192' vitest run --coverage",
     "test:coverage:codecov": "vitest run --coverage",

--- a/scripts/windows-npm-install.ps1
+++ b/scripts/windows-npm-install.ps1
@@ -98,6 +98,19 @@ if (-not $success) {
     }
 }
 
+Write-Host "`nVerifying local Biome CLI..." -ForegroundColor Cyan
+$biomePath = Join-Path $PWD "node_modules\.bin\biome.cmd"
+if (-not (Test-Path $biomePath)) {
+    Write-Host "Local Biome CLI not found at $biomePath" -ForegroundColor Red
+    exit 1
+}
+
+& $biomePath --version
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Local Biome CLI failed to execute" -ForegroundColor Red
+    exit $LASTEXITCODE
+}
+
 # Try to install onnxruntime-node separately if needed
 Write-Host "`nChecking onnxruntime-node installation..." -ForegroundColor Cyan
 node -e "require('onnxruntime-node')"

--- a/vitest.bot-ai.config.ts
+++ b/vitest.bot-ai.config.ts
@@ -1,0 +1,54 @@
+import path from "node:path"
+
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./src/test/setup.ts"],
+    include: [
+      "src/core/services/__tests__/ai-project-editor.test.ts",
+      "src/core/services/__tests__/bot-*.test.ts",
+      "src/core/services/__tests__/render-job-events.test.ts",
+      "src/adapters/node/__tests__/ai-project-editor.test.ts",
+      "src/adapters/node/__tests__/bot-*.test.ts",
+      "src/adapters/node/__tests__/publish.test.ts",
+      "src/adapters/node/__tests__/render-job.test.ts",
+      "src/adapters/node/__tests__/rust-*.test.ts",
+      "src/adapters/node/__tests__/telegram-*.test.ts",
+      "src/cli/commands/__tests__/bot-*.test.ts",
+      "src/cli/commands/__tests__/render-job.test.ts",
+    ],
+    exclude: ["e2e/**/*", "node_modules/**/*"],
+    testTimeout: 15_000,
+    pool: "threads",
+    maxWorkers: 2,
+    fileParallelism: true,
+    isolate: true,
+    reporters: ["default", "junit"],
+    outputFile: {
+      junit: "./test-results/bot-ai-junit.xml",
+    },
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+      "@features": path.resolve(__dirname, "./src/features"),
+      "@timeline-studio/core": path.resolve(__dirname, "./src/core"),
+      "@timeline-studio/domains": path.resolve(__dirname, "./src/domains"),
+      "@timeline-studio/adapters": path.resolve(__dirname, "./src/adapters"),
+      "@timeline-studio/ui/features": path.resolve(__dirname, "./src/features"),
+      "@timeline-studio/ui/components": path.resolve(__dirname, "./src/components/ui"),
+      "@tauri-apps/api/app": path.resolve(__dirname, "./src/test/mocks/tauri/api/app.ts"),
+      "@tauri-apps/api/core": path.resolve(__dirname, "./src/test/mocks/tauri/core.ts"),
+      "@tauri-apps/api/event": path.resolve(__dirname, "./src/test/mocks/tauri/event.ts"),
+      "@tauri-apps/api/path": path.resolve(__dirname, "./src/test/mocks/tauri/path.ts"),
+      "@tauri-apps/plugin-dialog": path.resolve(__dirname, "./src/test/mocks/tauri/dialog.ts"),
+      "@tauri-apps/plugin-fs": path.resolve(__dirname, "./src/test/mocks/tauri/fs.ts"),
+      "@tauri-apps/plugin-notification": path.resolve(__dirname, "./src/test/mocks/tauri/plugins/notification.ts"),
+      "@tauri-apps/plugin-os": path.resolve(__dirname, "./src/test/mocks/tauri/plugins/os.ts"),
+      "@tauri-apps/plugin-store": path.resolve(__dirname, "./src/test/mocks/tauri/store.ts"),
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- add a dedicated Bot AI Headless GitHub Actions workflow for Telegram bot-first, AI review, Rust adapter glue, and CLI headless tests
- add `test:bot-ai` backed by a standalone Vitest config with bounded workers and a separate JUnit report
- run skip-safe Rust AI review smoke diagnostics in the dedicated workflow
- verify the local Windows Biome CLI after dependency install so lint-js fails with an actionable dependency diagnostic

## Validation
- bun run test:bot-ai
- bun run check:type
- bun run smoke:ai-review:rust
- node -e "import('js-yaml').then(({default: yaml}) => { const fs = require('node:fs'); yaml.load(fs.readFileSync('.github/workflows/bot-ai-headless.yml', 'utf8')); console.log('workflow yaml ok') })"
- git diff --check

Note: pwsh is not installed in this local environment, so the Windows PowerShell change is validated by inspection and the PR's Windows lint job.

Closes #245