### PR TITLE
B46: Add AI review observability metadata

### DIFF
--- a/docs/08_tasks/planned/ai-module-node-rust-orchestration.md
+++ b/docs/08_tasks/planned/ai-module-node-rust-orchestration.md
@@ -127,6 +127,19 @@ new NodeTelegramBotWorker({
 - Bot worker restarts: file-backed edit session and job store must recover active state.
 - CI instability hides real regressions: bot/AI tests need a small dedicated smoke path separate from the large frontend suite.
 
+## AI Review Observability Contract
+
+Operators should not need raw logs only to diagnose a review loop failure. The bot path persists redacted structured metadata at the same boundary where state recovery happens:
+
+- revision metadata records AI `provider`, `model`, `promptId`, validation/repair attempts, command types, structured diagnostics and changed areas;
+- revision observability records preview `renderJobId`, optional Rust/provider job id, artifact path/URL and Telegram preview delivery status;
+- session observability records the latest failed AI edit stage and validation errors;
+- session observability records final publish destination/status/provider id/URL/error without storing credentials.
+
+The review chat exposes the same high-signal fields through `/status` and `/versions`: revision id, provider/model, prompt id, attempts, render job id, artifact reference, publish status and failure reason. API keys, tokens, authorization headers, secrets, passwords and credentials are redacted before they are stored or rendered.
+
+Workflow-specific runbook details live in [Telegram AI Review Editing Workflow](./telegram-ai-review-workflow.md). Generic deployment topology, log retention and cleanup policies stay linked to B28/#225.
+
 ## PR Slices
 
 ### B39: Audit current AI module and broken headless flows
@@ -194,9 +207,9 @@ new NodeTelegramBotWorker({
 
 **GitHub:** [#246](https://github.com/chatman-media/timeline-studio/issues/246)
 
-- [ ] Document production env variables and safe defaults.
-- [ ] Add structured logs for session id, revision id, planner/editor provider and Rust command status.
-- [ ] Add runbook for retrying failed preview/publish without losing approved revision.
+- [x] Document production config boundaries and safe defaults in the workflow-specific runbook.
+- [x] Add structured session/revision diagnostics for prompt id, provider/model, validation errors, repair attempts, render job id, artifact path and publish result.
+- [x] Add runbook guidance for retrying failed AI edit, preview delivery/render and publish without losing the approved revision.
 
 ## Acceptance Criteria
 

--- a/docs/08_tasks/planned/telegram-ai-review-workflow.md
+++ b/docs/08_tasks/planned/telegram-ai-review-workflow.md
@@ -127,6 +127,35 @@ Runtime должен использовать B28 deployment foundation для t
 - final publish: `NodeRustPublishService` (`timeline publish telegram|youtube --json`) as production path, `NodePublishService` only as simple fallback/test adapter.
 - capabilities: real configured destinations are `file`, `telegram`, `youtube`; `tiktok` and `vimeo` stay visible as unsupported until Rust publish support exists.
 
+### Runtime observability
+
+AI review runtime stores machine-readable diagnostics in edit session metadata and revision metadata. The operator entry points are the session store JSON plus `/status` and `/versions` in the review chat.
+
+Revision metadata includes:
+
+- `metadata.editor`: redacted AI editor metadata, including `provider`, `model`, `promptId`, finish reason, token usage and repair attempt when available;
+- `metadata.observability.aiEditor`: the same redacted editor identity for status/version output;
+- `metadata.observability.attempts`: validation/repair attempt count for the accepted revision;
+- `metadata.observability.diagnostics`: structured AI diagnostics with `level`, `code`, `message` and `path`;
+- `metadata.observability.renderPreview`: `renderJobId`, optional `providerJobId`, render status, artifact path/URL and MIME type;
+- `metadata.observability.previewDelivery`: Telegram preview delivery status, sent message id or fallback/error detail.
+
+Session metadata includes:
+
+- `metadata.observability.lastError`: failed stage (`ai_edit_validation` or `ai_edit_exception`), update id, source message id and validation errors;
+- `metadata.observability.lastPublish`: destination, publish status, provider id, URL/error and artifact path/URL.
+
+`/status` shows session status, latest revisions, publish result and failure reason. `/versions` lists revision ids with editor provider/model, prompt id, attempt count, render job id and artifact reference. Sensitive fields such as API keys, tokens, authorization headers, secrets and credentials are redacted before metadata is stored or rendered into responses.
+
+Operational checks:
+
+```bash
+bun run test:bot-ai
+bun run smoke:ai-review:rust
+```
+
+For production polling, keep model/provider and secret config at process/env/service-manager boundaries. Do not put raw provider credentials into edit session store metadata or issue/test output. Generic log retention, deployment topology and cleanup policies remain owned by B28/#225.
+
 ### Failure recovery checks
 
 - Worker restart: smoke reloads the active session from `NodeBotEditSessionFileStore`.
@@ -135,6 +164,13 @@ Runtime должен использовать B28 deployment foundation для t
 - Transcription failure: worker returns a failed edit session/result when voice feedback cannot be transcribed.
 - Preview delivery failure: B37 tests verify failed Telegram `sendVideo` preserves artifact path and sends fallback text.
 - Publish failure: approval path records failed publish result on the edit session and leaves the approved revision id intact.
+
+Retry guidance:
+
+- Failed AI validation/exception: inspect `metadata.observability.lastError`, keep the last valid revision, then send a corrected text/voice instruction after restoring the session to `preview_ready` if the operator decides to continue the review.
+- Failed preview render: use `metadata.observability.renderPreview.renderJobId` and the Rust render command/status output to diagnose. The last accepted revision remains in history; rerun render from its `projectSchema` rather than applying a new edit.
+- Failed Telegram preview delivery: use `metadata.observability.previewDelivery.artifactPath` and resend manually or let the fallback message provide the local artifact path.
+- Failed publish after approval: keep `approvedRevisionId` unchanged, inspect `publishResult` and `metadata.observability.lastPublish`, fix destination credentials/capability, then retry publish for the approved revision artifact.
 
 ## PR slices
 

--- a/src/adapters/node/__tests__/ai-project-editor.test.ts
+++ b/src/adapters/node/__tests__/ai-project-editor.test.ts
@@ -29,7 +29,14 @@ describe("NodeAIProjectEditor", () => {
                 },
               ],
               diagnostics: [{ level: "info", message: "Edit applied.", code: "edit_applied" }],
-              metadata: { changedClipCount: 1 },
+              metadata: {
+                changedClipCount: 1,
+                apiKey: "provider-secret",
+                nested: {
+                  accessToken: "nested-secret",
+                  safe: "kept",
+                },
+              },
             }),
           },
           finish_reason: "stop",
@@ -78,10 +85,17 @@ describe("NodeAIProjectEditor", () => {
           model: "editor-model",
           promptId: "ai-project-editor/v1",
           changedClipCount: 1,
+          apiKey: "[redacted]",
+          nested: {
+            accessToken: "[redacted]",
+            safe: "kept",
+          },
           usage: { prompt_tokens: 10, completion_tokens: 20 },
         }),
       },
     })
