### PR TITLE
Phase F7: Reduce color-grading UI domain warnings

### DIFF
--- a/config/package-boundaries-baseline.json
+++ b/config/package-boundaries-baseline.json
@@ -1,11 +1,11 @@
 {
-  "updated": "2026-06-08",
-  "source": "Phase F10 color scheme settings bridge",
-  "violations": 412,
+  "updated": "2026-06-10",
+  "source": "Phase F7 color-grading modal bridge",
+  "violations": 410,
   "bySeverity": {
-    "warn": 412
+    "warn": 410
   },
   "byEdge": {
-    "ui -> domains": 412
+    "ui -> domains": 410
   }
 }

--- a/docs/08_tasks/planned/monorepo-packages-migration.md
+++ b/docs/08_tasks/planned/monorepo-packages-migration.md
@@ -135,7 +135,8 @@ adapters -> core
 - [x] `options`: добавить core-facing `MediaFile` type bridge и убрать type-only imports из `@/domains/media-management`.
 - [x] `keyboard-shortcuts`: перевести modal hook imports на feature-facing compatibility layer `@/features/modals/services`.
 - [x] `color-scheme`: расширить feature-facing `user-settings` adapter и убрать прямые imports из `project-management`/`system-integration`.
-- [ ] Следующие маленькие кандидаты: `color-grading`.
+- [x] `color-grading`: перевести modal hook imports на feature-facing compatibility layer `@/features/modals/services`.
+- [ ] Следующие маленькие кандидаты: `resources`, `style-templates`, `fairlight-audio`, `updates`.
 
 ## Проверка каждого PR
 
@@ -157,13 +158,13 @@ bun run check:type
 
 CI использует `bun run check:boundaries:baseline`, который сравнивает отчет с `config/package-boundaries-baseline.json` и падает только при росте total/severity/edge counts. Strict mode останется выключенным до burn-down `domains -> ui`, `domains -> app-shell` и `ui -> domains`.
 
-Baseline на 2026-06-08:
+Baseline на 2026-06-10:
 
-- Scanned files: 1587
-- Violations: 412
+- Scanned files: 1628
+- Violations: 410
 - `error`: 0
-- `warn`: 412
-- Edges: `ui -> domains` 412
+- `warn`: 410
+- Edges: `ui -> domains` 410
 
 Следующие PR должны уменьшать этот отчет и не добавлять новые нарушения без явного follow-up.
 

--- a/src/features/color-grading/__tests__/components/color-grading-controls.test.tsx
+++ b/src/features/color-grading/__tests__/components/color-grading-controls.test.tsx
@@ -25,7 +25,7 @@ const mockAutoCorrect = vi.fn()
 const mockUseModals = vi.fn()
 const mockUseColorGradingContext = vi.fn()
 
-vi.mock("@/domains/system-integration", () => ({
+vi.mock("@/features/modals/services", () => ({
   useModals: () => mockUseModals(),
 }))
 

--- a/src/features/color-grading/__tests__/components/color-grading-save-preset-modal.test.tsx
+++ b/src/features/color-grading/__tests__/components/color-grading-save-preset-modal.test.tsx
@@ -18,7 +18,7 @@ const mockCloseModal = vi.fn()
 const mockOnSave = vi.fn()
 const mockUseModals = vi.fn()
 
-vi.mock("@/domains/system-integration", () => ({
+vi.mock("@/features/modals/services", () => ({
   useModals: () => mockUseModals(),
 }))
 

--- a/src/features/color-grading/components/controls/color-grading-controls.tsx
+++ b/src/features/color-grading/components/controls/color-grading-controls.tsx
@@ -10,7 +10,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { useModals } from "@/domains/system-integration"
+import { useModals } from "@/features/modals/services"
 
 import { useColorGradingContext } from "../../services/color-grading-provider"
 import { getAllPresetCategories } from "../../types/presets"

--- a/src/features/color-grading/components/controls/color-grading-save-preset-modal.tsx
+++ b/src/features/color-grading/components/controls/color-grading-save-preset-modal.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { useModals } from "@/domains/system-integration"
+import { useModals } from "@/features/modals/services"
 
 interface SavePresetModalData {
   onSave?: (presetName: string) => void


### PR DESCRIPTION
## Summary
- move color-grading modal usage from direct system-integration imports to the feature modal bridge
- update color-grading component mocks to target the same bridge
- lower the committed package-boundary baseline from 412 to 410 `ui -> domains` warnings

## Tests
- bun install --frozen-lockfile --ignore-scripts
- bun run check:boundaries
- bun run check:boundaries:baseline
- bun run check:workspaces
- bun run check:type
- bunx vitest run src/features/color-grading/__tests__/components/color-grading-controls.test.tsx src/features/color-grading/__tests__/components/color-grading-save-preset-modal.test.tsx
- bunx biome check src/features/color-grading/components/controls/color-grading-controls.tsx src/features/color-grading/components/controls/color-grading-save-preset-modal.tsx src/features/color-grading/__tests__/components/color-grading-controls.test.tsx src/features/color-grading/__tests__/components/color-grading-save-preset-modal.test.tsx config/package-boundaries-baseline.json docs/08_tasks/planned/monorepo-packages-migration.md
- git diff --check

Refs #165