### PR TITLE
Refresh project roadmap after Phase G

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/timeline-studio?style=flat-square&label=downloads)](https://www.npmjs.com/package/timeline-studio)
 
 [![GitHub stars](https://img.shields.io/github/stars/chatman-media/timeline-studio?style=for-the-badge)](https://github.com/chatman-media/timeline-studio/stargazers)
-[![Documentation](https://img.shields.io/badge/read-docs-blue?style=for-the-badge)](./docs/en/README.md)
+[![Documentation](https://img.shields.io/badge/read-docs-blue?style=for-the-badge)](./docs/README.md)
 [![Telegram](https://img.shields.io/badge/Join%20Group-Telegram-2CA5E0?style=for-the-badge&logo=telegram&logoColor=white)](https://t.me/timelinestudio)
 [![Discord](https://img.shields.io/badge/Chat-on%20Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/uvSBCw6e)
 
@@ -76,7 +76,7 @@
 - **Modular Architecture** - easily add new features through plugins
 - **Open Source** - transparency and ability to participate in development
 
-![Timeline Interface #1](/public/screen.png)
+![Timeline Interface #1](/public/screen2.png)
 
 ## 🏗️ Architecture
 
@@ -88,16 +88,16 @@ Timeline Studio is built on modern modular architecture:
 - **UI Components** - shadcn/ui + Radix UI + Tailwind CSS v4
 - **TypeScript** - strict typing and safety
 
-### Backend (Rust + Tauri v2)
-- **Modular structure** - Core, Security, Media, Compiler, Plugins
-- **Service layer** - DI container, EventBus, Telemetry
-- **FFmpeg integration** - advanced video processing
-- **Security** - API key encryption, OAuth, Keychain
+### Backend and Headless Runtime
+- **Rust workspace** - `crates/*` owns schema, render, media analysis, montage, publish and the `timeline` CLI
+- **TypeScript workspaces** - `packages/core`, `packages/domains`, `packages/adapters`, `packages/ui`
+- **Desktop host** - Tauri v2 remains the desktop shell over the shared runtime
+- **Headless entrypoints** - `render-job`, `bot-workflow`, `bot-worker` and Rust `timeline`
 
-📚 **[Detailed Frontend Architecture →](docs/en/03_architecture/frontend/)**
-📚 **[Detailed Backend Architecture →](docs/en/03_architecture/backend/)**
-📚 **[Plugin System →](docs/en/08_tasks/planned/plugin-system.md)**
-🛠️ **[Technical Stack Details →](docs/en/03_architecture/backend/rust-architecture.md#technology-overview)**
+📚 **[Detailed Frontend Architecture →](docs/03_architecture/frontend/)**
+📚 **[Detailed Backend Architecture →](docs/03_architecture/backend/)**
+📚 **[Plugin System →](docs/08_tasks/planned/plugin-system.md)**
+🛠️ **[Technical Stack Details →](docs/03_architecture/backend/rust-architecture.md#technology-overview)**
 
 ## 🤖 AI Integration
 
@@ -118,40 +118,36 @@ Timeline Studio features comprehensive AI integration with 100+ specialized tool
 - **And 40+ more specialized tools**
 
 📚 **[AI Chat Documentation →](src/features/ai-chat/README.md)**
-🛠️ **[AI Tools Reference →](src/features/ai-chat/tools/README.md)**
+🛠️ **[AI Tools Reference →](packages/domains/src/ai-tools/README.md)**
 
-## 📚 Backend Module Documentation
+## 📚 Runtime Documentation
 
-Timeline Studio uses a modular Rust backend architecture. Each module provides specific functionality:
+Timeline Studio uses a modular Rust + TypeScript workspace architecture. Desktop, CLI and bot/headless workflows share the same contracts where possible.
 
-### Core Modules
-🔧 **[Core System](src-tauri/src/core/README.md)** - DI container, EventBus, Performance monitoring
-🔌 **[Plugin System](src-tauri/src/core/plugins/README.md)** - Modular plugin architecture with sandbox security
-🎬 **[Video Compiler](src-tauri/src/video_compiler/README.md)** - FFmpeg integration and video processing
-📁 **[Media Management](src-tauri/src/media/README.md)** - File scanning, metadata extraction, thumbnails
+### Headless and Contracts
+📚 **[External Headless Contracts](docs/engineering/external-headless-contracts.md)** - supported `ProjectSchema`, Rust `timeline`, `render-job`, `bot-workflow`, `bot-worker` and `bot-cleanup` entrypoints
+🤖 **[Bot-First Production Contract](docs/engineering/bot-first-production-contract.md)** - Telegram AI review state, restart, retry, cleanup and Rust publish boundary
+🧪 **[Telegram AI Review Sandbox Smoke](docs/06_deployment/telegram-ai-review-sandbox-smoke.md)** - mocked and real sandbox validation path
 
-### AI & Recognition
-🧠 **[Smart Montage Planner](src-tauri/src/montage_planner/README.md)** - AI-powered video montage generation
-👁️ **[Recognition System](src-tauri/src/recognition/README.md)** - YOLO object detection and scene analysis
-📝 **[Subtitles Engine](src-tauri/src/subtitles/README.md)** - Subtitle generation, parsing, synchronization
+### Architecture
+🧱 **[Package Boundaries](docs/engineering/package-boundaries.md)** - workspace ownership and import boundaries
+🔁 **[Root Compatibility Shims](docs/engineering/root-compatibility-shims.md)** - temporary root paths and migration criteria
+🦀 **[Rust Backend Architecture](docs/03_architecture/backend/rust-architecture.md)** - Rust/Tauri architecture and technology overview
 
-### Security & Services
-🔒 **[Security Module](src-tauri/src/security/README.md)** - API validation, OAuth, secure storage
-
-*All modules include comprehensive test suites and detailed API documentation.*
+*`src-tauri` remains a desktop host/glue layer. External consumers should use the documented headless entrypoints instead of importing desktop internals.*
 
 ## 🏗️ Project Status
 
 **🚀 Alpha version: 97.5% ready** 🎯
 
-✅ **Completed**: 55+ modules (100% ready) - 30+ frontend + 25+ backend
+✅ **Completed**: modular Rust workspace, TypeScript workspaces and bot-first/headless contract hardening
 📋 **Recently Completed**:
-- 🤖 **AI Chat Integration** - Full Claude/OpenAI/DeepSeek/Ollama provider support with 100+ specialized tools
-- 💬 **Chat UI** - Modern chat interface with markdown support, code highlighting, and streaming responses
-- 🧠 **Smart Montage Planner** - AI-powered automatic montage generation with quality analysis
-- 🎬 **Timeline Integration** - Complete timeline editing with AI assistance
+- 📦 **Phase F TypeScript Workspaces** - `core`, `domains`, `adapters`, `ui`, `apps/desktop` and `apps/cli`
+- 🤖 **Bot-first Telegram AI Review** - upload, preview, text/voice/video-note revisions, approval and publish
+- 🧱 **Phase G Headless Contracts** - supported external entrypoints, package boundaries and root shim migration path
+- ✅ **Green main CI** - build, frontend tests, bot/AI headless tests and Node lint after Phase G merge
 
-[→ Detailed Roadmap](docs/en/10_project_state/)
+[→ Detailed Roadmap](docs/10_project_state/)
 
 ## Getting Started
 
@@ -190,10 +186,10 @@ sudo apt-get install ffmpeg libavcodec-dev libavformat-dev
 - **macOS**: Install Xcode Command Line Tools: `xcode-select --install`
 - **Linux**: Install build essentials: `sudo apt-get install build-essential`
 
-📚 **[Complete Installation Guide →](docs/en/02_requirements/)**
-🪟 **[Windows Setup →](docs/en/06_deployment/platforms/)**
+📚 **[Complete Installation Guide →](docs/02_requirements/)**
+🪟 **[Windows Setup →](docs/06_deployment/platforms/)**
 🎥 **[Video Tutorial →](https://www.youtube.com/@chatman-media)**
-📖 **[Full Documentation →](docs/en/)** - Complete documentation with 18+ sections
+📖 **[Full Documentation →](docs/)** - Complete documentation with 18+ sections
 
 ## Development
 
@@ -210,7 +206,7 @@ bun run test && bun run test:rust
 bun run check:all
 ```
 
-📚 **[Complete Development Guide →](docs/en/05_development/)**
+📚 **[Complete Development Guide →](docs/05_development/)**
 
 ## CI/CD & Code Quality
 
@@ -220,8 +216,8 @@ bun run check:all
 - ✅ **Coverage**: Codecov integration
 - ✅ **Build**: Cross-platform builds
 
-📚 **[Detailed CI/CD Guide →](docs/en/13_ci_cd/)**
-🔧 **[Linting & Formatting →](docs/en/05_development/linting-and-formatting.md)**
+📚 **[Detailed CI/CD Guide →](docs/13_ci_cd/)**
+🔧 **[Linting & Formatting →](docs/05_development/linting-and-formatting.md)**
 
 ## 👨‍💻 Developer Resources
 
@@ -231,15 +227,15 @@ bun run check:all
 - 💡 **[Feature Requests](https://github.com/chatman-media/timeline-studio/discussions)** - Suggest new features
 
 ### Plugin Development
-- 🔌 **[Plugin System Guide](docs/en/08_tasks/planned/plugin-system.md)** - Build your own plugins
-- 🚀 **[Plugin Quickstart](docs/en/05_development/)** - Get started in 5 minutes
-- 📦 **[Plugin API Reference](docs/en/04_api_reference/)** - Complete API documentation
+- 🔌 **[Plugin System Guide](docs/08_tasks/planned/plugin-system.md)** - Build your own plugins
+- 🚀 **[Plugin Quickstart](docs/05_development/)** - Get started in 5 minutes
+- 📦 **[Plugin API Reference](docs/04_api_reference/)** - Complete API documentation
 
 ### Testing & Quality
-- 🧪 **[Testing Guide](docs/en/12_testing/)** - Unit, integration, E2E testing
-- 📊 **[Test Utils](docs/en/12_testing/)** - Audio and Tauri component testing
+- 🧪 **[Testing Guide](docs/12_testing/)** - Unit, integration, E2E testing
+- 📊 **[Test Utils](docs/12_testing/)** - Audio and Tauri component testing
 - ✅ **[Code Style](CLAUDE.md#code-style-guidelines)** - Coding standards
-- 🔍 **[Performance Guide](docs/en/08_tasks/planned/performance-optimization.md)** - Optimization tips
+- 🔍 **[Performance Guide](docs/08_tasks/planned/performance-optimization.md)** - Optimization tips
 
 ## 🌐 Community & Support
 
@@ -250,21 +246,21 @@ bun run check:all
 [![YouTube](https://img.shields.io/badge/Subscribe-YouTube-FF0000?style=for-the-badge&logo=youtube&logoColor=white)](https://www.youtube.com/@chatman-media)
 
 ### Get Help
-- 📚 **[FAQ](docs/en/09_architectural_decisions/)** - Frequently asked questions
+- 📚 **[FAQ](docs/09_architectural_decisions/)** - Frequently asked questions
 - 💬 **[Discussions](https://github.com/chatman-media/timeline-studio/discussions)** - Ask questions, share ideas
 - 🐛 **[Issue Tracker](https://github.com/chatman-media/timeline-studio/issues)** - Report bugs
 - 📧 **Email Support** - ak.chatman.media@gmail.com
 
 ### Project Roadmap
-- 🗺️ **[Development Roadmap](docs/en/10_project_state/)** - See what's coming next
-- ✨ **[Completed Features](docs/en/08_tasks/completed/)** - Recently shipped features
-- 🎯 **[Alpha Release Progress](docs/en/17_releases/)** - 97.5% complete!
+- 🗺️ **[Development Roadmap](docs/10_project_state/)** - See what's coming next
+- ✨ **[Completed Features](docs/08_tasks/completed/)** - Recently shipped features
+- 🎯 **[Alpha Release Progress](docs/17_releases/)** - 97.5% complete!
 - 📊 **[Project Status](#project-status)** - Current development stats
 
 ### Support the Project
 - ⭐ **[Star on GitHub](https://github.com/chatman-media/timeline-studio)** - Show your support
 - 🤝 **[Contribute](CONTRIBUTING.md)** - Join the development
-- 💼 **[Commercial License](docs/en/11_legal/)** - For business use
+- 💼 **[Commercial License](docs/11_legal/)** - For business use
 
 ## 🤝 Contributors
 
@@ -349,4 +345,4 @@ Support the development via crypto donations:
 
 MIT License with Commons Clause - free for personal use, commercial use requires agreement.
 
-📄 **[Full License Details →](docs/en/11_legal/)** | 📧 **Commercial License**: ak.chatman.media@gmail.com
+📄 **[Full License Details →](docs/11_legal/)** | 📧 **Commercial License**: ak.chatman.media@gmail.com

--- a/docs/06_deployment/telegram-ai-review-sandbox-smoke.md
+++ b/docs/06_deployment/telegram-ai-review-sandbox-smoke.md
@@ -1,6 +1,6 @@
 # Telegram AI Review Sandbox Smoke
 
-**Status:** Phase G sandbox contract for [#289](https://github.com/chatman-media/timeline-studio/issues/289)
+**Status:** Completed Phase G sandbox contract for closed [#289](https://github.com/chatman-media/timeline-studio/issues/289)
 **Related:** [Bot-First Production Contract](../engineering/bot-first-production-contract.md), [Telegram Bot Worker Production Runbook](telegram-bot-worker-production.md), [Telegram AI Review Workflow](../08_tasks/planned/telegram-ai-review-workflow.md), [Timeline Studio CLI](../../apps/cli/COMMANDS.md)
 
 This smoke path validates the bot-first AI review loop without opening the desktop UI.

--- a/docs/06_deployment/telegram-bot-worker-production.md
+++ b/docs/06_deployment/telegram-bot-worker-production.md
@@ -1,6 +1,6 @@
 # Telegram Bot Worker Production Runbook
 
-**Status:** Production foundation documented for [#225](https://github.com/chatman-media/timeline-studio/issues/225)
+**Status:** Completed production foundation for closed [#225](https://github.com/chatman-media/timeline-studio/issues/225)
 **Related:** [Bot-First Production Contract](../engineering/bot-first-production-contract.md), [Telegram AI Review Sandbox Smoke](telegram-ai-review-sandbox-smoke.md), [Telegram AI Review Workflow](../08_tasks/planned/telegram-ai-review-workflow.md), [AI Module Stabilization](../08_tasks/planned/ai-module-node-rust-orchestration.md), [External And Headless Integration Contracts](../engineering/external-headless-contracts.md)
 
 This runbook defines the supported operating model for the Telegram bot-first and AI review worker. It covers topology, persistence, deployment, restart behavior, media retention and startup smoke. The product/runtime contract is in [Bot-First Production Contract](../engineering/bot-first-production-contract.md); the repeatable sandbox checklist is in [Telegram AI Review Sandbox Smoke](telegram-ai-review-sandbox-smoke.md).

--- a/docs/08_tasks/planned/README.md
+++ b/docs/08_tasks/planned/README.md
@@ -2,20 +2,36 @@
 
 Tasks planned for future development.
 
-## Tasks (30)
+*Last updated: 2026-06-11*
 
-### 🔴 CRITICAL
-- [Register Missing Tauri Commands](register-missing-tauri-commands.md) 🔴 **КРИТИЧЕСКИЙ** - 109 незарегистрированных команд
+## Current Recommendation
+
+The bot/headless migration backlog is complete in GitHub Project `Timeline Studio AI`. The next roadmap should be a new Phase H epic:
+
+**Phase H - Bot-first production rollout and external integration readiness**
+
+Recommended scope:
+
+- Real Telegram AI review sandbox smoke.
+- `postim`/headless integration example through supported entrypoints only.
+- Root compatibility shim retirement execution.
+- Rust/Node AI edit parity plan for future `llm-edit`.
+- Publish destination support matrix and validate-only coverage.
+- Operator observability for bot-worker sessions, revisions, preview renders and publish attempts.
+- Docs/SDK examples for `ProjectSchema`, `render-job`, `bot-workflow` and `bot-worker`.
+
+Details live in [Roadmap](../../10_project_state/roadmap.md#далее-phase-h-proposal).
+
+## Active Future Plans
 
 ### AI & Analysis
+
 - [AI Analysis Integration Plan](ai-analysis-integration-plan.md)
-- [AI Module Stabilization and Node/Rust Orchestration](ai-module-node-rust-orchestration.md) 🔴 **HIGH**
-- [AI Director v2 Concept](ai-director-v2-concept.md)
 - [Easy Mode AI Editor](easy-mode-ai-editor.md)
 - [Montage Planner Integration](montage-planner-integration-concept.md)
-- [Telegram AI Review Editing Workflow](telegram-ai-review-workflow.md) 🔴 **HIGH**
 
 ### Video & Effects
+
 - [Advanced Multicam Templates](advanced-multicam-templates.md)
 - [Effects Library Extension](effects-library-extension.md)
 - [Video Generation](video-generation.md)
@@ -23,35 +39,48 @@ Tasks planned for future development.
 - [Meme Machine](meme-machine.md)
 
 ### Cloud & Sync
+
 - [Cloud Rendering](cloud-rendering.md)
 - [Cloud Storage Sync](cloud-storage-sync.md)
 - [Live Streaming](live-streaming.md)
 
 ### Mobile & Apps
+
 - [Mobile Apps](mobile-apps.md)
 - [Telegram Mini App](telegram-mini-app.md)
 
 ### Architecture
-- [Register Missing Tauri Commands](register-missing-tauri-commands.md) 🔴 **КРИТИЧЕСКИЙ** - 109 команд
-- [AI Features Architecture Refactoring](ai-features-architecture-refactoring.md) 🔴 **HIGH**
-- [Browser Architecture Refactoring](browser-architecture-refactoring.md) 🟡 **MEDIUM** - 19 импортов
-- [Monorepo Packages Migration](monorepo-packages-migration.md) 🔴 **HIGH**
-- [Node.js Adapters Implementation](node-adapters-implementation.md) 🟡 **MEDIUM**
+
+- [AI Features Architecture Refactoring](ai-features-architecture-refactoring.md)
+- [Browser Architecture Refactoring](browser-architecture-refactoring.md)
+- [Export Architecture Refactoring](export-architecture-refactoring.md)
+- [Effects Architecture Refactoring](effects-architecture-refactoring.md)
+- [Montage Planner Refactoring](montage-planner-refactoring.md)
 
 ### Platform & Infrastructure
+
 - [Plugin System](plugin-system.md)
 - [EventBus API Extensions](eventbus-api-extensions.md)
 - [Performance Optimization](performance-optimization.md)
+- [Performance Rerender Optimization](performance-rerender-optimization.md)
 - [Stock Footage Integrations](stock-footage-integrations.md)
 - [Comprehensive Resources Database](comprehensive-resources-database.md)
 
 ### User System
+
 - [User Identity System](user-identity-system.md)
 - [User Analytics System](user-analytics-system.md)
 - [User Preferences Persistence](user-preferences-persistence.md)
 - [User Preferences AI Automation](user-preferences-ai-automation.md)
 - [Social Auth Integration](social-auth-integration.md)
 
----
+## Completed Specs Kept For History
 
-*Last updated: 2026-06-09 (AI Module Stabilization and Node/Rust Orchestration task added)*
+These documents remain in `planned/` because other docs link to their original paths, but their GitHub epics/issues are closed:
+
+- [Bot-first workflow](bot-first-workflow.md) - [#171](https://github.com/chatman-media/timeline-studio/issues/171)
+- [Telegram AI Review Editing Workflow](telegram-ai-review-workflow.md) - [#226](https://github.com/chatman-media/timeline-studio/issues/226)
+- [AI Module Stabilization and Node/Rust Orchestration](ai-module-node-rust-orchestration.md) - [#238](https://github.com/chatman-media/timeline-studio/issues/238)
+- [Monorepo Packages Migration](monorepo-packages-migration.md) - [#150](https://github.com/chatman-media/timeline-studio/issues/150)
+
+New work should create new planned docs or GitHub issues instead of extending those completed specs.

--- a/docs/08_tasks/planned/ai-module-node-rust-orchestration.md
+++ b/docs/08_tasks/planned/ai-module-node-rust-orchestration.md
@@ -37,7 +37,7 @@ Telegram AI review workflow уже добавил продуктовый кон�
 
 - Rust planner/editor parity still needs continued care when the Rust side changes its `ProjectSchema` emission.
 - Rust `llm-plan` is currently a first-cut planner only. It is not an edit command that accepts `currentProject + instruction + revisionHistory -> nextProject`.
-- Generic production topology, deployment assets, retention, cleanup jobs and sandbox operator checklist remain owned by B28/#225.
+- Generic production topology, deployment assets, retention and cleanup jobs were closed in B28/[#225](https://github.com/chatman-media/timeline-studio/issues/225). Real sandbox rollout and external consumer validation are now Phase H candidates.
 
 ## Node/Rust Ownership Decision
 
@@ -135,7 +135,7 @@ Operators should not need raw logs only to diagnose a review loop failure. The b
 
 The review chat exposes the same high-signal fields through `/status` and `/versions`: revision id, provider/model, prompt id, attempts, render job id, artifact reference, publish status and failure reason. API keys, tokens, authorization headers, secrets, passwords and credentials are redacted before they are stored or rendered.
 
-Workflow-specific runbook details live in [Telegram AI Review Editing Workflow](./telegram-ai-review-workflow.md). Generic deployment topology, log retention and cleanup policies stay linked to B28/#225.
+Workflow-specific runbook details live in [Telegram AI Review Editing Workflow](./telegram-ai-review-workflow.md). Generic deployment topology, log retention and cleanup policies are linked to closed B28/[#225](https://github.com/chatman-media/timeline-studio/issues/225). Real sandbox/production rollout belongs in the next roadmap.
 
 ## PR Slices
 
@@ -223,4 +223,4 @@ Workflow-specific runbook details live in [Telegram AI Review Editing Workflow](
 
 B39-B46 are complete and the Telegram AI review runtime now has a production Node/Rust boundary: Node owns Telegram orchestration, sessions, provider glue and validation; Rust owns first-cut planning, preview rendering and final publishing through CLI adapters.
 
-Remaining production-readiness work intentionally stays in [B28/#225](https://github.com/chatman-media/timeline-studio/issues/225): deployment topology, operator runbooks, retention/cleanup policy and sandbox checklist.
+Remaining production-readiness work is now the Phase H rollout layer: real sandbox execution, external consumer validation, operator observability and published integration examples. B28/[#225](https://github.com/chatman-media/timeline-studio/issues/225) is closed.

--- a/docs/08_tasks/planned/bot-first-workflow.md
+++ b/docs/08_tasks/planned/bot-first-workflow.md
@@ -1,13 +1,16 @@
 # Bot-first workflow
 
-**Статус:** Active, tracked in [#171](https://github.com/chatman-media/timeline-studio/issues/171)
+**Статус:** Completed, tracked in closed [#171](https://github.com/chatman-media/timeline-studio/issues/171)
 **Приоритет:** High
 **Создано:** 2026-06-08
+**Завершено:** 2026-06-10
 **Ответственный:** Architecture Team
 
 ## Контекст
 
 Целевая модель Timeline Studio - пользователь управляет созданием ролика через бота. Desktop UI остается полезным для просмотра, настройки и ручного редактирования, но основной happy path должен работать без открытия приложения: бот принимает материалы и параметры, запускает сборку проекта, рендерит видео и возвращает результат или публикует его в выбранный канал.
+
+Этот foundational epic закрыт. Production AI review, Node/Rust orchestration and external/headless contract hardening продолжены и закрыты в [#226](https://github.com/chatman-media/timeline-studio/issues/226), [#238](https://github.com/chatman-media/timeline-studio/issues/238) and [#282](https://github.com/chatman-media/timeline-studio/issues/282). Следующий recommended roadmap - [Phase H production rollout](../../10_project_state/roadmap.md#далее-phase-h-proposal).
 
 Это меняет приоритет архитектурной миграции: вместо отдельных UI/export slices нужно в первую очередь выделять headless contracts и worker-friendly services, которыми сможет пользоваться бот, CLI, desktop и будущий backend.
 

--- a/docs/08_tasks/planned/monorepo-packages-migration.md
+++ b/docs/08_tasks/planned/monorepo-packages-migration.md
@@ -1,9 +1,10 @@
 # Миграция на JS workspaces и модульную архитектуру
 
-**Статус:** Active, tracked in [#150](https://github.com/chatman-media/timeline-studio/issues/150)
+**Статус:** Completed, tracked in closed [#150](https://github.com/chatman-media/timeline-studio/issues/150)
 **Приоритет:** High
 **Создано:** 2025-11-29
 **Актуализировано:** 2026-06-11
+**Завершено:** 2026-06-10
 **Ответственный:** Architecture Team
 
 ## Контекст
@@ -36,7 +37,7 @@ timeline-studio/
 └── bun.lock
 ```
 
-После F5 пакеты получили физические workspace shells (`packages/*`, `apps/*`). После F7 package-boundary baseline снижен до нуля, поэтому следующие фазы переводят shell-пакеты в реальные владельцы кода:
+После F5 пакеты получили физические workspace shells (`packages/*`, `apps/*`). После F7 package-boundary baseline снижен до нуля. F9-F14 завершили физический перенос в реальные владельцы кода:
 
 - F9: `packages/core/src` становится владельцем core-контрактов, сервисов, hooks и типов.
 - F10: `packages/domains/src` становится владельцем domain-модулей.
@@ -59,7 +60,9 @@ adapters -> core
 
 ## Bot-first priority
 
-С 2026-06-08 следующий верхнеуровневый вектор - [Bot-first workflow](./bot-first-workflow.md). Phase F остается обязательной инженерной базой и quality gate, но новые slices должны в первую очередь приближать headless bot workflow: render job contracts, worker/event stream, intake contract и publishing destinations.
+С 2026-06-08 верхнеуровневым вектором был [Bot-first workflow](./bot-first-workflow.md). Phase F была обязательной инженерной базой и quality gate для этого направления: render job contracts, worker/event stream, intake contract and publishing destinations.
+
+На 2026-06-11 Phase F закрыта, а следующий фокус описан в [Roadmap](../../10_project_state/roadmap.md#далее-phase-h-proposal): production rollout and external integration readiness.
 
 ## Phase F PR slices
 

--- a/docs/08_tasks/planned/telegram-ai-review-workflow.md
+++ b/docs/08_tasks/planned/telegram-ai-review-workflow.md
@@ -1,6 +1,6 @@
 # Telegram AI Review Editing Workflow
 
-**Статус:** Implementation slice merged; production runtime stabilization completed in [AI Module Stabilization and Node/Rust Orchestration](./ai-module-node-rust-orchestration.md)
+**Статус:** Completed; implementation slice merged, production runtime stabilization completed in [AI Module Stabilization and Node/Rust Orchestration](./ai-module-node-rust-orchestration.md), external/headless contract hardening completed in [Phase G](https://github.com/chatman-media/timeline-studio/issues/282)
 **Приоритет:** High
 **Создано:** 2026-06-09
 **Ответственный:** Architecture Team
@@ -23,7 +23,7 @@ upload media
   -> publish only after explicit approval
 ```
 
-> Важно: этот документ описывает реализованный product/workflow contract. Production wiring для AI editor, Rust planner schema alignment, preview renderer and bot-worker CLI flags закрыты в [#238](https://github.com/chatman-media/timeline-studio/issues/238); deployment, retention and cleanup остаются в [#225](https://github.com/chatman-media/timeline-studio/issues/225).
+> Важно: этот документ описывает реализованный product/workflow contract. Production wiring для AI editor, Rust planner schema alignment, preview renderer and bot-worker CLI flags закрыты в [#238](https://github.com/chatman-media/timeline-studio/issues/238); deployment, retention and cleanup закрыты в [#225](https://github.com/chatman-media/timeline-studio/issues/225); supported external/headless contract закреплен в [#282](https://github.com/chatman-media/timeline-studio/issues/282). Следующий шаг - реальный sandbox/production rollout в [Phase H proposal](../../10_project_state/roadmap.md#далее-phase-h-proposal).
 
 ## Связь с B28 / production readiness
 
@@ -158,7 +158,7 @@ bun run smoke:ai-review:rust
 
 The repeatable sandbox operator checklist lives in [Telegram AI Review Sandbox Smoke](../../06_deployment/telegram-ai-review-sandbox-smoke.md). The production state, restart, cleanup and publish boundary lives in [Bot-First Production Contract](../../engineering/bot-first-production-contract.md).
 
-For production polling, keep model/provider and secret config at process/env/service-manager boundaries. Do not put raw provider credentials into edit session store metadata or issue/test output. Generic log retention, deployment topology and cleanup policies remain owned by B28/#225.
+For production polling, keep model/provider and secret config at process/env/service-manager boundaries. Do not put raw provider credentials into edit session store metadata or issue/test output. Generic log retention, deployment topology and cleanup policies were closed in B28/[#225](https://github.com/chatman-media/timeline-studio/issues/225); real sandbox rollout is a Phase H follow-up.
 
 ### Failure recovery checks
 

--- a/docs/10_project_state/current-status.md
+++ b/docs/10_project_state/current-status.md
@@ -1,81 +1,134 @@
 # Текущий статус Timeline Studio
 
-*Последнее обновление: 7 июня 2026*
+*Последнее обновление: 11 июня 2026*
 
 ## Сводка
 
-Timeline Studio перешел от монолитного Rust/Tauri backend к модульной headless-ready архитектуре на `ts-*` крейтах. Эпики декомпозиции и agentic pipeline закрыты:
+Timeline Studio завершил ключевой цикл архитектурного разбиения:
 
-- [#91](https://github.com/chatman-media/timeline-studio/issues/91) - декомпозиция монолита в layered Rust workspace.
+- Rust backend вынесен в layered workspace `crates/*`.
+- TypeScript runtime вынесен в workspaces `packages/*` и `apps/*`.
+- Bot-first/headless workflow доведен до production-oriented контракта.
+- External/headless integration boundaries закреплены для внешних потребителей.
+
+Последний закрытый этап: [Phase G - External/headless integration contract hardening](https://github.com/chatman-media/timeline-studio/issues/282). PR [#290](https://github.com/chatman-media/timeline-studio/pull/290) смержен в `main`, связанные задачи [#282](https://github.com/chatman-media/timeline-studio/issues/282)-[#289](https://github.com/chatman-media/timeline-studio/issues/289) закрыты и переведены в `Done`.
+
+На момент обновления GitHub Project `Timeline Studio AI` не содержит открытого backlog по текущему bot/headless треку. Поэтому следующий roadmap нужен отдельно: больше не стоит продолжать как "еще один рефакторинг перед всем"; следующий трек должен быть production rollout и external integration readiness.
+
+## Завершенные эпики
+
+- [#91](https://github.com/chatman-media/timeline-studio/issues/91) - Rust modularization into layered `ts-*` crates.
 - [#119](https://github.com/chatman-media/timeline-studio/issues/119) - agent-driven headless produce-to-publish pipeline.
-- [#120](https://github.com/chatman-media/timeline-studio/issues/120) - агентные контракты и `@timeline/shared-types`.
-
-Текущий фокус: стабилизировать CI после вынесения workspace packages, добавить headless smoke coverage и продолжить Phase F для TypeScript packages/workspaces.
+- [#120](https://github.com/chatman-media/timeline-studio/issues/120) - agent contracts and `@timeline/shared-types`.
+- [#171](https://github.com/chatman-media/timeline-studio/issues/171) - bot-first workflow foundation.
+- [#225](https://github.com/chatman-media/timeline-studio/issues/225) - bot-first production readiness leftovers.
+- [#226](https://github.com/chatman-media/timeline-studio/issues/226) - Telegram AI review editing workflow.
+- [#238](https://github.com/chatman-media/timeline-studio/issues/238) - AI module stabilization and Node/Rust orchestration.
+- [#150](https://github.com/chatman-media/timeline-studio/issues/150) - Phase F JS packages/workspaces.
+- [#282](https://github.com/chatman-media/timeline-studio/issues/282) - Phase G external/headless integration contract hardening.
 
 ## Архитектура
 
 ### Rust backend
 
-Модульная структура находится в `crates/`:
+Rust workspace находится в `crates/`:
 
-- `ts-schema` - `ProjectSchema` и контрактные типы.
-- `ts-core-types` - ошибки, EventBus, progress и общие DTO.
+- `ts-schema` - `ProjectSchema` and schema emission.
+- `ts-core-types` - errors, EventBus, progress and shared DTOs.
 - `ts-render` - headless render pipeline.
-- `ts-media`, `ts-recognition`, `ts-analysis`, `ts-montage`, `ts-subtitles` - доменные движки.
-- `ts-state` - headless `ProjectState` и `EventSink`.
-- `ts-agent` - agent orchestration и video tools.
-- `ts-platform`, `ts-publish`, `ts-cli` - оптимизация, публикация и единый headless CLI.
+- `ts-media`, `ts-recognition`, `ts-analysis`, `ts-montage`, `ts-subtitles` - domain engines.
+- `ts-state` - headless project state and event sink.
+- `ts-agent` - agent orchestration and video tools.
+- `ts-platform`, `ts-publish`, `ts-cli` - platform optimization, publishing and the Rust `timeline` CLI.
 
-`src-tauri` теперь выступает тонким host/glue слоем и подключает новые крейты path-зависимостями.
+`src-tauri` remains a desktop host/glue layer. External/headless consumers should not import `src-tauri` internals.
 
-### TypeScript packages
+### TypeScript workspaces
 
-Сейчас вынесен первый workspace package:
+Current workspace layout:
 
-- `packages/shared-types` - `@timeline/shared-types`, TS-зеркало Rust контрактов.
+- `packages/core` - `@timeline-studio/core`, platform-neutral ports, services, hooks and shared runtime contracts.
+- `packages/domains` - `@timeline-studio/domains`, domain modules and domain-owned machines/services.
+- `packages/adapters` - `@timeline-studio/adapters`, Node/Tauri/HTTP/mock/React adapter families.
+- `packages/ui` - `@timeline-studio/ui`, shared UI primitives and package-safe UI surfaces.
+- `packages/shared-types` - `@timeline/shared-types`, TypeScript mirror for Rust contract types.
+- `apps/cli` - `@timeline-studio/cli`, supported Node headless entrypoints.
+- `apps/desktop` - `@timeline-studio/desktop`, desktop app ownership metadata and compatibility entrypoints.
 
-Следующий трек описан в [#150](https://github.com/chatman-media/timeline-studio/issues/150): вынести `core`, `domains`, `adapters`, `ui` и подготовить `apps/desktop` / `apps/cli` без big-bang миграции.
+Package boundary rules are documented in [Package Boundaries](../engineering/package-boundaries.md) and enforced by `config/package-boundaries.json`.
 
-## Agent/headless integration
+## Supported Headless Contract
 
-Headless контур уже включает:
+Supported external/headless entrypoints are intentionally narrow:
 
-- `timeline render` - `ProjectSchema` JSON to video.
-- `timeline analyze` - media analysis JSON.
-- `timeline montage-plan` - montage plan to `ProjectSchema`.
-- `timeline optimize` / `thumbnail` - platform processing.
-- `timeline publish telegram|youtube` - реальные publish paths.
-- `timeline pipeline` - базовый `analyze -> optimize -> publish` flow.
-- `timeline emit-schema` / `emit-example` - внешний контракт.
+- `ProjectSchema` from `@timeline/shared-types`.
+- Rust `timeline` CLI from `crates/ts-cli`.
+- Node CLI `render-job`.
+- Node CLI `bot-workflow`.
+- Node CLI `bot-worker`.
+- Node CLI `bot-cleanup`.
 
-Контракт документирован в [AGENT_CONTRACT_REFERENCE.md](../engineering/AGENT_CONTRACT_REFERENCE.md).
+The contract is documented in [External And Headless Integration Contracts](../engineering/external-headless-contracts.md). Production Telegram review state/retry/cleanup/publish behavior is documented in [Bot-First Production Contract](../engineering/bot-first-production-contract.md).
 
-## Текущие блокеры
+Important boundary: external consumers such as `postim` should use the bot-first/headless layer and Rust CLI publish/render paths. They should not import root aliases, `src-tauri`, `packages/*/src`, or desktop internals.
 
-- [#147](https://github.com/chatman-media/timeline-studio/issues/147) - синхронизировать `bun.lock` и `package-lock.json` после `@timeline/shared-types`.
-- [#148](https://github.com/chatman-media/timeline-studio/issues/148) - исправить `ts-montage` doctest после смены API.
+## Current Gates
 
-Эта ветка содержит исправления для обоих пунктов; после merge нужно дождаться зеленого CI на `main`.
+The main branch is green after PR [#290](https://github.com/chatman-media/timeline-studio/pull/290). Post-merge workflows for commit `5f28fea3` completed successfully:
 
-## Следующие задачи
+- Bot AI Headless.
+- Build.
+- Bundle Analysis.
+- CI - Tests and Checks.
+- Lint Node.js.
+- Lint CSS.
+- Generate and Deploy API Docs.
+- Release.
 
-- [#149](https://github.com/chatman-media/timeline-studio/issues/149) - добавить end-to-end smoke для headless agent pipeline.
-- [#150](https://github.com/chatman-media/timeline-studio/issues/150) - Phase F: JS packages/workspaces.
-- Закрыть документационный долг в связанных архитектурных страницах после стабилизации CI.
+`Lint Rust` is skipped in that workflow configuration.
 
-## Проверки для ближайшего merge
-
-Минимальный набор:
-
-```bash
-bun install --frozen-lockfile
-npm ci --omit=optional
-cd crates && cargo test -p ts-montage --doc
-cd crates && cargo test --workspace --no-fail-fast -- --test-threads=2
-```
-
-Дополнительно для host changes:
+Local/PR validation for Phase G included:
 
 ```bash
-cd src-tauri && cargo check
+bun run lint:ci
+bun run check:type
+bun run check:boundaries:strict
+bun run check:boundaries:external
+bun run test:bot-ai
+bun run test
 ```
+
+## Current Risks
+
+No active project blocker is tracked in the GitHub project after Phase G. Remaining risks are product/production risks:
+
+- Real Telegram sandbox validation still needs operator-owned credentials and media fixtures.
+- Root compatibility shims are documented but not yet retired.
+- Rust `llm-plan` is still first-cut oriented; edit-capable Rust `llm-edit` remains a future parity track.
+- External consumer integration, especially `postim`, needs a concrete example contract and migration path.
+- Streaming should stay separate from Phase G and depend on stable headless boundaries.
+
+## Recommended Next Roadmap
+
+Create a new Phase H epic focused on production rollout and external integration readiness, not another broad extraction phase.
+
+Recommended Phase H scope:
+
+1. Real Telegram AI review sandbox smoke with operator checklist, redacted logs and rollback notes.
+2. `postim`/headless integration example using only supported entrypoints.
+3. Root compatibility shim retirement plan with package/export replacements.
+4. Rust/Node AI edit parity plan for `llm-edit` without blocking production bot usage.
+5. Publish destination support matrix and validate-only coverage for every supported destination.
+6. Operator observability for bot-worker sessions, revisions, preview renders and publish attempts.
+7. Docs/SDK examples for `ProjectSchema`, `render-job`, `bot-workflow` and `bot-worker`.
+
+Keep streaming as a separate future `ts-stream`/postim track that depends on Phase H contracts instead of being folded into Phase H.
+
+## Источники правды
+
+- [Roadmap](roadmap.md)
+- [External And Headless Integration Contracts](../engineering/external-headless-contracts.md)
+- [Bot-First Production Contract](../engineering/bot-first-production-contract.md)
+- [Root Compatibility Shims](../engineering/root-compatibility-shims.md)
+- [Package Boundaries](../engineering/package-boundaries.md)
+- [Timeline Studio CLI](../../apps/cli/COMMANDS.md)

--- a/docs/10_project_state/roadmap.md
+++ b/docs/10_project_state/roadmap.md
@@ -1,29 +1,29 @@
 # Roadmap Timeline Studio
 
-*Последнее обновление: 9 июня 2026*
+*Последнее обновление: 11 июня 2026*
 
 ## Видение
 
-Timeline Studio развивается в видеоредактор, которым можно пользоваться как через GUI, так и headless: агент получает цель, анализирует исходные медиа, строит `ProjectSchema`, рендерит, оптимизирует и публикует результат.
+Timeline Studio развивается в видеоредактор, которым можно пользоваться через desktop GUI, CLI и bot-first/headless workflows. Целевой поток: пользователь или внешний сервис передает медиа и цель, Timeline Studio строит `ProjectSchema`, рендерит, оптимизирует, возвращает preview, принимает правки и публикует только после явного approval.
 
-Ключевая архитектурная ставка: единый типизированный контракт между GUI, headless CLI, агентом и внешними интеграциями.
+Ключевая архитектурная ставка: один типизированный контракт между GUI, Rust CLI, Node bot worker, AI orchestration and external consumers.
 
 ## Завершено
 
 ### Rust modularization
 
-Закрыт epic [#91](https://github.com/chatman-media/timeline-studio/issues/91): backend распилен на layered `ts-*` crates.
+Закрыт epic [#91](https://github.com/chatman-media/timeline-studio/issues/91).
 
 Готово:
 
 - Cargo workspace для `crates/*`.
-- `ts-schema` и `ts-core-types` как foundation layer.
-- `ts-render` и headless render path.
-- Доменные крейты `ts-media`, `ts-recognition`, `ts-analysis`, `ts-montage`, `ts-subtitles`.
-- `ts-state` без Tauri-зависимости.
-- `ts-agent` и headless video tools.
-- Slim Tauri host поверх новых крейтов.
-- Изоляция heavy deps: `tauri`, `ort`, `pyo3`, `wasmtime` не протекают в общий headless path.
+- `ts-schema` and `ts-core-types` foundation layer.
+- `ts-render` and headless render path.
+- Domain crates: `ts-media`, `ts-recognition`, `ts-analysis`, `ts-montage`, `ts-subtitles`.
+- `ts-state` without Tauri dependency.
+- `ts-agent` and headless video tools.
+- Slim Tauri host over workspace crates.
+- Heavy dependencies isolated from the common headless path.
 
 ### Agentic headless pipeline
 
@@ -31,11 +31,11 @@ Timeline Studio развивается в видеоредактор, котор
 
 Готово:
 
-- Единый `timeline` CLI.
+- Rust `timeline` CLI.
 - `render`, `ingest`, `analyze`, `montage-plan`, `optimize`, `thumbnail`.
-- `publish telegram` и `publish youtube`.
-- `pipeline` для базового produce-to-publish flow.
-- LLM planner через OpenAI-compatible BYOK endpoint.
+- `publish telegram` and `publish youtube`.
+- `pipeline` for the basic produce-to-publish flow.
+- LLM planner through OpenAI-compatible BYOK endpoint.
 
 ### Contracts
 
@@ -48,98 +48,186 @@ Timeline Studio развивается в видеоредактор, котор
 - `@timeline/shared-types`.
 - [Agent Contract Reference](../engineering/AGENT_CONTRACT_REFERENCE.md).
 
+### Bot-first workflow
+
+Закрыт epic [#171](https://github.com/chatman-media/timeline-studio/issues/171).
+
+Готово:
+
+- `render-job`, `bot-workflow`, `bot-worker` CLI paths.
+- Telegram-like intake, media resolver, draft state, async queue, retry/cancel/status commands.
+- Bot workflow job store and polling offset store.
+- Rust render/publish adapters for bot-first paths.
+- Backpressure, acknowledgements and update-level error isolation.
+
+### Telegram AI review workflow
+
+Закрыт epic [#226](https://github.com/chatman-media/timeline-studio/issues/226).
+
+Готово:
+
+- Upload -> first preview -> text/voice/video-note revisions -> approval -> publish.
+- File-backed edit sessions and revision history.
+- AI project editor contract with validation/repair boundary.
+- First-cut generator via Rust planner with deterministic fallback.
+- Review commands: `/approve`, `/revise`, `/versions`, `/discard`, `/cancel`.
+- Per-revision preview artifact metadata and Telegram preview delivery.
+
+### AI module stabilization and Node/Rust orchestration
+
+Закрыт epic [#238](https://github.com/chatman-media/timeline-studio/issues/238).
+
+Готово:
+
+- Node owns Telegram orchestration, sessions, provider glue and validation.
+- Rust owns first-cut planning, preview rendering and final publishing through CLI adapters.
+- `bot-worker` production mode wires real AI review services, not only mocked unit smoke.
+- Dedicated bot/AI headless CI protects review-loop regressions.
+
+### Phase F: TypeScript workspaces
+
+Закрыт epic [#150](https://github.com/chatman-media/timeline-studio/issues/150).
+
+Готово:
+
+- `packages/core`, `packages/domains`, `packages/adapters`, `packages/ui`, `packages/shared-types`.
+- `apps/desktop` and `apps/cli`.
+- Zero package-boundary baseline.
+- `check:boundaries:strict` in CI.
+- Workspace-local test setup helpers.
+
+### Phase G: External/headless contract hardening
+
+Закрыт epic [#282](https://github.com/chatman-media/timeline-studio/issues/282).
+
+Готово:
+
+- Supported external entrypoints documented: `ProjectSchema`, Rust `timeline`, `render-job`, `bot-workflow`, `bot-worker`, `bot-cleanup`.
+- `postim`/headless guidance: use bot-first/headless layer, not `src-tauri`, root aliases or package-private paths.
+- Root compatibility shims documented with owners and removal criteria.
+- External contract examples guarded by `bun run check:boundaries:external`.
+- Telegram AI review sandbox smoke documented and expanded to text, voice and video-note feedback.
+- Bot-first production contract documents state, restart, retry, cleanup and Rust publish boundary.
+
 ## Сейчас
 
-### P0: стабилизировать CI
+There is no open GitHub Project backlog left for the completed bot/headless migration track. The immediate project need is not another broad refactor; it is a new production/external rollout roadmap.
 
-- [#147](https://github.com/chatman-media/timeline-studio/issues/147) - lock-файлы для `@timeline/shared-types`.
-- [#148](https://github.com/chatman-media/timeline-studio/issues/148) - `ts-montage` doctest/API drift.
+Current baseline:
 
-Acceptance:
+- `main` is green after PR [#290](https://github.com/chatman-media/timeline-studio/pull/290).
+- Issues [#282](https://github.com/chatman-media/timeline-studio/issues/282)-[#289](https://github.com/chatman-media/timeline-studio/issues/289) are closed and `Done`.
+- Supported headless boundaries are now documented and enforced for docs examples.
 
-- `bun install --frozen-lockfile` проходит.
-- `npm ci --omit=optional` проходит.
-- `cd crates && cargo test -p ts-montage --doc` проходит.
-- Crates workspace CI больше не падает на doctest.
+## Далее: Phase H proposal
 
-### P1: защитить headless pipeline
+Recommended next epic: **Phase H - Bot-first production rollout and external integration readiness**.
 
-- [#149](https://github.com/chatman-media/timeline-studio/issues/149) - end-to-end smoke для agent produce-to-publish.
+This phase should be hardening for real consumers, not another extraction phase. It should keep the official entrypoints stable and prove they are usable outside the desktop app.
 
-Acceptance:
+### H1: Real Telegram AI review sandbox
 
-- Быстрый smoke можно запускать локально и в CI.
-- Проверяется минимальный contract/render/analyze/pipeline path без GUI.
-- Failure clearly points to the broken pipeline step.
-
-### P1: Telegram AI review workflow
-
-- [#226](https://github.com/chatman-media/timeline-studio/issues/226) - Telegram становится интерфейсом итеративного AI-редактирования: upload, first preview, text/voice feedback, preview revisions, explicit approval and Rust-first publish. Implementation slice merged; production runtime stabilization completed in [#238](https://github.com/chatman-media/timeline-studio/issues/238).
-- [#225](https://github.com/chatman-media/timeline-studio/issues/225) документирует production topology, deployment foundation, generic media retention and cleanup policy. Runtime cleanup command/job: [#262](https://github.com/chatman-media/timeline-studio/issues/262).
-
-Готово в текущем implementation slice:
-
-- Edit session store, revision history and file-backed restart recovery.
-- Telegram voice/video-note feedback intake and transcription boundary.
-- AI project editor contract with validation/repair and deterministic mock.
-- First-cut generator boundary over Rust planner with deterministic fallback.
-- Review commands: `/approve`, `/revise`, `/versions`, `/discard`, `/cancel`.
-- Approval-gated publishing and Rust publish adapter for bot path.
-- Destination capability validation before render/publish.
-- Per-revision preview artifact metadata, Telegram `sendVideo` delivery and fallback links.
-- Mocked smoke for upload -> first preview -> text revision -> voice revision -> approval -> publish.
-
-### P1: AI module stabilization and Node/Rust orchestration
-
-- [#238](https://github.com/chatman-media/timeline-studio/issues/238) - production AI path для Telegram review workflow стабилизирован; граница ответственности Node/Rust закреплена.
-- [#239](https://github.com/chatman-media/timeline-studio/issues/239) - аудит текущих AI модулей, headless flows and broken wiring.
-- [#240](https://github.com/chatman-media/timeline-studio/issues/240) - Node/Rust ownership boundary.
-
-Итог:
-
-- `bot-worker` CLI прокидывает production `editSessionStore`, `feedbackTranscriber`, `aiProjectEditor`, Rust first-cut planner/generator fallback, preview renderer and publish services.
-- `IAIProjectEditor` имеет production OpenAI-compatible adapter; Rust `llm-edit` command остается medium-term направлением.
-- Rust `montage-plan`/`llm-plan` output покрыт TS `ProjectSchema` validation fixtures; deterministic fallback остается явным диагностируемым режимом.
-- Render and publish should stay Rust-first through `timeline render` / `timeline publish`; Node owns orchestration, sessions, provider glue and Telegram runtime.
+Goal: run the documented Telegram AI review loop against a real sandbox bot/channel with redacted logs and repeatable operator steps.
 
 Acceptance:
 
-- [x] Bot review loop runs from CLI with production wiring, not only mocked unit smoke.
-- [x] First-cut and edit outputs validate as canonical `ProjectSchema` or fail/fallback with explicit diagnostics.
-- [x] Text and voice feedback share one AI editor path.
-- [x] Dedicated headless bot/AI smoke catches regressions separately from the large frontend suite.
+- Real media upload produces first preview.
+- Text, voice and video-note revisions produce validated previews.
+- Approval gates publish.
+- Failure/retry path is documented with safe recovery.
 
-### P1: Phase F TypeScript packages
+### H2: `postim`/headless integration example
 
-- [#150](https://github.com/chatman-media/timeline-studio/issues/150) - JS packages/workspaces для `core`, `domains`, `adapters`, `ui`.
+Goal: give external consumers a concrete integration path without importing internals.
 
 Acceptance:
 
-- Есть пошаговый migration plan.
-- UI не импортирует platform-specific adapters напрямую.
-- Каждый slice оставляет desktop app buildable/testable.
+- Example uses only `ProjectSchema`, `render-job`, `bot-workflow`, `bot-worker`, `bot-cleanup` or Rust `timeline`.
+- No root aliases, `src-tauri`, `packages/*/src`, or desktop-only paths.
+- Example is covered by `check:boundaries:external`.
 
-## Далее
+### H3: Root shim retirement execution
 
-### Product hardening
+Goal: turn the shim inventory into migration slices.
 
-- Реальные fixture-based integration tests для render/analyze/publish validate paths.
-- Улучшение diagnostics для CLI и agent contract validation.
-- Headless Docker image и runtime docs после стабилизации CI.
+Acceptance:
 
-### Frontend architecture
+- Each root compatibility path has an owner, package replacement and removal condition.
+- Migration docs show old import -> supported import mapping.
+- No external/headless docs recommend root shims.
 
-- Перенести существующие Ports & Adapters правила из docs в enforceable import boundaries.
-- Начать package extraction с минимального shared/core слоя, затем adapters, затем UI/features.
+### H4: Rust/Node AI edit parity plan
 
-### Documentation
+Goal: define the path from Node-only `IAIProjectEditor` to Rust-backed `llm-edit` without blocking current production bot usage.
 
-- Обновить architecture overview под `crates/*`, `packages/shared-types` и `timeline` CLI.
-- Связать user-facing docs с headless/agent flows только после green smoke coverage.
+Acceptance:
+
+- `llm-edit` input/output contract is documented.
+- Current Node AI editor remains supported orchestration glue.
+- `ProjectSchema` stays canonical.
+
+### H5: Publish destination support matrix
+
+Goal: make publish behavior explicit across Telegram, YouTube and future destinations.
+
+Acceptance:
+
+- Matrix documents render support, validate-only support, credential requirements and failure modes.
+- Unsupported destinations fail before render/publish with actionable diagnostics.
+- TypeScript does not become a second production publish backend for Rust-supported destinations.
+
+### H6: Operator observability
+
+Goal: make bot-worker production failures debuggable without reading raw logs only.
+
+Acceptance:
+
+- Session/revision/publish diagnostics are persisted with redaction.
+- `/status` and `/versions` expose high-signal fields.
+- Preview render and publish failures retain enough metadata for retry.
+
+### H7: Docs and SDK examples
+
+Goal: make the supported contract copy-pasteable for integrators.
+
+Acceptance:
+
+- Minimal `ProjectSchema` example.
+- `render-job` JSON example.
+- `bot-workflow` Telegram-like fixture example.
+- `bot-worker` production/sandbox config example.
+- Docs examples pass boundary guardrails.
+
+## Separate Future Track
+
+Streaming should remain separate from Phase H.
+
+Recommended future track: `ts-stream` / postim streaming integration after Phase H confirms stable headless contracts. It should depend on the supported entrypoints and add streaming-specific APIs only where the current render/publish contract is insufficient.
+
+## Current Quality Gates
+
+For changes touching headless contracts, run:
+
+```bash
+bun run check:boundaries:strict
+bun run check:boundaries:external
+bun run test:bot-ai
+bun run check:type
+```
+
+For broad workspace changes, also run:
+
+```bash
+bun run lint:ci
+bun run test
+```
 
 ## Источники правды
 
 - [Current Status](current-status.md)
-- [Agent Contract Reference](../engineering/AGENT_CONTRACT_REFERENCE.md)
-- [Rust crates workspace](../../crates/Cargo.toml)
-- [Shared TypeScript package](../../packages/shared-types/package.json)
+- [External And Headless Integration Contracts](../engineering/external-headless-contracts.md)
+- [Bot-First Production Contract](../engineering/bot-first-production-contract.md)
+- [Telegram AI Review Sandbox Smoke](../06_deployment/telegram-ai-review-sandbox-smoke.md)
+- [Root Compatibility Shims](../engineering/root-compatibility-shims.md)
+- [Package Boundaries](../engineering/package-boundaries.md)
+- [Timeline Studio CLI](../../apps/cli/COMMANDS.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,9 +13,9 @@
 
 ## 📁 Структура документации
 
-### [00_manifest/](00_manifest/)
+### [00_project_manifest/](00_project_manifest/)
 Главный документ с видением, целями и ключевыми инновациями проекта:
-- **[Манифест проекта](00_manifest/project-overview.md)** - Полное описание проекта и его инноваций
+- **[Манифест проекта](00_project_manifest/README.md)** - Полное описание проекта и его инноваций
 
 ### [01_project_docs/](01_project_docs/)
 - **[Обзор архитектуры](01_project_docs/architecture-overview.md)** - Высокоуровневый обзор системы
@@ -53,9 +53,7 @@
 - **[Transition Sync API](04_api_reference/transition-sync-api.md)** - API для синхронизации переходов
 - **[Video Player Transitions API](04_api_reference/video-player-transitions-api.md)** - API для переходов в плеере
 - **[Backend API](04_api_reference/backend/)** - Backend API документация
-- **[WebSocket API](04_api_reference/websocket/)** - WebSocket API документация
 - **[Интеграции](04_api_reference/integrations/)** - API интеграций
-- **[Примеры](04_api_reference/examples/)** - Примеры использования API
 
 ### [05_development/](05_development/)
 Руководства для разработчиков:
@@ -89,10 +87,6 @@
 - **[Telegram Bot Worker Production Runbook](06_deployment/telegram-bot-worker-production.md)** - Production topology, systemd setup, retention and sandbox smoke for bot-first worker
 - **[Telegram AI Review Sandbox Smoke](06_deployment/telegram-ai-review-sandbox-smoke.md)** - Mocked and real sandbox smoke path for Telegram AI review without desktop UI
 - **[Платформы](06_deployment/platforms/)** - Специфика развертывания по платформам
-
-### [07_milestones/](07_milestones/)
-Основные вехи проекта:
-- **[Alpha релиз](07_milestones/alpha_release.md)** - Планы и требования для Alpha версии
 
 ### [08_tasks/](08_tasks/)
 - **[active/](08_tasks/active/)** - Текущие задачи  
@@ -146,11 +140,8 @@
 ### [17_releases/](17_releases/)
 Управление релизами:
 - **[Релизы](17_releases/README.md)** - Управление версиями и релизами
-- **[v0.60.0-alpha](17_releases/v0.60.0-alpha.md)** - Релиз Alpha версии
 
 ### [18_marketing/](18_marketing/) ⭐
-- **[Стратегия продвижения](18_marketing/timeline-studio-promotion-strategy.md)** - Стратегический план продвижения
-- **[Комплексный план](18_marketing/comprehensive-promotion-plan.md)** - Детальный маркетинговый план
 - **[Бизнес-план](18_marketing/business-plan.md)** - Бизнес-план проекта
 - **[Конкурентный анализ](18_marketing/competitive-analysis.md)** - Анализ конкурентов
 - **[Финансовые прогнозы](18_marketing/financial-projections.md)** - Финансовые прогнозы
@@ -170,17 +161,17 @@
 
 ## 📊 Ключевые метрики
 
-- **Общая готовность**: 94%+
-- **Frontend модулей**: 30+ завершено
-- **Backend модулей**: 21+ завершено  
-- **Покрытие тестами**: 80%+
+- **Alpha готовность**: 97.5%
+- **Rust workspace**: `crates/*` decomposition завершена
+- **TypeScript workspace**: `packages/*` and `apps/*` extraction завершены
+- **Bot/headless contracts**: Phase G закрыта, main CI зеленый
 
 ## 🤝 Как внести вклад
 
-1. Изучите [Манифест проекта](00_manifest/project-overview.md)
+1. Изучите [Манифест проекта](00_project_manifest/README.md)
 2. Выберите задачу из [Планируемых](08_tasks/planned/README.md)
 3. Следуйте руководствам из [Development](05_development/README.md)
-4. Используйте Claude Code multiflow методологию для документации
+4. Для bot/headless задач начинайте с [Current Status](10_project_state/current-status.md) and [Roadmap](10_project_state/roadmap.md)
 
 ## 🏗️ Структура документации
 
@@ -195,7 +186,8 @@
 
 - **GitHub**: https://github.com/chatman-media/timeline-studio
 - **Маркетинговые стратегии**: [18_marketing/](18_marketing/)
-- **Английская версия**: [../en/](../en/)
+- **Текущий статус**: [10_project_state/current-status.md](10_project_state/current-status.md)
+- **Roadmap**: [10_project_state/roadmap.md](10_project_state/roadmap.md)
 
 ### [99_templates/](99_templates/)
 Шаблоны документов:
@@ -207,4 +199,4 @@
 
 ---
 
-*Последнее обновление: Январь 2025*
+*Последнее обновление: 11 июня 2026*

--- a/docs/engineering/bot-first-production-contract.md
+++ b/docs/engineering/bot-first-production-contract.md
@@ -1,6 +1,6 @@
 # Bot-First Production Contract
 
-**Status:** Phase G contract hardening for [#288](https://github.com/chatman-media/timeline-studio/issues/288)
+**Status:** Completed Phase G contract hardening for closed [#288](https://github.com/chatman-media/timeline-studio/issues/288)
 **Related:** [External And Headless Integration Contracts](external-headless-contracts.md), [Telegram Bot Worker Production Runbook](../06_deployment/telegram-bot-worker-production.md), [Telegram AI Review Sandbox Smoke](../06_deployment/telegram-ai-review-sandbox-smoke.md), [Timeline Studio CLI](../../apps/cli/COMMANDS.md)
 
 This contract defines the supported bot-first/headless production path for Telegram AI review. Operators and external consumers should be able to understand this path without reading package internals.

--- a/docs/engineering/external-headless-contracts.md
+++ b/docs/engineering/external-headless-contracts.md
@@ -1,6 +1,6 @@
 # External And Headless Integration Contracts
 
-**Status:** Phase G contract hardening for [#282](https://github.com/chatman-media/timeline-studio/issues/282)
+**Status:** Completed Phase G contract hardening for closed [#282](https://github.com/chatman-media/timeline-studio/issues/282)
 **Related:** [G1](https://github.com/chatman-media/timeline-studio/issues/283), [G2](https://github.com/chatman-media/timeline-studio/issues/284), [Bot-First Production Contract](bot-first-production-contract.md), [Telegram AI Review Sandbox Smoke](../06_deployment/telegram-ai-review-sandbox-smoke.md), [Package Boundaries](package-boundaries.md), [Root Compatibility Shims](root-compatibility-shims.md), [Agent Contract Reference](AGENT_CONTRACT_REFERENCE.md)
 
 This document defines the supported integration surface for external consumers after the workspace extraction. It is intentionally narrow: consumers should build against `ProjectSchema`, the Rust `timeline` CLI, and the headless Node CLI commands. They should not import private package files, root aliases, or `src-tauri` internals.

--- a/docs/engineering/package-boundaries.md
+++ b/docs/engineering/package-boundaries.md
@@ -1,6 +1,6 @@
 # Package Boundaries
 
-**Status:** Phase F workspace ownership for [#150](https://github.com/chatman-media/timeline-studio/issues/150)
+**Status:** Completed Phase F workspace ownership for closed [#150](https://github.com/chatman-media/timeline-studio/issues/150)
 **Updated:** 2026-06-11
 
 This document defines the TypeScript package boundaries used during the modular architecture migration. After F9-F13, `core`, `domains`, `adapters`, reusable `ui`, and the CLI have real workspace-owned source trees. Desktop keeps a small set of root compatibility entrypoints while the root Next/Tauri build flow is still in place.

--- a/docs/engineering/root-compatibility-shims.md
+++ b/docs/engineering/root-compatibility-shims.md
@@ -1,6 +1,6 @@
 # Root Compatibility Shims
 
-**Status:** Phase G shim migration path for [#285](https://github.com/chatman-media/timeline-studio/issues/285)  
+**Status:** Completed Phase G shim migration path for closed [#285](https://github.com/chatman-media/timeline-studio/issues/285)
 **Related:** [External And Headless Integration Contracts](external-headless-contracts.md), [Package Boundaries](package-boundaries.md)
 
 Phase F moved core workspace ownership into `packages/*` and `apps/*`, but the repository still has root paths that are intentionally kept for compatibility. This document records the owner, migration path, and removal condition for each group. Removing a shim before its replacement path is documented is out of scope.


### PR DESCRIPTION
## Summary
- refresh current status and roadmap after Phase F/G completion
- document Phase H as the next recommended production/external rollout roadmap
- update planned-task index and completed spec statuses for bot/headless work
- fix central README/docs index links and headless runtime references

## Verification
- git diff --check
- key markdown link audit for README/docs indexes: 0 broken links
- bun run check:boundaries:external
- bun run check:boundaries:strict
- bun run lint:ci

## Notes
- Broad markdown scan still finds legacy broken links in translated README/API history docs; this is intentionally left as a separate docs hygiene task rather than mixed into the roadmap refresh.