+    expect(JSON.stringify(result)).not.toContain("provider-secret")
+    expect(JSON.stringify(result)).not.toContain("nested-secret")
     expect(fetch).toHaveBeenCalledWith(
       "https://llm.example/v1/chat/completions",
       expect.objectContaining({

--- a/src/adapters/node/__tests__/telegram-bot-worker.test.ts
+++ b/src/adapters/node/__tests__/telegram-bot-worker.test.ts
@@ -961,6 +961,68 @@ describe("Telegram bot worker", () => {
     })
   })
 
+  it("records structured observability when AI edit validation fails", async () => {
+    const { service, runTelegramLikePayload } = createWorkflowService(completedResult)
+    const session = createReviewSession()
+    const { store, records } = createEditSessionStore([session])
+    const worker = new NodeTelegramBotWorker({
+      workflow: service,
+      editSessionStore: store,
+      aiProjectEditor: new MockAIProjectEditor({
+        edit: () => ({
+          nextProject: { invalid: true } as never,
+          summary: "",
+          changedAreas: [],
+          commands: [],
+          diagnostics: [],
+          metadata: {
+            apiKey: "editor-secret",
+          },
+        }),
+      }),
+      now: () => "2026-06-08T08:00:11.000Z",
+    })
+
+    const result = await worker.handleUpdate({
+      update_id: 63,
+      message: {
+        message_id: 49,
+        chat: { id: "chat-1" },
+        from: { id: "user-1" },
+        text: "make it shorter",
+      },
+    })
+
+    expect(result).toMatchObject({
+      skipped: true,
+      reviewAction: "failed",
+      editSession: {
+        status: "failed",
+        failure: expect.stringContaining("version must be a non-empty string"),
+        metadata: {
+          observability: {
+            lastError: {
+              stage: "ai_edit_validation",
+              sessionId: session.id,
+              updateId: 63,
+              sourceMessageId: "49",
+              errors: expect.arrayContaining([
+                expect.objectContaining({
+                  code: "invalid_project",
+                  field: "nextProject",
+                  message: "version must be a non-empty string",
+                }),
+              ]),
+            },
+          },
+        },
+      },
+    })
+    expect(records.get(session.id)?.revisions).toHaveLength(1)
+    expect(runTelegramLikePayload).not.toHaveBeenCalled()
+    expect(JSON.stringify(records.get(session.id))).not.toContain("editor-secret")
+  })
+
   it("transcribes voice feedback before applying a preview-ready edit", async () => {
     const { service, runTelegramLikePayload } = createWorkflowService(completedResult)
     const session = createReviewSession()
@@ -1027,6 +1089,11 @@ describe("Telegram bot worker", () => {
         path: "/tmp/revision-1.mp4",
         destination: "file" as const,
         mimeType: "video/mp4",
+        metadata: {
+          renderJobId: "preview-job-1",
+          providerJobId: "rust-preview-job-1",
+          renderJobStatus: "done",
+        },
       })),
     }
     const previewResponder = {
@@ -1065,6 +1132,19 @@ describe("Telegram bot worker", () => {
             messageId: "preview-message-1",
             artifactPath: "/tmp/revision-1.mp4",
           },
+          observability: {
+            renderPreview: {
+              renderJobId: "preview-job-1",
+              providerJobId: "rust-preview-job-1",
+              renderJobStatus: "done",
+              artifactPath: "/tmp/revision-1.mp4",
+            },
+            previewDelivery: {
+              status: "sent",
+              messageId: "preview-message-1",
+              artifactPath: "/tmp/revision-1.mp4",
+            },
+          },
         },
       },
     })
