### PR TITLE
chore: decouple resources types from domains

### DIFF
--- a/config/package-boundaries-baseline.json
+++ b/config/package-boundaries-baseline.json
@@ -1,11 +1,11 @@
 {
   "updated": "2026-06-10",
-  "source": "Phase F7 style-template preview boundary",
-  "violations": 403,
+  "source": "Phase F7 resources local types",
+  "violations": 400,
   "bySeverity": {
-    "warn": 403
+    "warn": 400
   },
   "byEdge": {
-    "ui -> domains": 403
+    "ui -> domains": 400
   }
 }

--- a/src/features/resources/__tests__/components/resources-panel.test.tsx
+++ b/src/features/resources/__tests__/components/resources-panel.test.tsx
@@ -34,7 +34,7 @@ vi.mock("../../components/resource-thumbnail", () => ({
 
 // Mock useResources hook
 const mockUseResources = vi.fn()
-vi.mock("@/domains/video-editing", () => ({
+vi.mock("@/features/timeline/providers/resources-provider", () => ({
   useResources: () => mockUseResources(),
 }))
 

--- a/src/features/resources/index.ts
+++ b/src/features/resources/index.ts
@@ -1,2 +1,2 @@
-export * from "@/domains/video-editing"
+export * from "./types"
 export * from "./components/resources-panel"

--- a/src/features/resources/types.ts
+++ b/src/features/resources/types.ts
@@ -1,29 +1,279 @@
 /**
- * Типы перемещены в @/domains/shared/types/resources
- * Реэкспортируются здесь для обратной совместимости
+ * UI-facing resource types for the resources panel.
+ * Keep this file independent from domain packages so the feature can be
+ * extracted through package-boundary slices without changing runtime data.
  */
 
-export type {
-  EffectResource,
-  FilterResource,
-  MediaResource,
-  MusicResource,
-  Resource,
-  ResourceType,
-  StyleTemplateResource,
-  SubtitleResource,
-  TemplateResource,
-  TimelineResource,
-  TransitionResource,
-} from "@/domains/shared/types/resources"
+import { createLogger } from "@/lib/tauri-logger"
 
-export {
-  createEffectResource,
-  createFilterResource,
-  createMediaResource,
-  createMusicResource,
-  createStyleTemplateResource,
-  createSubtitleResource,
-  createTemplateResource,
-  createTransitionResource,
-} from "@/domains/shared/types/resources"
+const logger = createLogger("Resources:Types")
+
+export interface ResourceMediaFile {
+  id: string
+  name: string
+  path: string
+  type: any
+  duration?: number
+  size?: number
+  createdAt?: Date
+  updatedAt?: Date
+  width?: number
+  height?: number
+  fps?: number
+  bitrate?: number
+  thumbnail?: string
+  thumbnailPath?: string
+  probeData?: any
+  metadata?: {
+    type: "Video" | "Audio" | "Image"
+    [key: string]: any
+  }
+  isVideo?: boolean
+  isImage?: boolean
+  isAudio?: boolean
+  isAddedToTimeline?: boolean
+  isIncluded?: boolean
+  isUnavailable?: boolean
+  isLoadingMetadata?: boolean
+  [key: string]: any
+}
+
+export interface ResourceEffect {
+  id?: string
+  name?: string | { en?: string; ru?: string }
+  parameters?: Array<{
+    id: string
+    defaultValue?: any
+    [key: string]: any
+  }>
+  [key: string]: any
+}
+
+export interface ResourceFilter {
+  id?: string
+  name?: string
+  params?: Record<string, any>
+  [key: string]: any
+}
+
+export interface ResourceTransition {
+  id?: string
+  labels?: {
+    ru?: string
+    en?: string
+  }
+  parameters?: Record<string, any>
+  [key: string]: any
+}
+
+export interface ResourceTemplate {
+  id: string
+  [key: string]: any
+}
+
+export interface ResourceStyleTemplate {
+  id: string
+  name: string | { ru?: string; en?: string }
+  [key: string]: any
+}
+
+export interface ResourceSubtitleStyle {
+  id: string
+  name: string
+  [key: string]: any
+}
+
+export interface Resource {
+  id: string
+  type: ResourceType
+  name: string
+  resourceId: string
+  addedAt: number
+}
+
+export type ResourceType =
+  | "media"
+  | "music"
+  | "subtitle"
+  | "effect"
+  | "filter"
+  | "transition"
+  | "template"
+  | "styleTemplate"
+
+export interface MediaResource extends Resource {
+  type: "media"
+  file: ResourceMediaFile
+  params?: Record<string, any>
+}
+
+export interface MusicResource extends Resource {
+  type: "music"
+  file: ResourceMediaFile
+  params?: Record<string, any>
+}
+
+export interface SubtitleResource extends Resource {
+  type: "subtitle"
+  style: ResourceSubtitleStyle
+  params?: Record<string, any>
+}
+
+export interface EffectResource extends Resource {
+  type: "effect"
+  effect: ResourceEffect
+  params?: Record<string, any>
+}
+
+export interface FilterResource extends Resource {
+  type: "filter"
+  filter: ResourceFilter
+  params?: Record<string, any>
+}
+
+export interface TransitionResource extends Resource {
+  type: "transition"
+  transition: ResourceTransition
+  params?: Record<string, any>
+}
+
+export interface TemplateResource extends Resource {
+  type: "template"
+  template: ResourceTemplate
+  params?: Record<string, any>
+}
+
+export interface StyleTemplateResource extends Resource {
+  type: "styleTemplate"
+  template: ResourceStyleTemplate
+  params?: Record<string, any>
+}
+
+export type TimelineResource =
+  | MediaResource
+  | MusicResource
+  | SubtitleResource
+  | EffectResource
+  | FilterResource
+  | TransitionResource
+  | TemplateResource
+  | StyleTemplateResource
+
+export function createMediaResource(file: ResourceMediaFile): MediaResource {
+  return {
+    id: `media-${file.id}-${Date.now()}`,
+    type: "media",
+    name: file.name,
+    resourceId: file.id,
+    addedAt: Date.now(),
+    file,
+    params: {},
+  }
+}
+
+export function createMusicResource(file: ResourceMediaFile): MusicResource {
+  return {
+    id: `music-${file.id}-${Date.now()}`,
+    type: "music",
+    name: file.name,
+    resourceId: file.id,
+    addedAt: Date.now(),
+    file,
+    params: {},
+  }
+}
+
+export function createSubtitleResource(style: ResourceSubtitleStyle): SubtitleResource {
+  return {
+    id: `subtitle-${style.id}-${Date.now()}`,
+    type: "subtitle",
+    name: style.name,
+    resourceId: style.id,
+    addedAt: Date.now(),
+    style,
+    params: {},
+  }
+}
+
+export function createEffectResource(effect: ResourceEffect): EffectResource {
+  if (!effect || !effect.id || !effect.name) {
+    logger.errorSync("[createEffectResource] Invalid effect object", { effect })
+    throw new Error("Invalid effect object provided to createEffectResource")
+  }
+
+  return {
+    id: `effect-${effect.id}-${Date.now()}`,
+    type: "effect",
+    name: typeof effect.name === "string" ? effect.name : effect.name.en || effect.name.ru || "Effect",
+    resourceId: effect.id,
+    addedAt: Date.now(),
+    effect,
+    params: effect.parameters
+      ? effect.parameters.reduce<Record<string, any>>((acc, param) => {
+          acc[param.id] = param.defaultValue
+          return acc
+        }, {})
+      : {},
+  }
+}
+
+export function createFilterResource(filter: ResourceFilter): FilterResource {
+  if (!filter || !filter.id || !filter.name) {
+    logger.errorSync("[createFilterResource] Invalid filter object", { filter })
+    throw new Error("Invalid filter object provided to createFilterResource")
+  }
+
+  return {
+    id: `filter-${filter.id}-${Date.now()}`,
+    type: "filter",
+    name: filter.name,
+    resourceId: filter.id,
+    addedAt: Date.now(),
+    filter,
+    params: filter.params ? { ...filter.params } : {},
+  }
+}
+
+export function createTransitionResource(transition: ResourceTransition): TransitionResource {
+  if (!transition || !transition.id) {
+    logger.errorSync("[createTransitionResource] Invalid transition object", { transition })
+    throw new Error("Invalid transition object provided to createTransitionResource")
+  }
+
+  logger.infoSync("Creating transition resource from", { transitionId: transition.id })
+  const resource: TransitionResource = {
+    id: `transition-${transition.id}-${Date.now()}`,
+    type: "transition",
+    name: transition.labels?.ru || transition.id,
+    resourceId: transition.id,
+    addedAt: Date.now(),
+    transition,
+    params: transition.parameters ? { ...transition.parameters } : {},
+  }
+  logger.infoSync("Created transition resource", { resourceId: resource.id })
+  return resource
+}
+
+export function createTemplateResource(template: ResourceTemplate): TemplateResource {
+  return {
+    id: `template-${template.id}-${Date.now()}`,
+    type: "template",
+    name: template.id,
+    resourceId: template.id,
+    addedAt: Date.now(),
+    template,
+    params: {},
+  }
+}
+
+export function createStyleTemplateResource(template: ResourceStyleTemplate): StyleTemplateResource {
+  return {
+    id: `styleTemplate-${template.id}-${Date.now()}`,
+    type: "styleTemplate",
+    name: typeof template.name === "string" ? template.name : template.name.ru || template.name.en || template.id,
+    resourceId: template.id,
+    addedAt: Date.now(),
+    template,
+    params: {},
+  }
+}


### PR DESCRIPTION
## Summary
- replace `features/resources/types` domain re-exports with local UI-facing resource contracts and existing factory behavior
- stop re-exporting `domains/video-editing` from the `features/resources` barrel
- update `ResourcesPanel` tests to mock the actual resources-provider dependency
- update package-boundary baseline from 403 to 400 `ui -> domains` warnings

Refs #165

## Verification
- `bun install --frozen-lockfile --ignore-scripts`
- `bun run check:boundaries`
- `bun run check:boundaries:baseline`
- `bun run check:workspaces`
- `bun run check:type`
- `bunx vitest run src/features/resources/__tests__/types.test.ts src/features/resources/__tests__/components/resource-thumbnail.test.tsx src/features/resources/__tests__/components/resources-panel.test.tsx src/features/resources/__tests__/config/preview-config.test.ts`