### PR TITLE
B43: Wire bot-worker first-cut review config

### DIFF
--- a/docs/08_tasks/planned/ai-module-node-rust-orchestration.md
+++ b/docs/08_tasks/planned/ai-module-node-rust-orchestration.md
@@ -10,10 +10,10 @@
 
 Telegram AI review workflow уже добавил продуктовый контракт: upload media, first preview, текстовые/голосовые правки, AI revision loop, explicit approval and publish.
 
-Следующая проблема не в UX-сценарии, а в production runtime:
+Этот эпик закрывает не UX-сценарий, а production runtime:
 
-- текущий bot-worker CLI не прокидывает все AI review зависимости;
-- production `IAIProjectEditor` еще не реализован;
+- bot-worker CLI должен прокидывать AI review зависимости через явные CLI/env boundaries;
+- production `IAIProjectEditor` должен валидировать structured output до записи revision;
 - Rust `montage-plan`/`llm-plan` output не совпадает с TS `ProjectSchema` validation shape;
 - AI codebase split между `src/adapters/node`, `src/domains/ai-services`, `src/features/ai-director`, `src/features/montage-planner`, `crates/ts-agent` and `crates/ts-montage`;
 - publish/render уже есть в Rust, поэтому TypeScript не должен становиться вторым полноценным production backend для этих операций.
@@ -30,15 +30,11 @@ Telegram AI review workflow уже добавил продуктовый кон�
 - `NodeRustRenderVideoService` already delegates rendering to `timeline render` or `timeline-render`.
 - `NodeRustPublishService` already delegates Telegram/YouTube publish to `timeline publish ... --json`.
 - `initNodeApp` умеет создать `botEditSessions`, `botFeedbackTranscriber`, `botFirstCutPlanner`, `botFirstCutGenerator`, `botStatus`, Rust render and Rust publish services.
+- `bot-worker` CLI прокидывает edit session store, transcriber provider/model/language, Rust first-cut planner/generator fallback, AI editor, Rust preview render and Rust publish config через CLI/env.
 
 ### Production gaps
 
-- `src/cli/commands/bot-worker.ts` creates `NodeTelegramBotWorker` without `editSessionStore`, `aiProjectEditor`, `feedbackTranscriber`, `previewRenderer` and `botFirstCutGenerator`.
-- `src/adapters/node/ai.ts` is mostly media/transcription and analysis stubs. It does not implement project editing or chat-completions for `IAIProjectEditor`.
-- Only `MockAIProjectEditor` implements `IAIProjectEditor`; it is deterministic test scaffolding, not production AI editing.
-- `DefaultBotFirstCutGenerator` validates planner output with `validateProjectSchemaShape`; invalid Rust planner output silently falls back to deterministic clip assembly unless fallback is disabled.
-- `crates/ts-montage/src/headless.rs` emits simplified JSON with `id`, `name`, `timeline`, `tracks`, `settings`, `meta`; it does not emit required TS contract fields such as `version`, `metadata`, `effects`, `filters`, `templates`, `style_templates`, `subtitles`.
-- `crates/ts-agent/src/llm_planner.rs` prompt asks for a simplified schema with camelCase clip fields; it also omits required TS `ProjectSchema` fields.
+- Rust planner/editor parity still needs continued care when the Rust side changes its `ProjectSchema` emission.
 - Rust `llm-plan` is currently a first-cut planner only. It is not an edit command that accepts `currentProject + instruction + revisionHistory -> nextProject`.
 - Legacy AI docs and modules claim a broader ready state than the actual headless bot path supports.
 