@@ -1099,6 +1179,19 @@ describe("Telegram bot worker", () => {
           status: "sent",
           messageId: "preview-message-1",
           artifactPath: "/tmp/revision-1.mp4",
+        },
+        observability: {
+          renderPreview: {
+            renderJobId: "preview-job-1",
+            providerJobId: "rust-preview-job-1",
+            renderJobStatus: "done",
+            artifactPath: "/tmp/revision-1.mp4",
+          },
+          previewDelivery: {
+            status: "sent",
+            messageId: "preview-message-1",
+            artifactPath: "/tmp/revision-1.mp4",
+          },
         },
       },
     })
@@ -1176,6 +1269,52 @@ describe("Telegram bot worker", () => {
   it("shows active edit session status and versions", async () => {
     const { service, runTelegramLikePayload } = createWorkflowService(completedResult)
     const session = createReviewSession()
+    session.publishResult = {
+      destination: "telegram",
+      status: "failed",
+      error: "missing auth",
+      metadata: {
+        provider: {
+          apiKey: "publish-secret",
+        },
+      },
+    }
+    session.revisions = [
+      {
+        ...session.revisions[0],
+        artifact: {
+          type: "file",
+          path: "/tmp/revision-0.mp4",
+          destination: "file",
+          metadata: {
+            apiKey: "artifact-secret",
+          },
+        },
+        metadata: {
+          attempts: 2,
+          editor: {
+            provider: "openai-compatible",
+            model: "gpt-4o-mini",
+            promptId: "ai-project-editor/v1",
+            apiKey: "editor-secret",
+          },
+          observability: {
+            attempts: 2,
+            aiEditor: {
+              provider: "openai-compatible",
+              model: "gpt-4o-mini",
+              promptId: "ai-project-editor/v1",
+              apiKey: "[redacted]",
+            },
+            renderPreview: {
+              renderJobId: "preview-job-0",
+              providerJobId: "rust-preview-job-0",
+              artifactPath: "/tmp/revision-0.mp4",
+            },
+          },
+        },
+      },
+    ]
     const { store } = createEditSessionStore([session])
     const commandResponder = {
       sendMessage: vi.fn(async () => ({ messageId: "status-message-2" })),
@@ -1237,6 +1376,19 @@ describe("Telegram bot worker", () => {
         command: "versions",
       },
     })
+    const sendMessageCalls = commandResponder.sendMessage.mock.calls as unknown as Array<[{ text: string }]>
+    const statusText = String(sendMessageCalls[0]?.[0].text)
+    const versionsText = String(sendMessageCalls[1]?.[0].text)
+    expect(statusText).toContain("Publish: failed to telegram")
+    expect(statusText).toContain("editor=openai-compatible/gpt-4o-mini")
+    expect(statusText).toContain("prompt=ai-project-editor/v1")
+    expect(statusText).toContain("attempts=2")
+    expect(statusText).toContain("render=preview-job-0")
+    expect(versionsText).toContain("editor=openai-compatible/gpt-4o-mini")
+    expect(versionsText).toContain("render=preview-job-0")
+    expect(`${statusText}\n${versionsText}`).not.toContain("editor-secret")
+    expect(`${statusText}\n${versionsText}`).not.toContain("artifact-secret")
+    expect(`${statusText}\n${versionsText}`).not.toContain("publish-secret")
     expect(runTelegramLikePayload).not.toHaveBeenCalled()
   })
 

--- a/src/adapters/node/__tests__/telegram-review-preview-renderer.test.ts
+++ b/src/adapters/node/__tests__/telegram-review-preview-renderer.test.ts
@@ -28,6 +28,7 @@ describe("NodeTelegramRenderJobReviewPreviewRenderer", () => {
     const run = vi.fn(async (_request: BotRenderJobRequest, _options?: BotRenderJobRunOptions) => ({
       job: {
         id: "preview-job-1",
+        providerJobId: "rust-preview-job-1",
         status: "done" as const,
         progress: 100,
         request: _request,
@@ -53,7 +54,17 @@ describe("NodeTelegramRenderJobReviewPreviewRenderer", () => {
         update: { update_id: 10 },
         payload: { message_id: 20, chat: { id: "chat-1" } },
       }),
-    ).resolves.toEqual(artifact)
+    ).resolves.toEqual({
+      ...artifact,
+      metadata: {
+        renderJobId: "preview-job-1",
+        providerJobId: "rust-preview-job-1",
+        renderJobStatus: "done",
+        reviewSessionId: "edit:telegram:chat-1:user-1",
+        reviewRevisionId: "revision-1",
+        artifactPath: path.join(tempDir, "session-1-r1.mp4"),
+      },
+    })
 
     expect(run).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/adapters/node/ai-project-editor.ts
+++ b/src/adapters/node/ai-project-editor.ts
@@ -9,6 +9,7 @@ import {
   validateAIProjectEditResult,
 } from "@/core"
 import type { ProjectSchema } from "@/types/contracts/project-schema"
+import { redactSensitiveMetadata } from "./sensitive-metadata"
 
 export type NodeAIProjectEditorFetch = typeof fetch
 
@@ -303,13 +304,13 @@ export class NodeAIProjectEditor implements IAIProjectEditor {
               },
             ],
       diagnostics: normalizeDiagnostics(value.diagnostics),
-      metadata: {
+      metadata: redactSensitiveMetadata({
+        ...(isRecord(value.metadata) ? value.metadata : {}),
+        ...metadata,
         provider: this.provider,
         model: this.model,
         promptId: this.promptId,
-        ...metadata,
-        ...(isRecord(value.metadata) ? value.metadata : {}),
-      },
+      }),
     }
   }
 

--- a/src/adapters/node/sensitive-metadata.ts
+++ b/src/adapters/node/sensitive-metadata.ts
@@ -1,0 +1,38 @@
+const REDACTED_VALUE = "[redacted]"
+const SENSITIVE_METADATA_KEY_PATTERN = /api[_-]?key|secret|password|authorization|bearer|credential/i
+
+export function redactSensitiveMetadata<T>(value: T): T {
+  return redactSensitiveValue(value) as T
+}
+
+function redactSensitiveValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => redactSensitiveValue(item))
+  }
+
+  if (!isPlainRecord(value)) {
+    return value
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, child]) => [
+      key,
+      isSensitiveMetadataKey(key) ? REDACTED_VALUE : redactSensitiveValue(child),
+    ]),
+  )
+}
+
+function isSensitiveMetadataKey(key: string): boolean {
+  const normalized = key.toLowerCase()
+  return (
+    SENSITIVE_METADATA_KEY_PATTERN.test(key) ||
+    normalized === "token" ||
+    normalized.endsWith("token") ||
+    normalized.endsWith("_token") ||
+    normalized.endsWith("-token")
+  )
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/src/adapters/node/telegram-bot-worker.ts
+++ b/src/adapters/node/telegram-bot-worker.ts
@@ -4,6 +4,7 @@ import type { AIProjectEditorResult, IAIProjectEditor, IBotFeedbackTranscriber, 
 import {
   createBotDestinationCapabilityRegistry,
   createBotEditRevisionId,
+  createBotEditSessionId,
   createBotWorkflowDraftId,
   createTelegramLikeBotWorkflow,
   mergeBotEditSessionWorkflow,
@@ -31,6 +32,7 @@ import type { ProjectSchema } from "@/types/contracts/project-schema"
 
 import { NodeBotStatusNotifier, type NodeTelegramStatusClient, type NodeTelegramVideoClient } from "./bot-status"
 import type { NodeBotWorkflowService, NodeBotWorkflowServiceOptions } from "./bot-workflow"
+import { redactSensitiveMetadata } from "./sensitive-metadata"
 import type { NodeTelegramBotWorkflowJobRecord, NodeTelegramBotWorkflowJobStore } from "./telegram-bot-job-store"
 
 export interface TelegramBotFile {
@@ -1318,27 +1320,40 @@ export class NodeTelegramBotWorker {
         error: formatUnknownError(error),
       }
     }
+    const sanitizedPublishResult = redactSensitiveMetadata(publishResult)
 
     const publishedTimestamp = this.now()
     const publishedSession: BotEditSession = {
       ...publishingSession,
-      status: publishResult.status === "done" ? "done" : "failed",
-      publishResult,
-      ...(publishResult.status === "done" ? { publishedAt: publishedTimestamp } : { failedAt: publishedTimestamp }),
-      ...(publishResult.status !== "done" ? { failure: publishResult.error ?? "Publishing failed" } : {}),
+      status: sanitizedPublishResult.status === "done" ? "done" : "failed",
+      publishResult: sanitizedPublishResult,
+      ...(sanitizedPublishResult.status === "done"
+        ? { publishedAt: publishedTimestamp }
+        : { failedAt: publishedTimestamp }),
+      ...(sanitizedPublishResult.status !== "done"
+        ? { failure: sanitizedPublishResult.error ?? "Publishing failed" }
+        : {}),
+      metadata: mergeMetadataObservability(publishingSession.metadata, {
+        lastPublish: createPublishObservability({
+          session,
+          revision,
+          result: sanitizedPublishResult,
+          timestamp: publishedTimestamp,
+        }),
+      }),
       updatedAt: publishedTimestamp,
     }
     await this.options.editSessionStore?.writeSession(publishedSession)
 
     return this.createReviewSkippedResult({
-      action: publishResult.status === "done" ? "published" : "failed",
+      action: sanitizedPublishResult.status === "done" ? "published" : "failed",
       command,
       session: publishedSession,
       revision,
       payload,
       update,
-      publishResult,
-      message: publishResult.error,
+      publishResult: sanitizedPublishResult,
+      message: sanitizedPublishResult.error,
     })
   }
 
@@ -1499,7 +1514,23 @@ export class NodeTelegramBotWorker {
       })
 
       if (!edit.ok) {
-        const failedSession = this.failEditSession(editingSession, edit.errors.map((error) => error.message).join("; "))
+        const failedSession = this.failEditSession(
+          editingSession,
+          edit.errors.map((error) => error.message).join("; "),
+          {
+            lastError: {
+              stage: "ai_edit_validation",
+              sessionId: session.id,
+              updateId: update.update_id,
+              ...(payload.message_id !== undefined ? { sourceMessageId: String(payload.message_id) } : {}),
+              errors: edit.errors.map((error) => ({
+                code: error.code,
+                field: error.field,
+                message: error.message,
+              })),
+            },
+          },
+        )
         await this.options.editSessionStore?.writeSession(failedSession)
         return this.createReviewSkippedResult({
           action: "failed",
@@ -1528,12 +1559,19 @@ export class NodeTelegramBotWorker {
           update,
           payload,
         })
+        const previewRenderedAt = this.now()
         revision = {
           ...revision,
           artifact,
-          metadata: mergeRevisionMetadata(revision.metadata, {
-            previewRenderedAt: this.now(),
-          }),
+          metadata: mergeMetadataObservability(
+            revision.metadata,
+            {
+              renderPreview: createRenderPreviewObservability(artifact, previewRenderedAt),
+            },
+            {
+              previewRenderedAt,
+            },
+          ),
         }
       }
 
@@ -1564,7 +1602,15 @@ export class NodeTelegramBotWorker {
         feedbackText: instruction,
       })
     } catch (error) {
-      const failedSession = this.failEditSession(editingSession, formatUnknownError(error))
+      const failedSession = this.failEditSession(editingSession, formatUnknownError(error), {
+        lastError: {
+          stage: "ai_edit_exception",
+          sessionId: session.id,
+          updateId: update.update_id,
+          ...(payload.message_id !== undefined ? { sourceMessageId: String(payload.message_id) } : {}),
+          error: formatUnknownError(error),
+        },
+      })
       await this.options.editSessionStore?.writeSession(failedSession)
       return this.createReviewSkippedResult({
         action: "failed",
@@ -1577,13 +1623,18 @@ export class NodeTelegramBotWorker {
     }
   }
 
-  private failEditSession(session: BotEditSession, failure: string): BotEditSession {
+  private failEditSession(
+    session: BotEditSession,
+    failure: string,
+    observabilityPatch?: Record<string, unknown>,
+  ): BotEditSession {
     const timestamp = this.now()
     return {
       ...session,
       status: "failed",
       failedAt: timestamp,
       failure,
+      ...(observabilityPatch ? { metadata: mergeMetadataObservability(session.metadata, observabilityPatch) } : {}),
       updatedAt: timestamp,
     }
   }
@@ -1732,40 +1783,37 @@ export class NodeTelegramBotWorker {
             revisionId: revision.id,
           },
         })
+        const previewDelivery = {
+          status: "sent",
+          messageId: sent.messageId,
+          artifactPath: artifact.path,
+        }
         return {
           ...revision,
-          metadata: mergeRevisionMetadata(revision.metadata, {
-            previewDelivery: {
-              status: "sent",
-              messageId: sent.messageId,
-              artifactPath: artifact.path,
-            },
-          }),
+          metadata: mergeMetadataObservability(revision.metadata, { previewDelivery }, { previewDelivery }),
         }
       } catch (error) {
         await this.sendReviewPreviewFallback(responder, chatId, payload, revision, formatUnknownError(error))
+        const previewDelivery = {
+          status: "failed",
+          error: formatUnknownError(error),
+          artifactPath: artifact.path,
+        }
         return {
           ...revision,
-          metadata: mergeRevisionMetadata(revision.metadata, {
-            previewDelivery: {
-              status: "failed",
-              error: formatUnknownError(error),
-              artifactPath: artifact.path,
-            },
-          }),
+          metadata: mergeMetadataObservability(revision.metadata, { previewDelivery }, { previewDelivery }),
         }
       }
     }
 
     await this.sendReviewPreviewFallback(responder, chatId, payload, revision)
