### PR TITLE
chore: move style template types to core

### DIFF
--- a/config/package-boundaries-baseline.json
+++ b/config/package-boundaries-baseline.json
@@ -1,11 +1,11 @@
 {
   "updated": "2026-06-10",
-  "source": "Phase F7 fairlight modal bridge",
-  "violations": 406,
+  "source": "Phase F7 style-template core types",
+  "violations": 405,
   "bySeverity": {
-    "warn": 406
+    "warn": 405
   },
   "byEdge": {
-    "ui -> domains": 406
+    "ui -> domains": 405
   }
 }

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -33,4 +33,5 @@ export type {
 export * from "./bot-workflow"
 export * from "./media"
 export * from "./render-job"
+export * from "./style-template"
 export * from "./video-editing"

--- a/src/core/types/style-template.ts
+++ b/src/core/types/style-template.ts
@@ -1,0 +1,112 @@
+/**
+ * Core-facing style template types used by UI slices.
+ * Keep this file independent from domain packages so style-template UI can be
+ * extracted without depending on video-editing domain type barrels.
+ */
+
+export interface StyleTemplate {
+  id: string
+  name: {
+    ru: string
+    en: string
+  }
+  category: "intro" | "outro" | "lower-third" | "title" | "transition" | "overlay"
+  style: "modern" | "vintage" | "minimal" | "corporate" | "creative" | "cinematic"
+  aspectRatio: "16:9" | "9:16" | "1:1"
+  duration: number
+  hasText: boolean
+  hasAnimation: boolean
+  thumbnail?: string
+  previewVideo?: string
+  tags?: {
+    ru: string[]
+    en: string[]
+  }
+  elements: TemplateElement[]
+  description?: {
+    ru: string
+    en: string
+  }
+}
+
+export interface TemplateElement {
+  id: string
+  type: "text" | "shape" | "image" | "video" | "animation" | "particle"
+  name: {
+    ru: string
+    en: string
+  }
+  position: {
+    x: number
+    y: number
+  }
+  size: {
+    width: number
+    height: number
+  }
+  timing: {
+    start: number
+    end: number
+  }
+  properties: ElementProperties
+  animations?: Animation[]
+}
+
+export interface ElementProperties {
+  opacity?: number
+  rotation?: number
+  scale?: number
+  text?: string
+  fontSize?: number
+  fontFamily?: string
+  color?: string
+  textAlign?: "left" | "center" | "right"
+  fontWeight?: "normal" | "bold" | "light"
+  backgroundColor?: string
+  borderColor?: string
+  borderWidth?: number
+  borderRadius?: number
+  src?: string
+  objectFit?: "contain" | "cover" | "fill"
+  [key: string]: any
+}
+
+export interface Animation {
+  id: string
+  type: "fadeIn" | "fadeOut" | "slideIn" | "slideOut" | "scaleIn" | "scaleOut" | "bounce" | "shake"
+  duration: number
+  delay?: number
+  easing?: "linear" | "ease" | "ease-in" | "ease-out" | "ease-in-out"
+  direction?: "left" | "right" | "up" | "down"
+  properties?: Record<string, any>
+}
+
+export interface StyleTemplateCategory {
+  id: string
+  name: {
+    ru: string
+    en: string
+  }
+  description: {
+    ru: string
+    en: string
+  }
+  icon?: string
+  templates: StyleTemplate[]
+}
+
+export interface StyleTemplateFilter {
+  category?: string
+  style?: string
+  aspectRatio?: string
+  hasText?: boolean
+  hasAnimation?: boolean
+  duration?: {
+    min?: number
+    max?: number
+  }
+}
+
+export type StyleTemplateSortBy = "name" | "duration" | "category" | "style" | "recent"
+export type StyleTemplateSortField = "name" | "duration" | "category" | "style"
+export type StyleTemplateSortOrder = "asc" | "desc"

--- a/src/features/style-templates/types/style-template.ts
+++ b/src/features/style-templates/types/style-template.ts
@@ -1,7 +1,5 @@
 /**
  * Типы для стилистических шаблонов
- *
- * Re-export from canonical source in video-editing domain
  */
 
 export type {
@@ -14,4 +12,4 @@ export type {
   StyleTemplateSortField,
   StyleTemplateSortOrder,
   TemplateElement,
-} from "@/domains/video-editing/types/templates"
+} from "@/core/types"


### PR DESCRIPTION
## Summary
- add core-facing style-template contracts under `src/core/types`
- point `features/style-templates` type barrel at `@/core/types` instead of `domains/video-editing`
- update the package-boundary baseline from 406 to 405 `ui -> domains` warnings

Refs #165

## Verification
- `bun install --frozen-lockfile --ignore-scripts`
- `bun run check:boundaries`
- `bun run check:boundaries:baseline`
- `bun run check:workspaces`
- `bun run check:type`
- `bunx vitest run src/features/style-templates/components/__tests__/style-template-drag-source.test.tsx src/features/style-templates/__tests__/hooks/use-style-templates.test.ts src/features/style-templates/__tests__/utils/style-template-utils.test.ts src/features/style-templates/__tests__/utils/custom-templates-storage.test.ts`

## Notes
- The broader style-template targeted run still has existing failures in `style-template-preview.test.tsx` and `use-style-templates-import.test.ts`; both continue to exercise the real `ResourcesProvider` instead of the mocked resource callbacks and are unrelated to this type-only slice.