### PR TITLE
Add Telegram AI review sandbox runbook

### DIFF
--- a/apps/cli/COMMANDS.md
+++ b/apps/cli/COMMANDS.md
@@ -186,6 +186,7 @@ Fixture payloads live in `docs/08_tasks/planned/fixtures/`.
 Запуск Telegram worker для bot-first workflow: обработка raw `Update`, один `getUpdates` batch или долгоживущий polling loop.
 В polling-режиме ошибки обработки отдельного update возвращаются как failed-result, отправляют короткий ответ в чат при наличии chat id и не останавливают batch.
 Production topology, systemd setup and retention policy are documented in [Telegram Bot Worker Production Runbook](../../docs/06_deployment/telegram-bot-worker-production.md). The supported production state/publish/recovery contract is documented in [Bot-First Production Contract](../../docs/engineering/bot-first-production-contract.md), and the repeatable sandbox checklist is documented in [Telegram AI Review Sandbox Smoke](../../docs/06_deployment/telegram-ai-review-sandbox-smoke.md). Use [config/bot-worker.production.env.example](../../config/bot-worker.production.env.example) as the production env template.
+For local real Telegram AI review validation, start from [config/bot-worker.sandbox.env.example](../../config/bot-worker.sandbox.env.example); it defaults to file-only final approval so a sandbox can verify the review loop before any real publish upload.
 Supported external/headless entrypoints and unsupported internal imports are documented in [External And Headless Integration Contracts](../../docs/engineering/external-headless-contracts.md).
 
 ```bash
@@ -213,6 +214,22 @@ TIMELINE_BOT_WORKFLOW_QUEUE_LIMIT=20 \
 TIMELINE_BOT_MEDIA_DIR=.tmp/timeline-bot/media \
 bun run apps/cli/src/index.ts bot-worker --poll --rust-render
 ```
+
+Для реального Telegram AI review sandbox:
+
+```bash
+cp config/bot-worker.sandbox.env.example .env.telegram-ai-review-sandbox
+chmod 0600 .env.telegram-ai-review-sandbox
+
+set -a
+. ./.env.telegram-ai-review-sandbox
+set +a
+
+cargo build --manifest-path crates/Cargo.toml -p ts-cli --bin timeline
+bun run apps/cli/src/index.ts bot-worker --poll --async-workflows --rust-render --pretty
+```
+
+Сначала проходите sandbox с `TIMELINE_BOT_DEFAULT_DESTINATION=file` и `TIMELINE_BOT_RUST_PUBLISH=false`. После успешного `/approve` можно отдельно включить `TIMELINE_BOT_DEFAULT_DESTINATION=telegram` и `TIMELINE_BOT_RUST_PUBLISH=true` для проверки реальной финальной публикации.
 
 Для проверки Rust-backed AI review preview/publish path без запуска Telegram worker:
 