+    const previewDelivery = {
+      status: "fallback_message",
+      artifact: artifact.url ?? artifact.path,
+    }
     return {
       ...revision,
-      metadata: mergeRevisionMetadata(revision.metadata, {
-        previewDelivery: {
-          status: "fallback_message",
-          artifact: artifact.url ?? artifact.path,
-        },
-      }),
+      metadata: mergeMetadataObservability(revision.metadata, { previewDelivery }, { previewDelivery }),
     }
   }
 
@@ -1906,6 +1954,9 @@ export class NodeTelegramBotWorker {
       ...(workflowResult.workflow.userId ? { userId: workflowResult.workflow.userId } : {}),
       activeOnly: true,
     })
+    const sessionId = existing?.id ?? createBotEditSessionId(workflowResult.workflow)
+    const revisionIndex = existing?.revisionCounter ?? 0
+    const revisionId = createBotEditRevisionId(sessionId, revisionIndex)
     const session = mergeBotEditSessionWorkflow(existing, workflowResult.workflow, {
       now: () => timestamp,
       status: "preview_ready",
@@ -1925,12 +1976,22 @@ export class NodeTelegramBotWorker {
           source: "telegram-bot-worker",
           renderJobId: workflowResult.result.job.id,
           approvalGate: workflowResult.approvalGate,
+          observability: {
+            sessionId,
+            revisionId,
+            revisionIndex,
+            renderPreview: createRenderPreviewObservability(artifact, timestamp, workflowResult.result.job.id),
+          },
         },
       },
       metadata: {
         source: "telegram-bot-worker",
         renderJobId: workflowResult.result.job.id,
         approvalGate: workflowResult.approvalGate,
+        observability: {
+          sessionId,
+          renderPreview: createRenderPreviewObservability(artifact, timestamp, workflowResult.result.job.id),
+        },
       },
     })
 
