### PR TITLE
chore: decouple style template preview from domains

### DIFF
--- a/config/package-boundaries-baseline.json
+++ b/config/package-boundaries-baseline.json
@@ -1,11 +1,11 @@
 {
   "updated": "2026-06-10",
-  "source": "Phase F7 style-template core types",
-  "violations": 405,
+  "source": "Phase F7 style-template preview boundary",
+  "violations": 403,
   "bySeverity": {
-    "warn": 405
+    "warn": 403
   },
   "byEdge": {
-    "ui -> domains": 405
+    "ui -> domains": 403
   }
 }

--- a/src/features/style-templates/__tests__/hooks/use-style-templates-import.test.ts
+++ b/src/features/style-templates/__tests__/hooks/use-style-templates-import.test.ts
@@ -64,8 +64,8 @@ vi.mock("@/lib/tauri-logger", async (importOriginal) => {
 const mockAddStyleTemplate = vi.fn()
 
 // Мокаем useResources для возврата mockAddStyleTemplate
-vi.mock("@/domains/video-editing", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/domains/video-editing")>()
+vi.mock("@/features/timeline/providers/resources-provider", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/timeline/providers/resources-provider")>()
   return {
     ...actual,
     useResources: () => ({

--- a/src/features/style-templates/components/__tests__/style-template-preview.test.tsx
+++ b/src/features/style-templates/components/__tests__/style-template-preview.test.tsx
@@ -18,8 +18,8 @@ vi.mock("@/features/user-settings/hooks/use-user-settings", () => ({
   }),
 }))
 
-vi.mock("@/domains/video-editing", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/domains/video-editing")>()
+vi.mock("@/features/timeline/providers/resources-provider", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/timeline/providers/resources-provider")>()
   return {
     ...actual,
     useResources: () => ({

--- a/src/features/style-templates/components/style-template-preview.tsx
+++ b/src/features/style-templates/components/style-template-preview.tsx
@@ -1,12 +1,16 @@
 import { Play } from "lucide-react"
 import { useCallback, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { MediaType } from "@/domains/media-management"
-import type { StyleTemplateResource } from "@/domains/shared/types/resources"
 import { AddMediaButton } from "@/features/browser/components/layout/add-media-button"
 import { FavoriteButton } from "@/features/browser/components/layout/favorite-button"
 import { useResources } from "@/features/timeline/providers/resources-provider"
 import type { StyleTemplate } from "../types"
+
+type FavoriteButtonFile = React.ComponentProps<typeof FavoriteButton>["file"]
+type StyleTemplateTimelineResource = Extract<
+  React.ComponentProps<typeof AddMediaButton>["resource"],
+  { type: "styleTemplate" }
+>
 
 interface StyleTemplatePreviewProps {
   template: StyleTemplate
@@ -36,6 +40,28 @@ export function StyleTemplatePreview({
 
   // Проверяем, добавлен ли шаблон в ресурсы
   const isAdded = useMemo(() => isStyleTemplateAdded(template), [isStyleTemplateAdded, template])
+  const templateName = template.name[currentLanguage]
+  const favoriteFile = useMemo<FavoriteButtonFile>(
+    () => ({
+      id: template.id,
+      path: "",
+      name: templateName,
+      type: "graphics" as FavoriteButtonFile["type"],
+    }),
+    [template.id, templateName],
+  )
+  const styleTemplateResource = useMemo<StyleTemplateTimelineResource>(
+    () => ({
+      id: template.id,
+      type: "styleTemplate",
+      name: templateName,
+      resourceId: template.id,
+      addedAt: 0,
+      template,
+      params: {},
+    }),
+    [template, templateName],
+  )
 
   // Делаем превью квадратными, как в Effects
   const width = previewWidth ?? size
@@ -160,12 +186,7 @@ export function StyleTemplatePreview({
 
         {/* Кнопка избранного */}
         <FavoriteButton
-          file={{
-            id: template.id,
-            path: "",
-            name: template.name[currentLanguage],
-            type: MediaType.Graphics,
-          }}
+          file={favoriteFile}
           size={size}
           type="styleTemplate"
           data-oid="igl6i04"
@@ -177,13 +198,7 @@ export function StyleTemplatePreview({
           data-oid="nfarhzu"
         >
           <AddMediaButton
-            resource={
-              {
-                id: template.id,
-                type: "styleTemplate",
-                name: template.name[currentLanguage],
-              } as StyleTemplateResource
-            }
+            resource={styleTemplateResource}
             size={size}
             type="styleTemplate"
             data-oid="b8fv3fd"


### PR DESCRIPTION
## Summary
- remove direct domain imports from `StyleTemplatePreview` by deriving button payload types from the local browser buttons
- pass a complete style-template resource payload to `AddMediaButton` instead of a partial cast
- update style-template tests to mock the actual `resources-provider` dependency
- update package-boundary baseline from 405 to 403 `ui -> domains` warnings

Refs #165

## Verification
- `bun install --frozen-lockfile --ignore-scripts`
- `bun run check:boundaries`
- `bun run check:boundaries:baseline`
- `bun run check:workspaces`
- `bun run check:type`
- `bunx vitest run src/features/style-templates/components/__tests__/style-template-preview.test.tsx src/features/style-templates/components/__tests__/style-template-drag-source.test.tsx src/features/style-templates/__tests__/hooks/use-style-templates.test.ts src/features/style-templates/__tests__/hooks/use-style-templates-import.test.ts src/features/style-templates/__tests__/utils/style-template-utils.test.ts src/features/style-templates/__tests__/utils/custom-templates-storage.test.ts`