@@ -345,7 +362,7 @@ export AI_REVIEW_RUST_SMOKE_YOUTUBE_TOKEN=ya29...
 ```
 
 `bot-worker` also accepts `TELEGRAM_BOT_TOKEN` as a generic fallback. Explicit CLI flags take priority over `TIMELINE_BOT_*` environment defaults.
-For production, prefer the dedicated env template at `config/bot-worker.production.env.example` instead of copying these inline examples.
+For production, prefer the dedicated env template at `config/bot-worker.production.env.example` instead of copying these inline examples. For local real Telegram AI review validation, prefer `config/bot-worker.sandbox.env.example`.
 
 ## Примеры использования
 

--- a/config/bot-worker.sandbox.env.example
+++ b/config/bot-worker.sandbox.env.example
@@ -1,0 +1,88 @@
+# Timeline Studio Telegram AI review sandbox env template.
+# Copy to .env.telegram-ai-review-sandbox, set mode 0600, and fill only sandbox credentials.
+# Safe default: file-only final approval; real Telegram publish is opt-in below.
+
+# Telegram access. Use a non-production bot and private sandbox chat/channel.
+TIMELINE_BOT_TELEGRAM_TOKEN=replace-with-sandbox-bot-token
+TIMELINE_BOT_ALLOWED_CHAT_IDS=replace-with-sandbox-chat-id
+TIMELINE_BOT_ALLOWED_USER_IDS=
+TIMELINE_BOT_STATUS_CHAT_ID=
+
+# Local sandbox state. These paths are intentionally relative and disposable.
+TIMELINE_BOT_OFFSET_FILE=.tmp/timeline-bot-sandbox/offset.json
+TIMELINE_BOT_DRAFT_DIR=.tmp/timeline-bot-sandbox/drafts
+TIMELINE_BOT_JOB_STORE_FILE=.tmp/timeline-bot-sandbox/jobs.json
+TIMELINE_BOT_EDIT_SESSION_DIR=.tmp/timeline-bot-sandbox/edit-sessions
+TIMELINE_BOT_MEDIA_DIR=.tmp/timeline-bot-sandbox/media
+TIMELINE_BOT_REVIEW_PREVIEW_DIR=.tmp/timeline-bot-sandbox/previews
+TIMELINE_BOT_FIRST_CUT_PLANNER_TEMP_DIR=.tmp/timeline-bot-sandbox/first-cut
+
+# Cleanup stays dry-run unless explicitly changed.
+TIMELINE_BOT_CLEANUP_DELETE=false
+TIMELINE_BOT_CLEANUP_MEDIA_RETENTION=7d
+TIMELINE_BOT_CLEANUP_REVIEW_PREVIEW_RETENTION=7d
+TIMELINE_BOT_CLEANUP_FIRST_CUT_RETENTION=1d
+TIMELINE_BOT_CLEANUP_DRAFT_RETENTION=14d
+TIMELINE_BOT_CLEANUP_JOB_RETENTION=30d
+TIMELINE_BOT_CLEANUP_EDIT_SESSION_RETENTION=30d
+
+# Polling and queue behavior.
+TIMELINE_BOT_RECOVER_STALE_JOBS=true
+TIMELINE_BOT_ASYNC_WORKFLOWS=true
+TIMELINE_BOT_WORKFLOW_CONCURRENCY=1
+TIMELINE_BOT_WORKFLOW_QUEUE_LIMIT=10
+TIMELINE_BOT_POLL_LIMIT=20
+TIMELINE_BOT_POLL_TIMEOUT=10
+TIMELINE_BOT_IDLE_DELAY=1000
+
+# Status throttling. Keep sandbox feedback responsive but not noisy.
+TIMELINE_BOT_STATUS_MIN_INTERVAL=10000
+TIMELINE_BOT_STATUS_MIN_PROGRESS_DELTA=10
+
+# Media intake guardrails.
+TIMELINE_BOT_DOWNLOAD_REMOTE_MEDIA=false
+TIMELINE_BOT_MEDIA_MAX_BYTES=52428800
+TIMELINE_BOT_REMOTE_MEDIA_ALLOW_HOSTS=
+TIMELINE_BOT_REMOTE_MEDIA_BLOCK_HOSTS=
+
+# Rust preview render.
+TIMELINE_BOT_RUST_RENDER=true
+TIMELINE_BOT_RUST_RENDER_COMMAND=crates/target/debug/timeline
+TIMELINE_BOT_RUST_RENDER_KIND=timeline
+TIMELINE_BOT_RENDER_POLL_INTERVAL=1000
+TIMELINE_BOT_RENDER_TIMEOUT=1800000
+
+# Safe final approval target. This verifies approval/session state without uploading final video.
+TIMELINE_BOT_DEFAULT_DESTINATION=file
+TIMELINE_BOT_DEFAULT_OUTPUT=.tmp/timeline-bot-sandbox/final/final.mp4
+TIMELINE_BOT_RUST_PUBLISH=false
+TIMELINE_BOT_RUST_PUBLISH_COMMAND=crates/target/debug/timeline
+TIMELINE_BOT_YOUTUBE_ACCESS_TOKEN=
+
+# AI editor and transcription. Use sandbox/provider keys only.
+TIMELINE_BOT_AI_EDITOR=true
+TIMELINE_BOT_AI_EDITOR_API_KEY=replace-with-sandbox-ai-key
+TIMELINE_BOT_AI_EDITOR_API_URL=
+TIMELINE_BOT_AI_EDITOR_PROVIDER=openai-compatible
+TIMELINE_BOT_AI_EDITOR_MODEL=gpt-4.1-mini
+TIMELINE_BOT_AI_EDITOR_TEMPERATURE=0.1
+TIMELINE_BOT_AI_EDITOR_MAX_TOKENS=4096
+TIMELINE_BOT_AI_EDITOR_REPAIR_ATTEMPTS=1
+
+# Voice/video-note feedback transcription.
+TIMELINE_BOT_FEEDBACK_TRANSCRIBER_PROVIDER=openai
+TIMELINE_BOT_FEEDBACK_TRANSCRIBER_MODEL=whisper-1
+TIMELINE_BOT_FEEDBACK_TRANSCRIBER_LANGUAGE=
+
+# First-cut planner. auto falls back to deterministic planning when strict mode is false.
+TIMELINE_BOT_FIRST_CUT_PLANNER=true
+TIMELINE_BOT_FIRST_CUT_PLANNER_COMMAND=crates/target/debug/timeline
+TIMELINE_BOT_FIRST_CUT_PLANNER_KIND=auto
+TIMELINE_BOT_FIRST_CUT_PLANNER_API_KEY=
+TIMELINE_BOT_FIRST_CUT_PLANNER_API_URL=
+TIMELINE_BOT_FIRST_CUT_PLANNER_MODEL=
+TIMELINE_BOT_FIRST_CUT_STRICT=false
+
+# Optional real Telegram final publish after the file-only sandbox pass succeeds.
+# TIMELINE_BOT_DEFAULT_DESTINATION=telegram
+# TIMELINE_BOT_RUST_PUBLISH=true

--- a/docs/06_deployment/README.md
+++ b/docs/06_deployment/README.md
@@ -13,6 +13,7 @@
 ### 🤖 Bot-first deployment
 - [**telegram-bot-worker-production.md**](telegram-bot-worker-production.md) - Production topology, systemd setup, restart behavior and retention for Telegram bot-worker
 - [**telegram-ai-review-sandbox-smoke.md**](telegram-ai-review-sandbox-smoke.md) - Mocked and real sandbox smoke checklist for Telegram AI review without desktop UI
+- [**telegram-ai-review-sandbox-report.template.md**](telegram-ai-review-sandbox-report.template.md) - Sanitized evidence template for real Telegram AI review sandbox runs
 
 ### 💻 Платформы
 - [**platforms/windows.md**](platforms/windows.md) - Специфика сборки для Windows

--- a/docs/06_deployment/telegram-ai-review-sandbox-report.template.md
+++ b/docs/06_deployment/telegram-ai-review-sandbox-report.template.md
@@ -1,0 +1,58 @@
+# Telegram AI Review Sandbox Report
+
+Use this template for a real sandbox run. Keep tokens, raw chat ids, channel names, provider keys and private media out of the report.
+
+## Run Metadata
+
+| Field | Value |
+| --- | --- |
+| Date | YYYY-MM-DD |
+| Operator |  |
+| Git branch / commit |  |
+| Sandbox bot username | redacted or internal reference |
+| Sandbox chat/channel | redacted or internal reference |
+| Env file | `.env.telegram-ai-review-sandbox` |
+| Rust `timeline` binary | `crates/target/debug/timeline` or installed path |
+| AI editor provider/model |  |
+| Transcriber provider/model |  |
+| Final destination | `file` or `telegram` |
+
+## Preflight
+
+| Check | Command / Evidence | Result |
+| --- | --- | --- |
+| Dependencies installed | `bun install --frozen-lockfile --ignore-scripts` |  |
+| Rust CLI built | `cargo build --manifest-path crates/Cargo.toml -p ts-cli --bin timeline` |  |
+| Mocked AI review smoke | `bunx vitest run --config vitest.bot-ai.config.ts packages/adapters/src/node/__tests__/telegram-ai-review-workflow-smoke.test.ts` |  |
+| Rust AI review smoke | `bun run smoke:ai-review:rust` |  |
+| Telegram access check | `bot-worker --poll-once --pretty` with review env disabled |  |
+
+## Chat Workflow
+
+| Step | User action | Expected bot response | Observed evidence | Result |
+| --- | --- | --- | --- | --- |
+| Help | `/help` | Command list or command-handled response | Message id / screenshot ref |  |
+| Upload | Small video with `Make a 15s product promo destination=file` | Queued/running status and first preview | Preview message id + artifact path |  |
+| Text correction | Plain text feedback | `Applied revision: ...` and new preview | Revision id + preview path |  |
+| Voice correction | Voice message | Transcription succeeds, `Applied revision: ...`, new preview | Revision id + preview path |  |
+| Video-note correction | Video note | Transcription succeeds, `Applied revision: ...`, new preview | Revision id + preview path |  |
+| Versions | `/versions` | Revision list with redacted provider/render metadata | Redacted response |  |
+| Restart | Stop/start worker, then `/status` | Latest session/revision survives restart | Status response |  |
+| Approval | `/approve` | Approved revision; file-only publish done or Telegram publish result | Publish result |  |
+| Cleanup dry-run | `bot-cleanup --pretty` | Active sessions preserved, only expired terminal artifacts listed | Redacted JSON/log |  |
+
+## Artifact Checklist
+
+Record paths only; do not attach private media unless the sandbox asset is explicitly shareable.
+
+- Offset file:
+- Job store:
+- Edit session JSON:
+- Media download directory:
+- Preview directory:
+- Final output path:
+- First-cut temp directory:
+
+## Gaps / Follow-Up
+
+- [ ] 

--- a/docs/06_deployment/telegram-ai-review-sandbox-smoke.md
+++ b/docs/06_deployment/telegram-ai-review-sandbox-smoke.md
@@ -1,6 +1,6 @@
 # Telegram AI Review Sandbox Smoke
 
-**Status:** Completed Phase G sandbox contract for closed [#289](https://github.com/chatman-media/timeline-studio/issues/289)
+**Status:** Phase H real sandbox runbook for [#293](https://github.com/chatman-media/timeline-studio/issues/293), building on completed Phase G sandbox contract [#289](https://github.com/chatman-media/timeline-studio/issues/289)
 **Related:** [Bot-First Production Contract](../engineering/bot-first-production-contract.md), [Telegram Bot Worker Production Runbook](telegram-bot-worker-production.md), [Telegram AI Review Workflow](../08_tasks/planned/telegram-ai-review-workflow.md), [Timeline Studio CLI](../../apps/cli/COMMANDS.md)
 
 This smoke path validates the bot-first AI review loop without opening the desktop UI.
@@ -61,19 +61,86 @@ In a real sandbox chat, operators should see this progression:
 
 ## Real Sandbox Checklist
 
-Use a non-production bot, private chat/channel and small media file.
+Use a non-production bot, private chat/channel and small media file. The sandbox env template is [config/bot-worker.sandbox.env.example](../../config/bot-worker.sandbox.env.example). It intentionally defaults final approval to `destination=file` and `TIMELINE_BOT_RUST_PUBLISH=false`; real Telegram final publish is an opt-in second pass.
 
-1. Build/install the Rust `timeline` CLI and ensure `TIMELINE_BOT_RUST_RENDER=true`.
-2. Copy [config/bot-worker.production.env.example](../../config/bot-worker.production.env.example) to a local sandbox env file and set only sandbox tokens/ids.
-3. Set `TIMELINE_BOT_ALLOWED_CHAT_IDS` or `TIMELINE_BOT_ALLOWED_USER_IDS`.
-4. Use temporary sandbox directories for offset, jobs, drafts, media, previews and edit sessions.
-5. Start `bot-worker --poll --rust-render`; use `--poll-once` first if validating update access.
-6. Send `/help`, then a small video with a caption such as `Make a 15s product promo destination=telegram`.
-7. Confirm preview delivery, then send one text correction, one voice correction and one video-note correction.
-8. Run `/versions` and confirm revision ids, provider/model and artifact references are present and secrets are redacted.
-9. Restart the worker, run `/status`, and confirm the latest session/revision survives.
-10. Run `/approve` only after verifying the preview; confirm publish result or stored publish failure.
-11. Run `bot-cleanup --pretty` in dry-run mode and confirm active sessions are preserved.
+Prepare the local env and disposable state directories:
+
+```bash
+cp config/bot-worker.sandbox.env.example .env.telegram-ai-review-sandbox
+chmod 0600 .env.telegram-ai-review-sandbox
+
+mkdir -p \
+  .tmp/timeline-bot-sandbox/drafts \
+  .tmp/timeline-bot-sandbox/edit-sessions \
+  .tmp/timeline-bot-sandbox/media \
+  .tmp/timeline-bot-sandbox/previews \
+  .tmp/timeline-bot-sandbox/first-cut \
+  .tmp/timeline-bot-sandbox/final
+```
+
+Edit `.env.telegram-ai-review-sandbox` and set only sandbox values:
+
+- `TIMELINE_BOT_TELEGRAM_TOKEN`;
+- `TIMELINE_BOT_ALLOWED_CHAT_IDS` or `TIMELINE_BOT_ALLOWED_USER_IDS`;
+- `TIMELINE_BOT_AI_EDITOR_API_KEY`, or `OPENAI_API_KEY`/`LLM_API_KEY` in the shell;
+- optional AI/transcriber model overrides.
+
+Run local preflight checks before polling Telegram:
+
+```bash
+bun install --frozen-lockfile --ignore-scripts
+cargo build --manifest-path crates/Cargo.toml -p ts-cli --bin timeline
+
+bunx vitest run --config vitest.bot-ai.config.ts \
+  packages/adapters/src/node/__tests__/telegram-ai-review-workflow-smoke.test.ts
+
+bun run smoke:ai-review:rust
+```
+
+Check Telegram access before enabling AI review state. This intentionally disables review-specific env for the access check, because `TIMELINE_BOT_EDIT_SESSION_DIR` enables AI review mode and requires an AI editor key.
+
+```bash
+set -a
+. ./.env.telegram-ai-review-sandbox
+set +a
+
+env \
+  -u TIMELINE_BOT_EDIT_SESSION_DIR \
+  -u TIMELINE_BOT_REVIEW_PREVIEW_DIR \
+  -u TIMELINE_BOT_FIRST_CUT_PLANNER_TEMP_DIR \
+  -u TIMELINE_BOT_AI_EDITOR_API_KEY \
+  -u TIMELINE_BOT_AI_EDITOR \
+  bun run apps/cli/src/index.ts bot-worker --poll-once --pretty
+```
+
+Start the real sandbox worker after access succeeds:
+
+```bash
+set -a
+. ./.env.telegram-ai-review-sandbox
+set +a
+
+bun run apps/cli/src/index.ts bot-worker \
+  --poll \
+  --async-workflows \
+  --rust-render \
+  --pretty
+```
+
+Exercise the chat workflow:
+
+1. Send `/help`.
+2. Send a small video with a caption such as `Make a 15s product promo destination=file`.
+3. Confirm queued/running status and first preview delivery.
+4. Send one text correction.
+5. Send one voice correction.
+6. Send one video-note correction.
+7. Run `/versions` and confirm revision ids, provider/model and artifact references are present and secrets are redacted.
+8. Stop and restart the worker, then run `/status` and confirm the latest session/revision survives.
+9. Run `/approve` only after verifying the preview. In the default file-only pass, approval should record a `file` publish result against the approved preview artifact. For real Telegram final publish, first complete the file-only pass, then explicitly set `TIMELINE_BOT_DEFAULT_DESTINATION=telegram` and `TIMELINE_BOT_RUST_PUBLISH=true` in the sandbox env.
+10. Run `bot-cleanup --pretty` in dry-run mode and confirm active sessions are preserved.
+
+Capture sanitized evidence with [telegram-ai-review-sandbox-report.template.md](telegram-ai-review-sandbox-report.template.md). Do not paste raw tokens, chat ids, provider keys, private media names or unredacted session JSON into public issues.
 
 ## Publish Validation
 

--- a/docs/06_deployment/telegram-bot-worker-production.md
+++ b/docs/06_deployment/telegram-bot-worker-production.md
@@ -33,7 +33,7 @@ Use durable storage for all bot state. A recommended system layout:
 /var/lib/timeline-studio/bot/first-cut/       Rust planner temp ProjectSchema files
 ```
 
