### PR TITLE
chore: decouple transcription types from domains

### DIFF
--- a/config/package-boundaries-baseline.json
+++ b/config/package-boundaries-baseline.json
@@ -1,11 +1,11 @@
 {
   "updated": "2026-06-10",
-  "source": "Phase F7 resources local types",
-  "violations": 400,
+  "source": "Phase F7 transcription local types",
+  "violations": 398,
   "bySeverity": {
-    "warn": 400
+    "warn": 398
   },
   "byEdge": {
-    "ui -> domains": 400
+    "ui -> domains": 398
   }
 }

--- a/src/features/transcription/hooks/use-transcription.ts
+++ b/src/features/transcription/hooks/use-transcription.ts
@@ -1,13 +1,13 @@
 import { useCallback, useRef, useState } from "react"
 import { TranscriptionService } from "@/domains/ai-services/services/transcription-service"
+import { logError, logInfo } from "@/lib/tauri-logger"
 import type {
   ModelInfo,
   SubtitleFormat,
   TranscriptionOptions,
   TranscriptionProgress,
   TranscriptionResult,
-} from "@/domains/ai-services/types/transcription"
-import { logError, logInfo } from "@/lib/tauri-logger"
+} from "../types"
 
 export function useTranscription() {
   const [isTranscribing, setIsTranscribing] = useState(false)

--- a/src/features/transcription/types.ts
+++ b/src/features/transcription/types.ts
@@ -1,15 +1,71 @@
 /**
- * Типы для модуля транскрипции
- * Реэкспорт типов из domains/ai-services/types/transcription
+ * UI-facing transcription types.
+ * Keep these contracts local to the feature so UI code does not depend on
+ * ai-services domain type barrels while the service bridge is still legacy.
  */
 
-export type {
-  ModelInfo,
-  SubtitleFormat,
-  TranscriptionOptions,
-  TranscriptionProgress,
-  TranscriptionResult,
-  TranscriptionSegment,
-  TranscriptionWord,
-  WhisperIntegrationOptions,
-} from "@/domains/ai-services/types/transcription"
+export interface TranscriptionOptions {
+  language?: string
+  task: "transcribe" | "translate"
+  modelSize: "tiny" | "base" | "small" | "medium" | "large-v1" | "large-v2" | "large-v3"
+  wordTimestamps: boolean
+  vadFilter: boolean
+  maxSegmentLength?: number
+  provider?: "openai" | "local" | "faster-whisper"
+  device?: "auto" | "cpu" | "cuda" | "mps"
+  computeType?: "auto" | "int8" | "float16" | "float32"
+}
+
+export interface TranscriptionSegment {
+  id: number
+  start: number
+  end: number
+  text: string
+  words?: TranscriptionWord[]
+  confidence?: number
+  speaker?: string
+}
+
+export interface TranscriptionWord {
+  word: string
+  start: number
+  end: number
+  confidence?: number
+}
+
+export interface TranscriptionResult {
+  segments: TranscriptionSegment[]
+  language: string
+  languageProbability: number
+  duration: number
+  text: string
+  processingTime?: number
+}
+
+export interface TranscriptionProgress {
+  status: "idle" | "initializing" | "processing" | "completed" | "error"
+  progress: number
+  message?: string
+  currentTime?: number
+  totalTime?: number
+}
+
+export interface ModelInfo {
+  name: string
+  size: string
+  params?: string
+  englishOnly?: boolean
+  isDownloaded: boolean
+}
+
+export type SubtitleFormat = "srt" | "vtt" | "ass"
+
+export interface WhisperIntegrationOptions {
+  provider?: "whisper" | "faster-whisper" | "openai"
+  modelSize?: "tiny" | "base" | "small" | "medium" | "large-v3"
+  language?: string
+  wordTimestamps?: boolean
+  vadFilter?: boolean
+  device?: "auto" | "cpu" | "cuda" | "mps"
+  computeType?: "auto" | "int8" | "float16" | "float32"
+}


### PR DESCRIPTION
## Summary
- replace the `features/transcription/types` domain re-export with local UI-facing transcription contracts
- point `use-transcription` at the local type barrel while leaving the legacy runtime service bridge unchanged
- update package-boundary baseline from 400 to 398 `ui -> domains` warnings

Refs #165

## Verification
- `bun install --frozen-lockfile --ignore-scripts`
- `bun run check:boundaries`
- `bun run check:boundaries:baseline`
- `bun run check:workspaces`
- `bun run check:type`
- `bunx vitest run src/features/transcription/__tests__`