### PR TITLE
B42: Add AI editor output fixtures

### DIFF
--- a/docs/08_tasks/planned/ai-module-node-rust-orchestration.md
+++ b/docs/08_tasks/planned/ai-module-node-rust-orchestration.md
@@ -177,6 +177,7 @@ Workflow-specific runbook details live in [Telegram AI Review Editing Workflow](
 - [ ] Align Rust `llm-plan` prompt/output with TS `ProjectSchema`.
 - [ ] Add explicit diagnostics when first-cut falls back to deterministic assembly.
 - [x] Enable bounded AI editor repair attempts in the Telegram review runtime with CLI/env configuration.
+- [x] Add AI editor fixture tests for promo creation, shorten intro, title/captions, platform adaptation, and invalid provider output.
 - [ ] Add fixtures for planner valid/invalid output.
 
 ### B43: Wire Telegram bot-worker runtime to real AI review services

--- a/src/adapters/node/__tests__/ai-project-editor.test.ts
+++ b/src/adapters/node/__tests__/ai-project-editor.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest"
-import { createBotProjectSchemaFromRenderJob, runAIProjectEdit } from "@/core"
+import { createBotProjectSchemaFromRenderJob, runAIProjectEdit, validateAIProjectEditResult } from "@/core"
 import { createNodeServices, NodeAIProjectEditor, type NodeAIProjectEditorFetch } from "../index"
+import {
+  AI_PROJECT_EDITOR_INVALID_RESPONSE_FIXTURE,
+  AI_PROJECT_EDITOR_VALID_FIXTURES,
+} from "./fixtures/ai-project-editor-fixtures"
 
 describe("NodeAIProjectEditor", () => {
   it("calls an OpenAI-compatible chat endpoint and returns a valid edit result", async () => {
@@ -223,6 +227,98 @@ describe("NodeAIProjectEditor", () => {
       result: {
         nextProject: project,
         diagnostics: [expect.objectContaining({ level: "error", code: "provider_invalid_json" })],
+      },
+    })
+  })
+
+  it.each(AI_PROJECT_EDITOR_VALID_FIXTURES)("accepts valid fixture provider output for $id", async (fixture) => {
+    const project = createProject()
+    const fixtureResult = fixture.createResult(project)
+    const fetch = createFetch({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify(fixtureResult),
+          },
+          finish_reason: "stop",
+        },
+      ],
+      usage: { prompt_tokens: 100, completion_tokens: 200 },
+    })
+    const editor = new NodeAIProjectEditor({
+      apiKey: "test-key",
+      provider: "fixture-provider",
+      model: "fixture-model",
+      fetch,
+    })
+
+    const result = await runAIProjectEdit(editor, {
+      currentProject: project,
+      sourceMedia: [{ type: "file", value: "/tmp/input.mp4", name: "input.mp4" }],
+      userInstruction: fixture.instruction,
+      ...(fixture.targetPlatform ? { targetPlatform: fixture.targetPlatform } : {}),
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      attempts: 1,
+      result: {
+        summary: fixtureResult.summary,
+        changedAreas: fixtureResult.changedAreas,
+        commands: fixtureResult.commands.map((command) => expect.objectContaining({ type: command.type })),
+        diagnostics: fixtureResult.diagnostics.map((diagnostic) =>
+          expect.objectContaining({ level: diagnostic.level, code: diagnostic.code }),
+        ),
+        metadata: expect.objectContaining({
+          provider: "fixture-provider",
+          model: "fixture-model",
+          promptId: "ai-project-editor/v1",
+          fixtureId: fixture.id,
+        }),
+      },
+    })
+    if (!result.ok) throw new Error("Expected fixture provider output to validate")
+    expect(
+      validateAIProjectEditResult(
+        { currentProject: project, sourceMedia: [], userInstruction: fixture.instruction },
+        result.result,
+      ),
+    ).toEqual([])
+  })
+
+  it("keeps the current project for invalid fixture provider output", async () => {
+    const project = createProject()
+    const fetch = createFetch({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify(AI_PROJECT_EDITOR_INVALID_RESPONSE_FIXTURE.response),
+          },
+        },
+      ],
+    })
+    const editor = new NodeAIProjectEditor({ apiKey: "test-key", fetch })
+
+    const result = await runAIProjectEdit(editor, {
+      currentProject: project,
+      sourceMedia: [{ type: "file", value: "/tmp/input.mp4" }],
+      userInstruction: AI_PROJECT_EDITOR_INVALID_RESPONSE_FIXTURE.instruction,
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      result: {
+        nextProject: project,
+        diagnostics: [
+          expect.objectContaining({
+            level: "error",
+            code: "provider_invalid_output",
+            message: expect.stringContaining("version must be a non-empty string"),
+          }),
+        ],
+        metadata: expect.objectContaining({
+          noop: true,
+        }),
       },
     })
   })