-The env template lives at [config/bot-worker.production.env.example](../../config/bot-worker.production.env.example). Systemd examples live at [config/systemd/timeline-bot-worker.service](../../config/systemd/timeline-bot-worker.service), [config/systemd/timeline-bot-cleanup.service](../../config/systemd/timeline-bot-cleanup.service), and [config/systemd/timeline-bot-cleanup.timer](../../config/systemd/timeline-bot-cleanup.timer).
+The production env template lives at [config/bot-worker.production.env.example](../../config/bot-worker.production.env.example). The safer local sandbox template lives at [config/bot-worker.sandbox.env.example](../../config/bot-worker.sandbox.env.example). Systemd examples live at [config/systemd/timeline-bot-worker.service](../../config/systemd/timeline-bot-worker.service), [config/systemd/timeline-bot-cleanup.service](../../config/systemd/timeline-bot-cleanup.service), and [config/systemd/timeline-bot-cleanup.timer](../../config/systemd/timeline-bot-cleanup.timer).
 
 ## Deployment
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -86,6 +86,7 @@
 - **[Настройка OAuth](06_deployment/oauth-setup.md)** - Настройка OAuth интеграций
 - **[Telegram Bot Worker Production Runbook](06_deployment/telegram-bot-worker-production.md)** - Production topology, systemd setup, retention and sandbox smoke for bot-first worker
 - **[Telegram AI Review Sandbox Smoke](06_deployment/telegram-ai-review-sandbox-smoke.md)** - Mocked and real sandbox smoke path for Telegram AI review without desktop UI
