### PR TITLE
Add explicit timeouts to build workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     name: Build project
     runs-on: ubuntu-22.04
+    timeout-minutes: 90
 
     steps:
       - name: Checkout code

--- a/.github/workflows/bundle-analysis.yml
+++ b/.github/workflows/bundle-analysis.yml
@@ -11,6 +11,7 @@ jobs:
   bundle-analysis:
     name: Bundle Size Analysis
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
     
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- add an explicit 90 minute timeout to the main Build workflow job
- add an explicit 60 minute timeout to the Bundle Analysis workflow job
- keep the change scoped to CI guardrails so stuck Rust dependency builds cannot run until the default GitHub Actions limit

## Verification
- ruby YAML parse for changed workflows
- git diff --check