@@ -184,10 +180,10 @@ Workflow-specific runbook details live in [Telegram AI Review Editing Workflow](
 
 **GitHub:** [#243](https://github.com/chatman-media/timeline-studio/issues/243)
 
-- [ ] Add CLI/env flags for edit session store, feedback transcriber, first-cut planner/generator and AI editor.
-- [ ] Pass those services into `NodeTelegramBotWorker`.
-- [ ] Add preview renderer backed by Rust render.
-- [ ] Add one-shot worker smoke that uses production wiring with mocked external commands.
+- [x] Add CLI/env flags for edit session store, feedback transcriber, first-cut planner/generator and AI editor.
+- [x] Pass those services into `NodeTelegramBotWorker`.
+- [x] Add preview renderer backed by Rust render.
+- [x] Add one-shot worker smoke that uses production wiring with mocked external commands.
 
 ### B44: Add Rust preview render and publish validate smoke for AI review
 

--- a/docs/10_project_state/roadmap.md
+++ b/docs/10_project_state/roadmap.md
@@ -97,9 +97,9 @@ Acceptance:
 
 Текущие выводы:
 
-- `NodeTelegramBotWorker` содержит review-loop extension points, но `bot-worker` CLI пока не прокидывает production `editSessionStore`, `feedbackTranscriber`, `aiProjectEditor`, `firstCutGenerator` and `previewRenderer`.
-- `IAIProjectEditor` пока реализован только mock adapter; production OpenAI-compatible adapter и/или Rust `llm-edit` command еще нужны.
-- Rust `montage-plan`/`llm-plan` output сейчас drift-ит от TS `ProjectSchema` validation и может приводить к deterministic fallback.
+- `bot-worker` CLI прокидывает production `editSessionStore`, `feedbackTranscriber`, `aiProjectEditor`, Rust first-cut planner/generator fallback, preview renderer and publish services.
+- `IAIProjectEditor` имеет production OpenAI-compatible adapter; Rust `llm-edit` command остается medium-term направлением.
+- Rust `montage-plan`/`llm-plan` output покрыт TS `ProjectSchema` validation fixtures; deterministic fallback остается явным диагностируемым режимом.
 - Render and publish should stay Rust-first through `timeline render` / `timeline publish`; Node owns orchestration, sessions, provider glue and Telegram runtime.
 
 Acceptance:

--- a/src/cli/commands/__tests__/bot-worker.test.ts
+++ b/src/cli/commands/__tests__/bot-worker.test.ts
@@ -52,6 +52,10 @@ describe("bot-worker command", () => {
     expect(botWorkerCommand.options.some((option) => option.long === "--rust-publish")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--youtube-access-token")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--edit-session-dir")).toBe(true)
+    expect(botWorkerCommand.options.some((option) => option.long === "--feedback-transcriber-provider")).toBe(true)
+    expect(botWorkerCommand.options.some((option) => option.long === "--first-cut-planner")).toBe(true)
+    expect(botWorkerCommand.options.some((option) => option.long === "--first-cut-planner-kind")).toBe(true)
+    expect(botWorkerCommand.options.some((option) => option.long === "--first-cut-strict")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--ai-editor")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--ai-editor-model")).toBe(true)
     expect(botWorkerCommand.options.some((option) => option.long === "--ai-editor-repair-attempts")).toBe(true)
@@ -312,6 +316,17 @@ describe("bot-worker command", () => {
         TIMELINE_BOT_RUST_PUBLISH_COMMAND: "timeline",
         TIMELINE_BOT_YOUTUBE_ACCESS_TOKEN: "youtube-token",
         TIMELINE_BOT_EDIT_SESSION_DIR: ".tmp/edit-sessions",
+        TIMELINE_BOT_FEEDBACK_TRANSCRIBER_PROVIDER: "faster-whisper",
+        TIMELINE_BOT_FEEDBACK_TRANSCRIBER_MODEL: "large-v3",
+        TIMELINE_BOT_FEEDBACK_TRANSCRIBER_LANGUAGE: "en",
+        TIMELINE_BOT_FIRST_CUT_PLANNER: "true",
+        TIMELINE_BOT_FIRST_CUT_PLANNER_COMMAND: "timeline-first-cut",
+        TIMELINE_BOT_FIRST_CUT_PLANNER_KIND: "llm-plan",
+        TIMELINE_BOT_FIRST_CUT_PLANNER_API_KEY: "planner-key",
+        TIMELINE_BOT_FIRST_CUT_PLANNER_API_URL: "https://planner.example/v1",
+        TIMELINE_BOT_FIRST_CUT_PLANNER_MODEL: "planner-model",
+        TIMELINE_BOT_FIRST_CUT_PLANNER_TEMP_DIR: ".tmp/first-cut",
+        TIMELINE_BOT_FIRST_CUT_STRICT: "true",
         TIMELINE_BOT_AI_EDITOR: "true",
         TIMELINE_BOT_AI_EDITOR_API_KEY: "editor-key",
         TIMELINE_BOT_AI_EDITOR_API_URL: "https://llm.example/v1",
@@ -355,6 +370,17 @@ describe("bot-worker command", () => {
       rustPublishCommand: "timeline",
       youtubeAccessToken: "youtube-token",
       editSessionDir: ".tmp/edit-sessions",
+      feedbackTranscriberProvider: "faster-whisper",
+      feedbackTranscriberModel: "large-v3",
+      feedbackTranscriberLanguage: "en",
+      firstCutPlanner: true,
+      firstCutPlannerCommand: "timeline-first-cut",
+      firstCutPlannerKind: "llm-plan",
+      firstCutPlannerApiKey: "planner-key",
+      firstCutPlannerApiUrl: "https://planner.example/v1",
+      firstCutPlannerModel: "planner-model",
+      firstCutPlannerTempDir: ".tmp/first-cut",
+      firstCutStrict: true,
       aiEditor: true,
       aiEditorApiKey: "editor-key",
       aiEditorApiUrl: "https://llm.example/v1",
@@ -388,6 +414,17 @@ describe("bot-worker command", () => {
         youtubeAccessToken: "cli-youtube-token",
         downloadRemoteMedia: false,
         editSessionDir: ".tmp/cli-edit-sessions",
+        feedbackTranscriberProvider: "local",
+        feedbackTranscriberModel: "cli-transcriber-model",
+        feedbackTranscriberLanguage: "ru",
+        firstCutPlanner: true,
+        firstCutPlannerCommand: "cli-timeline",
+        firstCutPlannerKind: "montage-plan",
+        firstCutPlannerApiKey: "cli-planner-key",
+        firstCutPlannerApiUrl: "https://cli-planner.example/v1",
+        firstCutPlannerModel: "cli-planner-model",
+        firstCutPlannerTempDir: ".tmp/cli-first-cut",
+        firstCutStrict: false,
         aiEditor: true,
         aiEditorApiKey: "cli-editor-key",
         aiEditorModel: "cli-editor-model",
@@ -413,6 +450,17 @@ describe("bot-worker command", () => {
         TIMELINE_BOT_YOUTUBE_ACCESS_TOKEN: "env-youtube-token",
         TIMELINE_BOT_DOWNLOAD_REMOTE_MEDIA: "true",
         TIMELINE_BOT_EDIT_SESSION_DIR: ".tmp/env-edit-sessions",
+        TIMELINE_BOT_FEEDBACK_TRANSCRIBER_PROVIDER: "openai",
+        TIMELINE_BOT_FEEDBACK_TRANSCRIBER_MODEL: "env-transcriber-model",
+        TIMELINE_BOT_FEEDBACK_TRANSCRIBER_LANGUAGE: "en",
+        TIMELINE_BOT_FIRST_CUT_PLANNER: "false",
+        TIMELINE_BOT_FIRST_CUT_PLANNER_COMMAND: "env-timeline",
+        TIMELINE_BOT_FIRST_CUT_PLANNER_KIND: "llm-plan",
+        TIMELINE_BOT_FIRST_CUT_PLANNER_API_KEY: "env-planner-key",
+        TIMELINE_BOT_FIRST_CUT_PLANNER_API_URL: "https://env-planner.example/v1",
+        TIMELINE_BOT_FIRST_CUT_PLANNER_MODEL: "env-planner-model",
+        TIMELINE_BOT_FIRST_CUT_PLANNER_TEMP_DIR: ".tmp/env-first-cut",
+        TIMELINE_BOT_FIRST_CUT_STRICT: "true",
         TIMELINE_BOT_AI_EDITOR: "false",
         TIMELINE_BOT_AI_EDITOR_API_KEY: "env-editor-key",
         TIMELINE_BOT_AI_EDITOR_MODEL: "env-editor-model",
@@ -440,11 +488,36 @@ describe("bot-worker command", () => {
       youtubeAccessToken: "cli-youtube-token",
       downloadRemoteMedia: false,
       editSessionDir: ".tmp/cli-edit-sessions",
+      feedbackTranscriberProvider: "local",
+      feedbackTranscriberModel: "cli-transcriber-model",
+      feedbackTranscriberLanguage: "ru",
+      firstCutPlanner: true,
+      firstCutPlannerCommand: "cli-timeline",
+      firstCutPlannerKind: "montage-plan",
+      firstCutPlannerApiKey: "cli-planner-key",
+      firstCutPlannerApiUrl: "https://cli-planner.example/v1",
+      firstCutPlannerModel: "cli-planner-model",
+      firstCutPlannerTempDir: ".tmp/cli-first-cut",
+      firstCutStrict: false,
       aiEditor: true,
       aiEditorApiKey: "cli-editor-key",
       aiEditorModel: "cli-editor-model",
       aiEditorRepairAttempts: "0",
       reviewPreviewDir: ".tmp/cli-review-previews",
     })
+  })
+
+  it("does not treat generic LLM keys as first-cut planner config by themselves", () => {
+    const resolved = resolveBotWorkerCommandOptions(
+      {},
+      {
+        OPENAI_API_KEY: "shared-openai-key",
+        LLM_API_KEY: "shared-llm-key",
+      },
+    )
+
+    expect(resolved.aiEditorApiKey).toBe("shared-openai-key")
+    expect(resolved.firstCutPlanner).toBeUndefined()
+    expect(resolved.firstCutPlannerApiKey).toBeUndefined()
   })
 })

--- a/src/cli/commands/bot-worker.ts
+++ b/src/cli/commands/bot-worker.ts
@@ -10,6 +10,8 @@ import path from "node:path"
 import { Command } from "commander"
 import type {
   NodeAIProjectEditorOptions,
+  NodeRustFirstCutPlannerKind,
+  NodeRustFirstCutPlannerOptions,
   NodeTelegramBotWorkerPollResult,
   NodeTelegramBotWorkerRunResult,
   NodeTelegramBotWorkerUpdateResult,
@@ -26,6 +28,7 @@ import {
   NodeTelegramRenderJobReviewPreviewRenderer,
   recoverStaleTelegramWorkflowJobs,
 } from "@/adapters/node"
+import type { BotFeedbackTranscriptionProvider } from "@/core/ports"
 import type {
   BotRenderJobDestination,
   BotWorkflowRunResult,
@@ -70,6 +73,17 @@ export interface BotWorkerCommandOptions {
   rustPublishCommand?: string
   youtubeAccessToken?: string
   editSessionDir?: string
+  feedbackTranscriberProvider?: BotFeedbackTranscriptionProvider
+  feedbackTranscriberModel?: string
+  feedbackTranscriberLanguage?: string
+  firstCutPlanner?: boolean
+  firstCutPlannerCommand?: string
+  firstCutPlannerKind?: NodeRustFirstCutPlannerKind
+  firstCutPlannerApiKey?: string
+  firstCutPlannerApiUrl?: string
+  firstCutPlannerModel?: string
+  firstCutPlannerTempDir?: string
+  firstCutStrict?: boolean
   aiEditor?: boolean
   aiEditorApiKey?: string
   aiEditorApiUrl?: string
@@ -125,6 +139,23 @@ export const botWorkerCommand = new Command("bot-worker")
   .option("--rust-publish-command <path>", "Path/name for the Rust timeline publish command")
   .option("--youtube-access-token <token>", "YouTube access token for Rust publishing")
   .option("--edit-session-dir <path>", "Persist Telegram AI review edit sessions in a directory")
+  .option(
+    "--feedback-transcriber-provider <provider>",
+    "Review voice transcription provider: openai, local, or faster-whisper",
+  )
+  .option("--feedback-transcriber-model <model>", "Review voice transcription model")
+  .option("--feedback-transcriber-language <language>", "Review voice transcription language hint")
+  .option("--first-cut-planner", "Enable Rust timeline montage-plan/llm-plan first-cut planning")
+  .option("--first-cut-planner-command <path>", "Path/name for the Rust timeline first-cut planner command")
+  .option("--first-cut-planner-kind <kind>", "Rust first-cut planner kind: auto, montage-plan, or llm-plan")
+  .option("--first-cut-planner-api-key <key>", "API key for Rust timeline llm-plan first-cut planning")
+  .option("--first-cut-planner-api-url <url>", "OpenAI-compatible base URL for Rust timeline llm-plan")
+  .option("--first-cut-planner-model <model>", "Model for Rust timeline llm-plan first-cut planning")
+  .option("--first-cut-planner-temp-dir <path>", "Temp directory for Rust first-cut planner ProjectSchema output")
+  .option(
+    "--first-cut-strict",
+    "Fail instead of deterministic first-cut fallback when Rust planner fails or returns invalid output",
+  )
   .option("--ai-editor", "Enable the production AI project editor for review feedback")
   .option("--ai-editor-api-key <key>", "API key for the AI project editor")
   .option("--ai-editor-api-url <url>", "OpenAI-compatible base URL for the AI project editor")
@@ -184,7 +215,9 @@ export async function runBotWorker(options: BotWorkerCommandOptions = {}): Promi
     ai: createBotAIOptions(resolvedOptions),
     aiProjectEditor: createBotAIProjectEditorOptions(resolvedOptions),
     botEditSessions: createBotEditSessionStoreOptions(resolvedOptions),
-    botFeedbackTranscriber: resolvedOptions.editSessionDir ? {} : false,
+    botFeedbackTranscriber: createBotFeedbackTranscriberOptions(resolvedOptions),
+    botFirstCutPlanner: createBotFirstCutPlannerOptions(resolvedOptions),
+    botFirstCutGenerator: createBotFirstCutGeneratorOptions(resolvedOptions),
     botMediaResolver: createBotMediaResolverOptions(resolvedOptions),
     botStatus: createBotStatusOptions(resolvedOptions),
     publish: createBotPublishOptions(resolvedOptions),
@@ -312,6 +345,32 @@ export function resolveBotWorkerCommandOptions(
       env.YOUTUBE_ACCESS_TOKEN,
     ),
     editSessionDir: firstConfigured(options.editSessionDir, env.TIMELINE_BOT_EDIT_SESSION_DIR),
+    feedbackTranscriberProvider: firstConfigured(
+      options.feedbackTranscriberProvider,
+      normalizeFeedbackTranscriberProvider(env.TIMELINE_BOT_FEEDBACK_TRANSCRIBER_PROVIDER),
+    ),
+    feedbackTranscriberModel: firstConfigured(
+      options.feedbackTranscriberModel,
+      env.TIMELINE_BOT_FEEDBACK_TRANSCRIBER_MODEL,
+    ),
+    feedbackTranscriberLanguage: firstConfigured(
+      options.feedbackTranscriberLanguage,
+      env.TIMELINE_BOT_FEEDBACK_TRANSCRIBER_LANGUAGE,
+    ),
+    firstCutPlanner: options.firstCutPlanner ?? parseBooleanEnv(env.TIMELINE_BOT_FIRST_CUT_PLANNER),
+    firstCutPlannerCommand: firstConfigured(options.firstCutPlannerCommand, env.TIMELINE_BOT_FIRST_CUT_PLANNER_COMMAND),
+    firstCutPlannerKind: firstConfigured(
+      options.firstCutPlannerKind,
+      normalizeFirstCutPlannerKind(env.TIMELINE_BOT_FIRST_CUT_PLANNER_KIND),
+    ),
+    firstCutPlannerApiKey: firstConfigured(options.firstCutPlannerApiKey, env.TIMELINE_BOT_FIRST_CUT_PLANNER_API_KEY),
+    firstCutPlannerApiUrl: firstConfigured(options.firstCutPlannerApiUrl, env.TIMELINE_BOT_FIRST_CUT_PLANNER_API_URL),
+    firstCutPlannerModel: firstConfigured(options.firstCutPlannerModel, env.TIMELINE_BOT_FIRST_CUT_PLANNER_MODEL),
+    firstCutPlannerTempDir: firstConfigured(
+      options.firstCutPlannerTempDir,
+      env.TIMELINE_BOT_FIRST_CUT_PLANNER_TEMP_DIR,
+    ),
+    firstCutStrict: options.firstCutStrict ?? parseBooleanEnv(env.TIMELINE_BOT_FIRST_CUT_STRICT),
     aiEditor: options.aiEditor ?? parseBooleanEnv(env.TIMELINE_BOT_AI_EDITOR),
     aiEditorApiKey: firstConfigured(
       options.aiEditorApiKey,
@@ -387,6 +446,46 @@ function createBotEditSessionStoreOptions(options: BotWorkerCommandOptions) {
   if (!options.editSessionDir) return false
   return {
     directory: path.resolve(options.editSessionDir),
+  }
+}
+
+function createBotFeedbackTranscriberOptions(options: BotWorkerCommandOptions) {
+  if (!options.editSessionDir) return false
+  return {
+    ...(options.feedbackTranscriberProvider ? { provider: options.feedbackTranscriberProvider } : {}),
+    ...(options.feedbackTranscriberModel ? { model: options.feedbackTranscriberModel } : {}),
+    ...(options.feedbackTranscriberLanguage ? { language: options.feedbackTranscriberLanguage } : {}),
+  }
+}
+
+function createBotFirstCutPlannerOptions(options: BotWorkerCommandOptions): NodeRustFirstCutPlannerOptions | false {
+  if (options.firstCutPlanner === false) return false
+
+  const hasConfig = Boolean(
+    options.firstCutPlanner ||
+      options.firstCutPlannerCommand ||
+      options.firstCutPlannerKind ||
+      options.firstCutPlannerApiKey ||
+      options.firstCutPlannerApiUrl ||
+      options.firstCutPlannerModel ||
+      options.firstCutPlannerTempDir,
+  )
+  if (!hasConfig) return false
+
+  return {
+    ...(options.firstCutPlannerCommand ? { command: options.firstCutPlannerCommand } : {}),
+    ...(options.firstCutPlannerKind ? { plannerKind: options.firstCutPlannerKind } : {}),
+    ...(options.firstCutPlannerApiKey ? { apiKey: options.firstCutPlannerApiKey } : {}),
+    ...(options.firstCutPlannerApiUrl ? { apiUrl: options.firstCutPlannerApiUrl } : {}),
+    ...(options.firstCutPlannerModel ? { model: options.firstCutPlannerModel } : {}),
+    ...(options.firstCutPlannerTempDir ? { tempDir: path.resolve(options.firstCutPlannerTempDir) } : {}),
+  }
+}
+
+function createBotFirstCutGeneratorOptions(options: BotWorkerCommandOptions) {
+  if (!options.firstCutStrict) return undefined
+  return {
+    fallbackToDeterministic: false,
   }
 }
 
@@ -674,6 +773,28 @@ function normalizeRustRenderKind(value: string | undefined): BotWorkerCommandOpt
     case "timeline":
     case "timeline-render":
       return value.trim() as BotWorkerCommandOptions["rustRenderKind"]
+    default:
+      return undefined
+  }
+}
+
+function normalizeFeedbackTranscriberProvider(value: string | undefined): BotFeedbackTranscriptionProvider | undefined {
+  switch (value?.trim()) {
+    case "openai":
+    case "local":
+    case "faster-whisper":
+      return value.trim() as BotFeedbackTranscriptionProvider
+    default:
+      return undefined
+  }
+}
+
+function normalizeFirstCutPlannerKind(value: string | undefined): NodeRustFirstCutPlannerKind | undefined {
+  switch (value?.trim()) {
+    case "auto":
+    case "montage-plan":
+    case "llm-plan":
+      return value.trim() as NodeRustFirstCutPlannerKind
     default:
       return undefined
   }


### PR DESCRIPTION
## Summary
- add bot-worker CLI/env config for feedback transcriber provider/model/language and Rust first-cut planner settings
- wire first-cut planner and generator fallback options into initNodeApp for Telegram AI review runtime
- update B43 docs/roadmap status and guard against generic LLM keys enabling first-cut planner implicitly

## Tests
- bunx vitest run src/cli/commands/__tests__/bot-worker.test.ts
- bun run check:type
- bun run test:bot-ai
- bunx biome check src/cli/commands/bot-worker.ts src/cli/commands/__tests__/bot-worker.test.ts docs/08_tasks/planned/ai-module-node-rust-orchestration.md docs/10_project_state/roadmap.md
- git diff --check

Closes #243