--- a/src/adapters/node/__tests__/fixtures/ai-project-editor-fixtures.ts
+++ b/src/adapters/node/__tests__/fixtures/ai-project-editor-fixtures.ts
@@ -1,0 +1,169 @@
+import type { AIProjectEditorResult } from "@/core"
+import type { BotRenderJobDestination } from "@/core/types"
+import type { ProjectSchema } from "@/types/contracts/project-schema"
+
+export interface AIProjectEditorFixture {
+  id: string
+  instruction: string
+  targetPlatform?: BotRenderJobDestination
+  createResult(project: ProjectSchema): AIProjectEditorResult
+}
+
+export const AI_PROJECT_EDITOR_VALID_FIXTURES: readonly AIProjectEditorFixture[] = [
+  {
+    id: "promo_creation",
+    instruction: "make a fast launch promo",
+    targetPlatform: "telegram",
+    createResult(project) {
+      const nextProject = cloneProject(project)
+      nextProject.metadata.name = "Launch promo"
+      nextProject.metadata.description = "Short launch promo for Telegram review."
+      nextProject.metadata.modified_at = "2026-06-09T12:00:00.000Z"
+      nextProject.settings.custom = {
+        ...nextProject.settings.custom,
+        aiFixture: {
+          id: "promo_creation",
+          style: "fast_promo",
+        },
+      }
+
+      return {
+        nextProject,
+        summary: "Created a faster launch promo structure.",
+        changedAreas: ["metadata.name", "metadata.description", "settings.custom.aiFixture"],
+        commands: [
+          {
+            type: "set_project_metadata",
+            params: {
+              name: "Launch promo",
+              description: "Short launch promo for Telegram review.",
+            },
+            rationale: "User asked for a launch promo.",
+          },
+        ],
+        diagnostics: [{ level: "info", code: "fixture_promo_creation", message: "Promo fixture applied." }],
+        metadata: { fixtureId: "promo_creation" },
+      }
+    },
+  },
+  {
+    id: "shorten_intro",
+    instruction: "shorten the intro by two seconds",
+    createResult(project) {
+      const nextProject = cloneProject(project)
+      const duration = Math.max(1, project.timeline.duration - 2)
+      nextProject.timeline.duration = duration
+      nextProject.settings.output = {
+        ...nextProject.settings.output,
+        duration,
+      }
+      nextProject.metadata.modified_at = "2026-06-09T12:01:00.000Z"
+
+      return {
+        nextProject,
+        summary: "Shortened the intro and adjusted timeline duration.",
+        changedAreas: ["timeline.duration", "settings.output.duration"],
+        commands: [
+          {
+            type: "set_timeline_duration",
+            params: { duration },
+            rationale: "User asked to shorten the intro.",
+          },
+        ],
+        diagnostics: [{ level: "info", code: "fixture_shorten_intro", message: "Intro shortened." }],
+        metadata: { fixtureId: "shorten_intro" },
+      }
+    },
+  },
+  {
+    id: "add_title_captions",
+    instruction: "add a title card and captions",
+    targetPlatform: "telegram",
+    createResult(project) {
+      const nextProject = cloneProject(project)
+      nextProject.metadata.modified_at = "2026-06-09T12:02:00.000Z"
+      nextProject.subtitles = [
+        ...nextProject.subtitles,
+        {
+          id: "fixture-title-caption",
+          text: "Launch day",
+          start_time: 0,
+          end_time: 2.5,
+          position: "bottom",
+        },
+      ] as ProjectSchema["subtitles"]
+
+      return {
+        nextProject,
+        summary: "Added an opening title caption.",
+        changedAreas: ["subtitles"],
+        commands: [
+          {
+            type: "add_subtitle",
+            targetId: "fixture-title-caption",
+            params: {
+              text: "Launch day",
+              start_time: 0,
+              end_time: 2.5,
+            },
+            rationale: "User asked for a title card and captions.",
+          },
+        ],
+        diagnostics: [{ level: "info", code: "fixture_add_title_captions", message: "Caption added." }],
+        metadata: { fixtureId: "add_title_captions" },
+      }
+    },
+  },
+  {
+    id: "platform_adaptation",
+    instruction: "adapt this for YouTube",
+    targetPlatform: "youtube",
+    createResult(project) {
+      const nextProject = cloneProject(project)
+      nextProject.metadata.description = "YouTube-ready edit with clearer title metadata."
+      nextProject.metadata.modified_at = "2026-06-09T12:03:00.000Z"
+      nextProject.settings.custom = {
+        ...nextProject.settings.custom,
+        aiFixture: {
+          id: "platform_adaptation",
+          targetPlatform: "youtube",
+          titleSafeArea: true,
+        },
+      }
+
+      return {
+        nextProject,
+        summary: "Adapted the project metadata for YouTube.",
+        changedAreas: ["metadata.description", "settings.custom.aiFixture"],
+        commands: [
+          {
+            type: "set_project_metadata",
+            params: {
+              description: "YouTube-ready edit with clearer title metadata.",
+              targetPlatform: "youtube",
+            },
+            rationale: "User asked to adapt the edit for YouTube.",
+          },
+        ],
+        diagnostics: [{ level: "info", code: "fixture_platform_adaptation", message: "Platform metadata updated." }],
+        metadata: { fixtureId: "platform_adaptation" },
+      }
+    },
+  },
+]
+
+export const AI_PROJECT_EDITOR_INVALID_RESPONSE_FIXTURE = {
+  id: "invalid_missing_project_shape",
+  instruction: "make a valid edit from a malformed provider response",
+  response: {
+    nextProject: { tracks: [] },
+    summary: "",
+    commands: [],
+    diagnostics: [],
+    metadata: { fixtureId: "invalid_missing_project_shape" },
+  },
+} as const
+
+function cloneProject(project: ProjectSchema): ProjectSchema {
+  return structuredClone(project)
+}


### PR DESCRIPTION
## Summary
- add deterministic AI editor provider-output fixtures for promo creation, shortening intro, title/captions, and platform adaptation
- verify each fixture flows through NodeAIProjectEditor + runAIProjectEdit as a valid ProjectSchema result
- add invalid provider-output fixture coverage that preserves the current project with actionable diagnostics
- update the B42 checklist for this fixture slice

## Verification
- bunx vitest run src/adapters/node/__tests__/ai-project-editor.test.ts src/core/services/__tests__/ai-project-editor.test.ts
- bun run check:type
- bun run test:bot-ai
- bun run smoke:ai-review:rust
- bunx biome check src/adapters/node/__tests__/ai-project-editor.test.ts src/adapters/node/__tests__/fixtures/ai-project-editor-fixtures.ts
- git diff --check

Part of #242