+- **[Telegram AI Review Sandbox Report Template](06_deployment/telegram-ai-review-sandbox-report.template.md)** - Sanitized evidence template for real sandbox runs
 - **[Платформы](06_deployment/platforms/)** - Специфика развертывания по платформам
 
 ### [08_tasks/](08_tasks/)


### PR DESCRIPTION
## Summary

- add a safe `config/bot-worker.sandbox.env.example` for real Telegram AI review validation
- expand the Telegram AI review sandbox smoke doc into an operator runbook with access check, full worker run, restart/status, approval and cleanup steps
- add a sanitized sandbox report template for evidence capture without leaking tokens/chat ids/private media
- link the sandbox template/report from CLI and deployment docs

## Verification

- `git diff --check`
- changed-doc markdown link audit: `broken=0`
- `bunx vitest run --config vitest.bot-ai.config.ts packages/adapters/src/node/__tests__/telegram-ai-review-workflow-smoke.test.ts`
- `bun run lint:ci`
- `bun run check:boundaries:external`
- `bun run smoke:ai-review:rust` (Rust preview render passed; publish validate skipped because sandbox provider tokens are not configured)

## Notes

This is the repo-side sandbox kit for H1. The real Telegram chat pass still needs sandbox `TIMELINE_BOT_TELEGRAM_TOKEN`, allowlist chat/user id and AI editor/transcriber credentials; keep #293 open until that external run is executed and the sanitized report is filled.

Refs #293