@@ -2765,6 +2826,8 @@ function formatBotEditSessionStatusMessage(session: BotEditSession | undefined):
     "Timeline Studio bot",
     formatBotEditSessionStatus(session),
     ...(session.goal ? [`Goal: ${truncateStatusText(session.goal)}`] : []),
+    ...(session.publishResult ? [formatBotEditSessionPublishLine(session.publishResult)] : []),
+    ...(session.failure ? [`Failure: ${truncateStatusText(session.failure)}`] : []),
     ...(session.revisions.length > 0 ? ["Recent revisions:", ...formatRecentBotEditRevisionLines(session)] : []),
   ].join("\n")
 }
@@ -2797,8 +2860,17 @@ function formatRecentBotEditRevisionLines(session: BotEditSession, limit = 5): s
 function formatBotEditRevisionLine(revision: BotEditRevision): string {
   const details = [`#${revision.index}`, revision.id]
   if (revision.summary) details.push(truncateStatusText(revision.summary))
+  const observability = readRevisionObservability(revision)
+  const editor = readRevisionEditorMetadata(revision)
+  const editorLine = formatRevisionEditorLine(editor)
+  if (editorLine) details.push(editorLine)
+  const attempts = readNumericMetadataValue(observability?.attempts ?? revision.metadata?.attempts)
+  if (attempts !== undefined) details.push(`attempts=${attempts}`)
+  const renderJobId = readStringMetadataValue(observability?.renderPreview, "renderJobId")
+  if (renderJobId) details.push(`render=${renderJobId}`)
   if (revision.artifact?.url) details.push(revision.artifact.url)
   else if (revision.artifact?.path) details.push(revision.artifact.path)
+  if (revision.diagnostics?.[0]) details.push(`diag=${truncateStatusText(revision.diagnostics[0])}`)
   return details.join(": ")
 }
 
