### PR TITLE
Close out AI orchestration epic

### DIFF
--- a/docs/08_tasks/planned/ai-module-node-rust-orchestration.md
+++ b/docs/08_tasks/planned/ai-module-node-rust-orchestration.md
@@ -1,8 +1,9 @@
 # AI Module Stabilization and Node/Rust Orchestration
 
-**Статус:** Active
+**Статус:** Completed
 **Приоритет:** High
 **Создано:** 2026-06-09
+**Завершено:** 2026-06-10
 **GitHub epic:** [#238](https://github.com/chatman-media/timeline-studio/issues/238)
 **Связано:** [Telegram AI Review Editing Workflow](./telegram-ai-review-workflow.md), [Bot-first workflow](./bot-first-workflow.md), [Montage Planner Refactoring](./montage-planner-refactoring.md)
 
@@ -32,11 +33,11 @@ Telegram AI review workflow уже добавил продуктовый кон�
 - `initNodeApp` умеет создать `botEditSessions`, `botFeedbackTranscriber`, `botFirstCutPlanner`, `botFirstCutGenerator`, `botStatus`, Rust render and Rust publish services.
 - `bot-worker` CLI прокидывает edit session store, transcriber provider/model/language, Rust first-cut planner/generator fallback, AI editor, Rust preview render and Rust publish config через CLI/env.
 
-### Production gaps
+### Follow-ups Outside This Epic
 
 - Rust planner/editor parity still needs continued care when the Rust side changes its `ProjectSchema` emission.
 - Rust `llm-plan` is currently a first-cut planner only. It is not an edit command that accepts `currentProject + instruction + revisionHistory -> nextProject`.
-- Legacy AI docs and modules claim a broader ready state than the actual headless bot path supports.
+- Generic production topology, deployment assets, retention, cleanup jobs and sandbox operator checklist remain owned by B28/#225.
 
 ## Node/Rust Ownership Decision
 
@@ -68,7 +69,7 @@ Node is the production owner for chat/bot orchestration:
 
 ### AI project editing strategy
 
-Short term:
+Completed short term:
 
 - implement a Node OpenAI-compatible `IAIProjectEditor` adapter;
 - force structured JSON output matching `AIProjectEditorResult`;
@@ -160,10 +161,10 @@ Workflow-specific runbook details live in [Telegram AI Review Editing Workflow](
 
 **GitHub:** [#241](https://github.com/chatman-media/timeline-studio/issues/241)
 
-- [ ] Add OpenAI-compatible `IAIProjectEditor` adapter.
-- [ ] Make model/base URL/API key configurable through CLI/env.
-- [ ] Return `AIProjectEditorResult` only; no free-form text as persisted state.
-- [ ] Add focused tests for valid edit, provider error and missing key.
+- [x] Add OpenAI-compatible `IAIProjectEditor` adapter.
+- [x] Make model/base URL/API key configurable through CLI/env.
+- [x] Return `AIProjectEditorResult` only; no free-form text as persisted state.
+- [x] Add focused tests for valid edit, provider error and missing key.
 
 ### B42: Harden AI output schema validation, repair and fallbacks
 
@@ -211,9 +212,15 @@ Workflow-specific runbook details live in [Telegram AI Review Editing Workflow](
 
 ## Acceptance Criteria
 
-- Telegram bot can run the full AI review loop from CLI without test-only mocks.
-- First-cut planner output either validates as `ProjectSchema` or fails/falls back with clear diagnostics.
-- Text and voice revisions use the same `IAIProjectEditor` path.
-- Preview render and final publish go through Rust-backed adapters in production mode.
-- TypeScript publish/render remains a thin adapter/fallback, not the main production path.
-- CI has a dedicated smoke that catches bot/AI workflow regressions quickly.
+- [x] Telegram bot can run the full AI review loop from CLI without test-only mocks.
+- [x] First-cut planner output either validates as `ProjectSchema` or fails/falls back with clear diagnostics.
+- [x] Text and voice revisions use the same `IAIProjectEditor` path.
+- [x] Preview render and final publish go through Rust-backed adapters in production mode.
+- [x] TypeScript publish/render remains a thin adapter/fallback, not the main production path.
+- [x] CI has a dedicated smoke that catches bot/AI workflow regressions quickly.
+
+## Closeout
+
+B39-B46 are complete and the Telegram AI review runtime now has a production Node/Rust boundary: Node owns Telegram orchestration, sessions, provider glue and validation; Rust owns first-cut planning, preview rendering and final publishing through CLI adapters.
+
+Remaining production-readiness work intentionally stays in [B28/#225](https://github.com/chatman-media/timeline-studio/issues/225): deployment topology, operator runbooks, retention/cleanup policy and sandbox checklist.

--- a/docs/08_tasks/planned/telegram-ai-review-workflow.md
+++ b/docs/08_tasks/planned/telegram-ai-review-workflow.md
@@ -1,6 +1,6 @@
 # Telegram AI Review Editing Workflow
 
-**Статус:** Implementation slice merged; production runtime stabilization continues in [AI Module Stabilization and Node/Rust Orchestration](./ai-module-node-rust-orchestration.md)
+**Статус:** Implementation slice merged; production runtime stabilization completed in [AI Module Stabilization and Node/Rust Orchestration](./ai-module-node-rust-orchestration.md)
 **Приоритет:** High
 **Создано:** 2026-06-09
 **Ответственный:** Architecture Team
@@ -23,7 +23,7 @@ upload media
   -> publish only after explicit approval
 ```
 
-> Важно: этот документ описывает реализованный product/workflow contract и mocked smoke. Production wiring для AI editor, Rust planner schema alignment, preview renderer and bot-worker CLI flags теперь отслеживается в [#238](https://github.com/chatman-media/timeline-studio/issues/238).
+> Важно: этот документ описывает реализованный product/workflow contract. Production wiring для AI editor, Rust planner schema alignment, preview renderer and bot-worker CLI flags закрыты в [#238](https://github.com/chatman-media/timeline-studio/issues/238); deployment, retention and cleanup остаются в [#225](https://github.com/chatman-media/timeline-studio/issues/225).
 
 ## Связь с B28 / production readiness
 

--- a/docs/10_project_state/roadmap.md
+++ b/docs/10_project_state/roadmap.md
@@ -74,7 +74,7 @@ Acceptance:
 
 ### P1: Telegram AI review workflow
 
-- [#226](https://github.com/chatman-media/timeline-studio/issues/226) - Telegram становится интерфейсом итеративного AI-редактирования: upload, first preview, text/voice feedback, preview revisions, explicit approval and Rust-first publish. Implementation slice merged; production runtime stabilization now continues in [#238](https://github.com/chatman-media/timeline-studio/issues/238).
+- [#226](https://github.com/chatman-media/timeline-studio/issues/226) - Telegram становится интерфейсом итеративного AI-редактирования: upload, first preview, text/voice feedback, preview revisions, explicit approval and Rust-first publish. Implementation slice merged; production runtime stabilization completed in [#238](https://github.com/chatman-media/timeline-studio/issues/238).
 - [#225](https://github.com/chatman-media/timeline-studio/issues/225) остается владельцем production topology, deployment foundation, generic media retention and cleanup jobs.
 
 Готово в текущем implementation slice:
@@ -91,11 +91,11 @@ Acceptance:
 
 ### P1: AI module stabilization and Node/Rust orchestration
 
-- [#238](https://github.com/chatman-media/timeline-studio/issues/238) - стабилизировать production AI path для Telegram review workflow и закрепить границу ответственности Node/Rust.
+- [#238](https://github.com/chatman-media/timeline-studio/issues/238) - production AI path для Telegram review workflow стабилизирован; граница ответственности Node/Rust закреплена.
 - [#239](https://github.com/chatman-media/timeline-studio/issues/239) - аудит текущих AI модулей, headless flows and broken wiring.
 - [#240](https://github.com/chatman-media/timeline-studio/issues/240) - Node/Rust ownership boundary.
 
-Текущие выводы:
+Итог:
 
 - `bot-worker` CLI прокидывает production `editSessionStore`, `feedbackTranscriber`, `aiProjectEditor`, Rust first-cut planner/generator fallback, preview renderer and publish services.
 - `IAIProjectEditor` имеет production OpenAI-compatible adapter; Rust `llm-edit` command остается medium-term направлением.
@@ -104,10 +104,10 @@ Acceptance:
 
 Acceptance:
 
-- Bot review loop runs from CLI with production wiring, not only mocked unit smoke.
-- First-cut and edit outputs validate as canonical `ProjectSchema` or fail/fallback with explicit diagnostics.
-- Text and voice feedback share one AI editor path.
-- Dedicated headless bot/AI smoke catches regressions separately from the large frontend suite.
+- [x] Bot review loop runs from CLI with production wiring, not only mocked unit smoke.
+- [x] First-cut and edit outputs validate as canonical `ProjectSchema` or fail/fallback with explicit diagnostics.
+- [x] Text and voice feedback share one AI editor path.
+- [x] Dedicated headless bot/AI smoke catches regressions separately from the large frontend suite.
 
 ### P1: Phase F TypeScript packages
 


### PR DESCRIPTION
## Summary
- mark AI Module Stabilization and Node/Rust Orchestration as completed
- check off B41 and epic acceptance criteria now that B39-B46 are done
- sync roadmap and Telegram AI review docs so remaining production-readiness work points to #225

## Tests
- git diff --check
- biome check docs/* was not applicable because these Markdown paths are ignored by the Biome config

Closes #238