### PR TITLE
B42: Add first-cut planner output fixtures

### DIFF
--- a/docs/08_tasks/planned/ai-module-node-rust-orchestration.md
+++ b/docs/08_tasks/planned/ai-module-node-rust-orchestration.md
@@ -173,12 +173,12 @@ Workflow-specific runbook details live in [Telegram AI Review Editing Workflow](
 
 **GitHub:** [#242](https://github.com/chatman-media/timeline-studio/issues/242)
 
-- [ ] Align Rust `montage-plan` output with TS `ProjectSchema` or add a typed wrapper converter.
-- [ ] Align Rust `llm-plan` prompt/output with TS `ProjectSchema`.
-- [ ] Add explicit diagnostics when first-cut falls back to deterministic assembly.
+- [x] Align Rust `montage-plan` output with TS `ProjectSchema` or add a typed wrapper converter.
+- [x] Align Rust `llm-plan` prompt/output with TS `ProjectSchema`.
+- [x] Add explicit diagnostics when first-cut falls back to deterministic assembly.
 - [x] Enable bounded AI editor repair attempts in the Telegram review runtime with CLI/env configuration.
 - [x] Add AI editor fixture tests for promo creation, shorten intro, title/captions, platform adaptation, and invalid provider output.
-- [ ] Add fixtures for planner valid/invalid output.
+- [x] Add fixtures for planner valid/invalid output.
 
 ### B43: Wire Telegram bot-worker runtime to real AI review services
 

--- a/src/adapters/node/__tests__/rust-first-cut-planner.test.ts
+++ b/src/adapters/node/__tests__/rust-first-cut-planner.test.ts
@@ -3,6 +3,7 @@ import os from "node:os"
 import path from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { createBotProjectSchemaFromRenderJob } from "@/core"
+import { FIRST_CUT_PLANNER_VALID_FIXTURES } from "@/core/services/__tests__/fixtures/first-cut-planner-fixtures"
 import { NodeRustFirstCutPlanner } from "../rust-first-cut-planner"
 
 describe("NodeRustFirstCutPlanner", () => {
@@ -115,6 +116,38 @@ describe("NodeRustFirstCutPlanner", () => {
     const metadataArgs = result.metadata?.args as string[]
     expect(metadataArgs).toContain("[redacted]")
     expect(metadataArgs).not.toContain("sk-secret")
+  })
+
+  it.each(FIRST_CUT_PLANNER_VALID_FIXTURES)("reads valid ProjectSchema fixture output for $id", async (fixture) => {
+    const runCommand = vi.fn(async (_command: string, args: string[]) => {
+      const outputPath = args[args.indexOf("--output") + 1]
+      if (!outputPath) throw new Error("Expected output path")
+      await fs.writeFile(outputPath, JSON.stringify(fixture.projectSchema))
+      return { stdout: "", stderr: fixture.diagnostics?.join("\n") ?? "" }
+    })
+    const planner = new NodeRustFirstCutPlanner({
+      command: "timeline",
+      tempDir,
+      idFactory: () => fixture.id,
+      plannerKind: fixture.provider,
+      apiKey: fixture.provider === "llm-plan" ? "sk-secret" : undefined,
+      runCommand,
+    })
+
+    const result = await planner.generatePlan({
+      sourceMedia: [{ type: "file", value: "/tmp/input.mp4" }],
+      goal: "make a fixture promo",
+      publishDestination: "telegram",
+    })
+
+    expect(result).toMatchObject({
+      provider: fixture.provider,
+      projectSchema: fixture.projectSchema,
+      diagnostics: fixture.diagnostics ?? [],
+      metadata: {
+        outputPath: path.join(tempDir, `${fixture.id}.project.json`),
+      },
+    })
   })
 })
 

--- a/src/core/services/__tests__/bot-first-cut-generator.test.ts
+++ b/src/core/services/__tests__/bot-first-cut-generator.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest"
 import type { IBotFirstCutPlanner } from "@/core"
 import { createBotProjectSchemaFromRenderJob, DefaultBotFirstCutGenerator } from "../index"
+import {
+  FIRST_CUT_PLANNER_INVALID_FIXTURES,
+  FIRST_CUT_PLANNER_VALID_FIXTURES,
+} from "./fixtures/first-cut-planner-fixtures"
 
 describe("DefaultBotFirstCutGenerator", () => {
   it("uses a valid planner result and creates revision zero", async () => {
@@ -65,6 +69,73 @@ describe("DefaultBotFirstCutGenerator", () => {
     expect(result.diagnostics).toEqual([
       expect.stringContaining("Planner llm-plan output failed ProjectSchema validation"),
     ])
+  })
+
+  it.each(FIRST_CUT_PLANNER_VALID_FIXTURES)("accepts valid planner fixture output for $id", async (fixture) => {
+    const planner: IBotFirstCutPlanner = {
+      generatePlan: vi.fn(async () => ({
+        projectSchema: fixture.projectSchema,
+        provider: fixture.provider,
+        summary: `${fixture.provider} fixture first cut`,
+        diagnostics: fixture.diagnostics,
+        metadata: { fixtureId: fixture.id },
+      })),
+    }
+    const generator = new DefaultBotFirstCutGenerator({
+      planner,
+      now: () => "2026-06-09T03:10:00.000Z",
+    })
+
+    const result = await generator.generateFirstCut({
+      sessionId: "edit:telegram:chat-1:user-1",
+      sourceMessageId: "message-fixture",
+      sourceMedia: [{ type: "file", value: "/tmp/input.mp4", name: "input.mp4" }],
+      goal: "make a fixture promo",
+      publishDestination: "telegram",
+    })
+
+    expect(result).toMatchObject({
+      provider: fixture.provider,
+      projectSchema: fixture.projectSchema,
+      summary: `${fixture.provider} fixture first cut`,
+      diagnostics: fixture.diagnostics ?? [],
+      metadata: { fixtureId: fixture.id },
+      revision: {
+        id: "edit:telegram:chat-1:user-1:revision:0",
+        index: 0,
+        projectSchema: fixture.projectSchema,
+        createdAt: "2026-06-09T03:10:00.000Z",
+      },
+    })
+  })
+
+  it.each(FIRST_CUT_PLANNER_INVALID_FIXTURES)("falls back for invalid planner fixture output $id", async (fixture) => {
+    const planner: IBotFirstCutPlanner = {
+      generatePlan: vi.fn(async () => ({
+        projectSchema: fixture.projectSchema as never,
+        provider: fixture.provider,
+        summary: `${fixture.provider} invalid fixture`,
+        metadata: { fixtureId: fixture.id },
+      })),
+    }
+    const generator = new DefaultBotFirstCutGenerator({
+      planner,
+      now: () => "2026-06-09T03:11:00.000Z",
+    })
+
+    const result = await generator.generateFirstCut({
+      sourceMedia: [{ type: "file", value: "/tmp/input.mp4", name: "input.mp4" }],
+      goal: "make a fixture promo",
+      targetDurationSeconds: 12,
+      publishDestination: "telegram",
+    })
+
+    expect(result.provider).toBe("deterministic-fallback")
+    expect(result.projectSchema.timeline.duration).toBe(12)
+    expect(result.diagnostics).toEqual([
+      expect.stringContaining(`Planner ${fixture.provider} output failed ProjectSchema validation`),
+    ])
+    expect(result.diagnostics[0]).toContain(fixture.expectedDiagnostic)
   })
 
   it("includes planner error diagnostics when falling back", async () => {

--- a/src/core/services/__tests__/fixtures/first-cut-planner-fixtures.ts
+++ b/src/core/services/__tests__/fixtures/first-cut-planner-fixtures.ts
@@ -1,0 +1,100 @@
+import type { ProjectSchema } from "@/types/contracts/project-schema"
+
+import type { BotFirstCutProvider } from "../../../ports"
+import { createBotProjectSchemaFromRenderJob } from "../../bot-project-assembler"
+
+export interface FirstCutPlannerValidFixture {
+  id: string
+  provider: Exclude<BotFirstCutProvider, "deterministic-fallback">
+  projectSchema: ProjectSchema
+  diagnostics?: string[]
+}
+
+export interface FirstCutPlannerInvalidFixture {
+  id: string
+  provider: Exclude<BotFirstCutProvider, "deterministic-fallback">
+  projectSchema: unknown
+  expectedDiagnostic: string
+}
+
+const montageProject = createFixtureProject("montage-plan-valid", "telegram")
+montageProject.metadata.description = "Valid montage-plan first cut fixture."
+montageProject.settings.custom = {
+  ...montageProject.settings.custom,
+  plannerFixture: {
+    id: "montage-plan-valid",
+    provider: "montage-plan",
+  },
+}
+
+const llmProject = createFixtureProject("llm-plan-valid", "youtube")
+llmProject.metadata.description = "Valid llm-plan first cut fixture."
+llmProject.settings.custom = {
+  ...llmProject.settings.custom,
+  plannerFixture: {
+    id: "llm-plan-valid",
+    provider: "llm-plan",
+    goal: "make a product launch short",
+  },
+}
+
+export const FIRST_CUT_PLANNER_VALID_FIXTURES: readonly FirstCutPlannerValidFixture[] = [
+  {
+    id: "montage-plan-valid",
+    provider: "montage-plan",
+    projectSchema: montageProject,
+    diagnostics: ["montage-plan fixture"],
+  },
+  {
+    id: "llm-plan-valid",
+    provider: "llm-plan",
+    projectSchema: llmProject,
+    diagnostics: ["llm-plan fixture"],
+  },
+]
+
+export const FIRST_CUT_PLANNER_INVALID_FIXTURES: readonly FirstCutPlannerInvalidFixture[] = [
+  {
+    id: "legacy-simplified-output",
+    provider: "llm-plan",
+    projectSchema: {
+      id: "legacy-plan",
+      name: "Legacy plan",
+      timeline: {
+        tracks: [],
+      },
+      tracks: [],
+      settings: {},
+      meta: {},
+    },
+    expectedDiagnostic: "version must be a non-empty string",
+  },
+  {
+    id: "missing-required-arrays",
+    provider: "montage-plan",
+    projectSchema: {
+      version: "1.0.0",
+      metadata: {
+        name: "Broken planner output",
+      },
+      timeline: {
+        duration: 12,
+        fps: 30,
+        resolution: [1920, 1080],
+      },
+      tracks: [],
+      settings: {},
+    },
+    expectedDiagnostic: "effects must be an array",
+  },
+]
+
+function createFixtureProject(name: string, destination: "telegram" | "youtube"): ProjectSchema {
+  const project = createBotProjectSchemaFromRenderJob({
+    source: "bot",
+    media: [{ type: "file", value: `/tmp/${name}.mp4`, name: `${name}.mp4` }],
+    output: { format: "mp4", destination },
+  })
+  if (!project) throw new Error(`Expected ProjectSchema fixture for ${name}`)
+  return project
+}


### PR DESCRIPTION
## Summary
- add reusable valid and invalid first-cut planner output fixtures
- verify DefaultBotFirstCutGenerator accepts valid montage/llm ProjectSchema outputs and falls back with diagnostics on invalid planner outputs
- verify NodeRustFirstCutPlanner can read valid fixture ProjectSchema output from the Rust command output file
- mark the B42 checklist complete

## Verification
- bunx vitest run src/core/services/__tests__/bot-first-cut-generator.test.ts src/adapters/node/__tests__/rust-first-cut-planner.test.ts
- bun run check:type
- bun run test:bot-ai
- bun run smoke:ai-review:rust
- bunx biome check src/core/services/__tests__/fixtures/first-cut-planner-fixtures.ts src/core/services/__tests__/bot-first-cut-generator.test.ts src/adapters/node/__tests__/rust-first-cut-planner.test.ts
- git diff --check

Closes #242