@@ -2811,8 +2883,10 @@ function createAppliedEditRevision(context: {
   timestamp: string
 }): BotEditRevision {
   const index = context.session.revisionCounter
+  const id = createBotEditRevisionId(context.session.id, index)
+  const editorMetadata = context.result.metadata ? redactSensitiveMetadata(context.result.metadata) : undefined
   return {
-    id: createBotEditRevisionId(context.session.id, index),
+    id,
     index,
     projectSchema: context.result.nextProject,
     instruction: context.instruction,
@@ -2823,9 +2897,17 @@ function createAppliedEditRevision(context: {
     createdAt: context.timestamp,
     updatedAt: context.timestamp,
     metadata: {
-      commands: context.result.commands,
+      commands: redactSensitiveMetadata(context.result.commands),
       attempts: context.attempts,
-      ...(context.result.metadata ? { editor: context.result.metadata } : {}),
+      ...(editorMetadata ? { editor: editorMetadata } : {}),
+      observability: createAIEditObservability({
+        session: context.session,
+        revisionId: id,
+        revisionIndex: index,
+        result: context.result,
+        attempts: context.attempts,
+        sourceMessageId: context.sourceMessageId,
+      }),
     },
   }
 }
@@ -2854,6 +2936,136 @@ function mergeRevisionMetadata(
     ...(base ?? {}),
     ...patch,
   }
+}
+
+function mergeMetadataObservability(
+  base: Record<string, unknown> | undefined,
+  observabilityPatch: Record<string, unknown>,
+  patch: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return mergeRevisionMetadata(base, {
+    ...patch,
+    observability: {
+      ...asRecord(base?.observability),
+      ...redactSensitiveMetadata(observabilityPatch),
+    },
+  })
+}
+
+function createAIEditObservability(context: {
+  session: BotEditSession
+  revisionId: string
+  revisionIndex: number
+  result: AIProjectEditorResult
+  attempts: number
+  sourceMessageId?: string | number
+}): Record<string, unknown> {
+  return redactSensitiveMetadata({
+    sessionId: context.session.id,
+    revisionId: context.revisionId,
+    revisionIndex: context.revisionIndex,
+    stage: "ai_edit",
+    ...(context.sourceMessageId !== undefined ? { sourceMessageId: String(context.sourceMessageId) } : {}),
+    ...(context.result.metadata ? { aiEditor: context.result.metadata } : {}),
+    attempts: context.attempts,
+    commandTypes: context.result.commands.map((command) => command.type),
+    changedAreas: context.result.changedAreas,
+    diagnostics: context.result.diagnostics.map((diagnostic) => ({
+      level: diagnostic.level,
+      message: diagnostic.message,
+      ...(diagnostic.code ? { code: diagnostic.code } : {}),
+      ...(diagnostic.path ? { path: diagnostic.path } : {}),
+    })),
+  })
+}
+
+function createRenderPreviewObservability(
+  artifact: BotRenderJobArtifact,
+  renderedAt: string,
+  renderJobId?: string,
+): Record<string, unknown> {
+  const artifactMetadata = asRecord(artifact.metadata)
+  return redactSensitiveMetadata({
+    ...(readStringMetadataValue(artifactMetadata, "renderJobId") || renderJobId
+      ? { renderJobId: readStringMetadataValue(artifactMetadata, "renderJobId") ?? renderJobId }
+      : {}),
+    ...(readStringMetadataValue(artifactMetadata, "providerJobId")
+      ? { providerJobId: readStringMetadataValue(artifactMetadata, "providerJobId") }
+      : {}),
+    ...(readStringMetadataValue(artifactMetadata, "renderJobStatus")
+      ? { renderJobStatus: readStringMetadataValue(artifactMetadata, "renderJobStatus") }
+      : {}),
+    renderedAt,
+    destination: artifact.destination,
+    ...(artifact.path ? { artifactPath: artifact.path } : {}),
+    ...(artifact.url ? { artifactUrl: artifact.url } : {}),
+    ...(artifact.mimeType ? { mimeType: artifact.mimeType } : {}),
+  })
+}
+
+function createPublishObservability(context: {
+  session: BotEditSession
+  revision: BotEditRevision
+  result: BotPublishResult
+  timestamp: string
+}): Record<string, unknown> {
+  return redactSensitiveMetadata({
+    sessionId: context.session.id,
+    revisionId: context.revision.id,
+    destination: context.result.destination,
+    status: context.result.status,
+    publishedAt: context.timestamp,
+    ...(context.result.providerId ? { providerId: context.result.providerId } : {}),
+    ...(context.result.url ? { url: context.result.url } : {}),
+    ...(context.result.error ? { error: context.result.error } : {}),
+    ...(context.result.artifact?.path ? { artifactPath: context.result.artifact.path } : {}),
+    ...(context.result.artifact?.url ? { artifactUrl: context.result.artifact.url } : {}),
+  })
+}
+
+function readRevisionObservability(revision: BotEditRevision): Record<string, unknown> | undefined {
+  return asRecord(revision.metadata?.observability)
+}
+
+function readRevisionEditorMetadata(revision: BotEditRevision): Record<string, unknown> | undefined {
+  const observabilityEditor = asRecord(readRevisionObservability(revision)?.aiEditor)
+  if (observabilityEditor) return observabilityEditor
+  return asRecord(revision.metadata?.editor)
+}
+
+function formatRevisionEditorLine(editor: Record<string, unknown> | undefined): string | undefined {
+  if (!editor) return undefined
+  const provider = readStringMetadataValue(editor, "provider")
+  const model = readStringMetadataValue(editor, "model")
+  const promptId = readStringMetadataValue(editor, "promptId")
+  const details: string[] = []
+  if (provider || model) details.push(`editor=${[provider, model].filter(Boolean).join("/")}`)
+  if (promptId) details.push(`prompt=${promptId}`)
+  return details.length > 0 ? details.join(" ") : undefined
+}
+
+function formatBotEditSessionPublishLine(result: BotPublishResult): string {
+  const details = [`Publish: ${result.status} to ${result.destination}`]
+  if (result.providerId) details.push(`provider=${result.providerId}`)
+  if (result.url) details.push(result.url)
+  if (result.error) details.push(`error=${truncateStatusText(result.error)}`)
+  return details.join(", ")
+}
+
+function readStringMetadataValue(value: unknown, key: string): string | undefined {
+  const record = asRecord(value)
+  const field = record?.[key]
+  return typeof field === "string" && field.length > 0 ? field : undefined
+}
+
+function readNumericMetadataValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined
 }
 
 function readInlineProjectSchema(project: BotRenderJobProjectInput | undefined): unknown | undefined {

--- a/src/adapters/node/telegram-review-preview-renderer.ts
+++ b/src/adapters/node/telegram-review-preview-renderer.ts
@@ -58,7 +58,19 @@ export class NodeTelegramRenderJobReviewPreviewRenderer implements NodeTelegramB
       throw new Error("Preview render completed without an artifact")
     }
 
