### PR TITLE
B42: Enable AI edit repair attempts in bot runtime

### DIFF
--- a/docs/08_tasks/planned/ai-module-node-rust-orchestration.md
+++ b/docs/08_tasks/planned/ai-module-node-rust-orchestration.md
@@ -176,6 +176,7 @@ Workflow-specific runbook details live in [Telegram AI Review Editing Workflow](
 - [ ] Align Rust `montage-plan` output with TS `ProjectSchema` or add a typed wrapper converter.
 - [ ] Align Rust `llm-plan` prompt/output with TS `ProjectSchema`.
 - [ ] Add explicit diagnostics when first-cut falls back to deterministic assembly.
+- [x] Enable bounded AI editor repair attempts in the Telegram review runtime with CLI/env configuration.
 - [ ] Add fixtures for planner valid/invalid output.
 
 ### B43: Wire Telegram bot-worker runtime to real AI review services

--- a/docs/08_tasks/planned/telegram-ai-review-workflow.md
+++ b/docs/08_tasks/planned/telegram-ai-review-workflow.md
@@ -123,6 +123,7 @@ Runtime должен использовать B28 deployment foundation для t
 - first cut: `DefaultBotFirstCutGenerator` with `NodeRustFirstCutPlanner` when `timeline montage-plan` / `timeline llm-plan` is configured;
 - feedback transcription: `NodeBotFeedbackTranscriber` backed by OpenAI Whisper or local transcription;
 - AI project edit: `IAIProjectEditor` implementation, mock in smoke, Node/OpenAI-compatible production adapter behind the same port short-term, and Rust `timeline llm-plan` extension as the Rust-first planner/editor strategy;
+- AI edit repair: `--ai-editor-repair-attempts` / `TIMELINE_BOT_AI_EDITOR_REPAIR_ATTEMPTS`, default `1`, bounds invalid editor output repair before a revision is accepted; set `0` to disable repair.
 - preview delivery: `NodeBotStatusNotifier.sendVideo` for Telegram review previews, fallback message keeps local artifact path;
 - final publish: `NodeRustPublishService` (`timeline publish telegram|youtube --json`) as production path, `NodePublishService` only as simple fallback/test adapter.
 - capabilities: real configured destinations are `file`, `telegram`, `youtube`; `tiktok` and `vimeo` stay visible as unsupported until Rust publish support exists.

--- a/src/adapters/node/__tests__/telegram-bot-worker.test.ts
+++ b/src/adapters/node/__tests__/telegram-bot-worker.test.ts
@@ -4,7 +4,7 @@ import path from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { BotEditSession, BotEditSessionQuery, BotEditSessionStore } from "@/core"
 import { createBotProjectSchemaFromRenderJob } from "@/core"
-import type { IBotFeedbackTranscriber, IPublishService } from "@/core/ports"
+import type { IAIProjectEditor, IBotFeedbackTranscriber, IPublishService } from "@/core/ports"
 import type { BotWorkflowDraft, BotWorkflowRunResult } from "@/core/types"
 import { MockAIProjectEditor } from "../../mock/ai-project-editor"
 import type { NodeBotWorkflowService } from "../bot-workflow"
@@ -1021,6 +1021,117 @@ describe("Telegram bot worker", () => {
     expect(records.get(session.id)?.revisions).toHaveLength(1)
     expect(runTelegramLikePayload).not.toHaveBeenCalled()
     expect(JSON.stringify(records.get(session.id))).not.toContain("editor-secret")
+  })
+
+  it("repairs invalid AI edit output before accepting a review revision", async () => {
+    const { service, runTelegramLikePayload } = createWorkflowService(completedResult)
+    const session = createReviewSession()
+    const { store, records } = createEditSessionStore([session])
+    const repairedProject = createProjectSchema()
+    repairedProject.metadata.modified_at = "2026-06-08T08:00:12.000Z"
+    const aiProjectEditor: IAIProjectEditor = {
+      editProject: vi.fn(async () => ({
+        nextProject: session.currentProjectSchema as never,
+        summary: "",
+        changedAreas: [],
+        commands: [],
+        diagnostics: [],
+        metadata: {
+          provider: "test-provider",
+          model: "broken-model",
+          promptId: "ai-project-editor/v1",
+        },
+      })),
+      repairProjectEdit: vi.fn(async (context) => ({
+        nextProject: repairedProject,
+        summary: "Repaired title card edit.",
+        changedAreas: ["project.metadata"],
+        commands: [
+          {
+            type: "custom" as const,
+            params: { instruction: context.request.userInstruction },
+            rationale: "Repair produced a valid ProjectSchema after validation failed.",
+          },
+        ],
+        diagnostics: [
+          {
+            level: "warning" as const,
+            code: "repair_applied",
+            message: "AI edit output was repaired after validation failed.",
+          },
+        ],
+        metadata: {
+          provider: "test-provider",
+          model: "repair-model",
+          promptId: "ai-project-editor/v1",
+          repairAttempt: context.attempt,
+        },
+      })),
+    }
+    const worker = new NodeTelegramBotWorker({
+      workflow: service,
+      editSessionStore: store,
+      aiProjectEditor,
+      aiProjectEditMaxRepairAttempts: 1,
+      now: () => "2026-06-08T08:00:12.000Z",
+    })
+
+    const result = await worker.handleUpdate({
+      update_id: 64,
+      message: {
+        message_id: 50,
+        chat: { id: "chat-1" },
+        from: { id: "user-1" },
+        text: "add a title card",
+      },
+    })
+
+    expect(result).toMatchObject({
+      skipped: true,
+      reviewAction: "feedback_applied",
+      editRevision: {
+        index: 1,
+        summary: "Repaired title card edit.",
+        diagnostics: ["warning: repair_applied: AI edit output was repaired after validation failed."],
+        metadata: {
+          attempts: 2,
+          editor: {
+            provider: "test-provider",
+            model: "repair-model",
+            promptId: "ai-project-editor/v1",
+            repairAttempt: 1,
+          },
+          observability: {
+            attempts: 2,
+            aiEditor: {
+              provider: "test-provider",
+              model: "repair-model",
+              promptId: "ai-project-editor/v1",
+              repairAttempt: 1,
+            },
+          },
+        },
+      },
+    })
+    expect(aiProjectEditor.repairProjectEdit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attempt: 1,
+        errors: expect.arrayContaining([
+          expect.objectContaining({ code: "missing_summary" }),
+          expect.objectContaining({ code: "missing_commands" }),
+        ]),
+      }),
+    )
+    expect(records.get(session.id)).toMatchObject({
+      status: "preview_ready",
+      revisionCounter: 2,
+      currentProjectSchema: repairedProject,
+      revisions: [
+        expect.objectContaining({ index: 0 }),
+        expect.objectContaining({ index: 1, projectSchema: repairedProject }),
+      ],
+    })
+    expect(runTelegramLikePayload).not.toHaveBeenCalled()
   })
 
   it("transcribes voice feedback before applying a preview-ready edit", async () => {

--- a/src/adapters/node/telegram-bot-worker.ts
+++ b/src/adapters/node/telegram-bot-worker.ts
@@ -120,6 +120,7 @@ export interface NodeTelegramBotWorkerOptions {
   workflowJobStore?: NodeTelegramBotWorkflowJobStore
   editSessionStore?: BotEditSessionStore
   aiProjectEditor?: IAIProjectEditor
+  aiProjectEditMaxRepairAttempts?: number
   feedbackTranscriber?: IBotFeedbackTranscriber
   publishService?: IPublishService
   previewRenderer?: NodeTelegramBotReviewPreviewRenderer
@@ -1492,26 +1493,32 @@ export class NodeTelegramBotWorker {
     await this.options.editSessionStore?.writeSession(editingSession)
 
     try {
-      const edit = await runAIProjectEdit(this.options.aiProjectEditor, {
-        currentProject: session.currentProjectSchema as ProjectSchema,
-        sourceMedia: session.media,
-        userInstruction: instruction,
-        ...((session.publishTarget ?? session.previewDestination)
-          ? { targetPlatform: session.publishTarget ?? session.previewDestination }
-          : {}),
-        revisionHistory: session.revisions.map((revision) => ({
-          id: revision.id,
-          index: revision.index,
-          ...(revision.instruction ? { instruction: revision.instruction } : {}),
-          ...(revision.summary ? { summary: revision.summary } : {}),
-          createdAt: revision.createdAt,
-        })),
-        metadata: {
-          sessionId: session.id,
-          updateId: update.update_id,
-          sourceMessageId: payload.message_id,
+      const edit = await runAIProjectEdit(
+        this.options.aiProjectEditor,
+        {
+          currentProject: session.currentProjectSchema as ProjectSchema,
+          sourceMedia: session.media,
+          userInstruction: instruction,
+          ...((session.publishTarget ?? session.previewDestination)
+            ? { targetPlatform: session.publishTarget ?? session.previewDestination }
+            : {}),
+          revisionHistory: session.revisions.map((revision) => ({
+            id: revision.id,
+            index: revision.index,
+            ...(revision.instruction ? { instruction: revision.instruction } : {}),
+            ...(revision.summary ? { summary: revision.summary } : {}),
+            createdAt: revision.createdAt,
+          })),
+          metadata: {
+            sessionId: session.id,
+            updateId: update.update_id,
+            sourceMessageId: payload.message_id,
+          },
         },
-      })
+        {
+          maxRepairAttempts: normalizeAIProjectEditMaxRepairAttempts(this.options.aiProjectEditMaxRepairAttempts),
+        },
+      )
 
       if (!edit.ok) {
         const failedSession = this.failEditSession(
@@ -3103,6 +3110,10 @@ function hasTelegramLikePayloadContent(payload: TelegramLikeBotPayload): boolean
 function normalizedTelegramText(text: string | undefined): string | undefined {
   const normalized = text?.trim()
   return normalized ? normalized : undefined
+}
+
+function normalizeAIProjectEditMaxRepairAttempts(value: number | undefined): number {
+  return Math.max(0, Math.trunc(value ?? 1))
 }
 
 function formatTelegramBotJobStatusLine(record: NodeTelegramBotWorkflowJobRecord): string {

--- a/src/cli/commands/__tests__/bot-worker.test.ts
+++ b/src/cli/commands/__tests__/bot-worker.test.ts
@@ -54,6 +54,7 @@ describe("bot-worker command", () => {
     expect(botWorkerCommand.options.some((option) => option.long === "--edit-session-dir")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--ai-editor")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--ai-editor-model")).toBe(true)
+    expect(botWorkerCommand.options.some((option) => option.long === "--ai-editor-repair-attempts")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--review-preview-dir")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--default-destination")).toBe(true)
   })
@@ -318,6 +319,7 @@ describe("bot-worker command", () => {
         TIMELINE_BOT_AI_EDITOR_MODEL: "editor-model",
         TIMELINE_BOT_AI_EDITOR_TEMPERATURE: "0.1",
         TIMELINE_BOT_AI_EDITOR_MAX_TOKENS: "2048",
+        TIMELINE_BOT_AI_EDITOR_REPAIR_ATTEMPTS: "2",
         TIMELINE_BOT_REVIEW_PREVIEW_DIR: ".tmp/review-previews",
       },
     )
@@ -360,6 +362,7 @@ describe("bot-worker command", () => {
       aiEditorModel: "editor-model",
       aiEditorTemperature: "0.1",
       aiEditorMaxTokens: "2048",
+      aiEditorRepairAttempts: "2",
       reviewPreviewDir: ".tmp/review-previews",
     })
   })
@@ -388,6 +391,7 @@ describe("bot-worker command", () => {
         aiEditor: true,
         aiEditorApiKey: "cli-editor-key",
         aiEditorModel: "cli-editor-model",
+        aiEditorRepairAttempts: "0",
         reviewPreviewDir: ".tmp/cli-review-previews",
       },
       {
@@ -412,6 +416,7 @@ describe("bot-worker command", () => {
         TIMELINE_BOT_AI_EDITOR: "false",
         TIMELINE_BOT_AI_EDITOR_API_KEY: "env-editor-key",
         TIMELINE_BOT_AI_EDITOR_MODEL: "env-editor-model",
+        TIMELINE_BOT_AI_EDITOR_REPAIR_ATTEMPTS: "2",
         TIMELINE_BOT_REVIEW_PREVIEW_DIR: ".tmp/env-review-previews",
       },
     )
@@ -438,6 +443,7 @@ describe("bot-worker command", () => {
       aiEditor: true,
       aiEditorApiKey: "cli-editor-key",
       aiEditorModel: "cli-editor-model",
+      aiEditorRepairAttempts: "0",
       reviewPreviewDir: ".tmp/cli-review-previews",
     })
   })

--- a/src/cli/commands/bot-worker.ts
+++ b/src/cli/commands/bot-worker.ts
@@ -77,6 +77,7 @@ export interface BotWorkerCommandOptions {
   aiEditorModel?: string
   aiEditorTemperature?: string
   aiEditorMaxTokens?: string
+  aiEditorRepairAttempts?: string
   reviewPreviewDir?: string
   defaultDestination?: BotRenderJobDestination
   defaultOutput?: string
@@ -131,6 +132,7 @@ export const botWorkerCommand = new Command("bot-worker")
   .option("--ai-editor-model <model>", "Model for the AI project editor")
   .option("--ai-editor-temperature <number>", "Temperature for the AI project editor")
   .option("--ai-editor-max-tokens <count>", "Max completion tokens for the AI project editor")
+  .option("--ai-editor-repair-attempts <count>", "Max AI project editor repair attempts for invalid output", "1")
   .option("--review-preview-dir <path>", "Directory for rendered Telegram AI review preview artifacts")
   .option("--default-destination <destination>", "Fallback destination when update has no destination hint")
   .option("--default-output <path>", "Fallback output path when update has no output hint")
@@ -217,6 +219,7 @@ export async function runBotWorker(options: BotWorkerCommandOptions = {}): Promi
     botToken: resolvedOptions.telegramBotToken,
     editSessionStore: services.botEditSessions,
     aiProjectEditor: services.aiProjectEditor,
+    aiProjectEditMaxRepairAttempts: parseOptionalNonNegativeInteger(resolvedOptions.aiEditorRepairAttempts) ?? 1,
     feedbackTranscriber: services.botFeedbackTranscriber,
     previewRenderer: createBotReviewPreviewRenderer(services.renderJob, resolvedOptions),
     publishService: services.publish,
@@ -321,6 +324,7 @@ export function resolveBotWorkerCommandOptions(
     aiEditorModel: firstConfigured(options.aiEditorModel, env.TIMELINE_BOT_AI_EDITOR_MODEL),
     aiEditorTemperature: firstConfigured(options.aiEditorTemperature, env.TIMELINE_BOT_AI_EDITOR_TEMPERATURE),
     aiEditorMaxTokens: firstConfigured(options.aiEditorMaxTokens, env.TIMELINE_BOT_AI_EDITOR_MAX_TOKENS),
+    aiEditorRepairAttempts: firstConfigured(options.aiEditorRepairAttempts, env.TIMELINE_BOT_AI_EDITOR_REPAIR_ATTEMPTS),
     reviewPreviewDir: firstConfigured(options.reviewPreviewDir, env.TIMELINE_BOT_REVIEW_PREVIEW_DIR),
     defaultDestination: firstConfigured(
       options.defaultDestination,


### PR DESCRIPTION
## Summary
- pass bounded AI edit repair attempts through Telegram review runtime, defaulting to one repair pass
- add --ai-editor-repair-attempts and TIMELINE_BOT_AI_EDITOR_REPAIR_ATTEMPTS for runtime control
- cover repaired invalid AI edit output before accepting a review revision
- document the runtime repair knob in the AI review runbook

## Verification
- bunx vitest run src/adapters/node/__tests__/telegram-bot-worker.test.ts src/cli/commands/__tests__/bot-worker.test.ts src/core/services/__tests__/ai-project-editor.test.ts
- bun run check:type
- bun run test:bot-ai
- bun run smoke:ai-review:rust
- bunx biome check src/adapters/node/telegram-bot-worker.ts src/adapters/node/__tests__/telegram-bot-worker.test.ts src/cli/commands/bot-worker.ts src/cli/commands/__tests__/bot-worker.test.ts
- git diff --check

Part of #242