-    return result.job.artifact
+    return {
+      ...result.job.artifact,
+      metadata: {
+        ...(isRecord(result.job.artifact.metadata) ? result.job.artifact.metadata : {}),
+        renderJobId: result.job.id,
+        ...(result.job.providerJobId ? { providerJobId: result.job.providerJobId } : {}),
+        renderJobStatus: result.job.status,
+        reviewSessionId: context.session.id,
+        reviewRevisionId: context.revision.id,
+        ...(result.job.artifact.path ? { artifactPath: result.job.artifact.path } : {}),
+        ...(result.job.artifact.url ? { artifactUrl: result.job.artifact.url } : {}),
+      },
+    }
   }
 }
 
@@ -71,4 +83,8 @@ function createRenderRunOptions(options: NodeTelegramRenderJobReviewPreviewRende
 
 function sanitizeFileSegment(value: string): string {
   return value.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "preview"
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
 }

--- a/src/core/types/render-job.ts
+++ b/src/core/types/render-job.ts
@@ -54,6 +54,7 @@ export interface BotRenderJobArtifact {
   url?: string
   destination: BotRenderJobDestination
   mimeType?: string
+  metadata?: Record<string, unknown>
 }
 
 export interface BotPublishMetadata {


### PR DESCRIPTION
## Summary
- add redacted AI review metadata for editor provider/model/prompt, attempts, diagnostics, render preview jobs, preview delivery, and publish result
- surface operator fields in Telegram /status and /versions without dumping raw metadata
- document the runtime observability/runbook flow for B46

## Verification
- bunx vitest run src/adapters/node/__tests__/ai-project-editor.test.ts src/adapters/node/__tests__/telegram-review-preview-renderer.test.ts src/adapters/node/__tests__/telegram-bot-worker.test.ts
- bun run check:type
- bun run test:bot-ai
- bun run smoke:ai-review:rust
- bunx biome check src/adapters/node/sensitive-metadata.ts src/adapters/node/ai-project-editor.ts src/adapters/node/telegram-review-preview-renderer.ts src/adapters/node/telegram-bot-worker.ts src/core/types/render-job.ts src/adapters/node/__tests__/ai-project-editor.test.ts src/adapters/node/__tests__/telegram-review-preview-renderer.test.ts src/adapters/node/__tests__/telegram-bot-worker.test.ts
- git diff --check

Closes #246