### PR TITLE
Add postim headless integration example

### DIFF
--- a/apps/cli/COMMANDS.md
+++ b/apps/cli/COMMANDS.md
@@ -114,6 +114,8 @@ npx ts-node apps/cli/src/index.ts render project.json output.mp4 --verbose
 
 `render-job` is the supported one-shot Node entrypoint for external job runners that already have a render job JSON payload. It returns machine-readable `BotRenderJobResult` JSON and can delegate rendering to the Rust headless CLI with `--rust-render`.
 
+The postim/headless contract example lives in [examples/headless-postim](../../examples/headless-postim/README.md).
+
 ```bash
 bun run apps/cli/src/index.ts render-job ./render-job.json --pretty --rust-render
 ```
@@ -160,6 +162,8 @@ bun run apps/cli/src/index.ts bot-workflow ./payload.json \
 ```
 
 Fixture payloads live in `docs/08_tasks/planned/fixtures/`.
+
+The postim/headless one-shot workflow example lives in [examples/headless-postim](../../examples/headless-postim/README.md).
 
 **Опции:**
 | Опция | Описание |

--- a/docs/engineering/external-headless-contracts.md
+++ b/docs/engineering/external-headless-contracts.md
@@ -1,7 +1,7 @@
 # External And Headless Integration Contracts
 
 **Status:** Completed Phase G contract hardening for closed [#282](https://github.com/chatman-media/timeline-studio/issues/282)
-**Related:** [G1](https://github.com/chatman-media/timeline-studio/issues/283), [G2](https://github.com/chatman-media/timeline-studio/issues/284), [Bot-First Production Contract](bot-first-production-contract.md), [Telegram AI Review Sandbox Smoke](../06_deployment/telegram-ai-review-sandbox-smoke.md), [Package Boundaries](package-boundaries.md), [Root Compatibility Shims](root-compatibility-shims.md), [Agent Contract Reference](AGENT_CONTRACT_REFERENCE.md)
+**Related:** [G1](https://github.com/chatman-media/timeline-studio/issues/283), [G2](https://github.com/chatman-media/timeline-studio/issues/284), [Bot-First Production Contract](bot-first-production-contract.md), [Telegram AI Review Sandbox Smoke](../06_deployment/telegram-ai-review-sandbox-smoke.md), [postim Headless Integration Example](../../examples/headless-postim/README.md), [Package Boundaries](package-boundaries.md), [Root Compatibility Shims](root-compatibility-shims.md), [Agent Contract Reference](AGENT_CONTRACT_REFERENCE.md)
 
 This document defines the supported integration surface for external consumers after the workspace extraction. It is intentionally narrow: consumers should build against `ProjectSchema`, the Rust `timeline` CLI, and the headless Node CLI commands. They should not import private package files, root aliases, or `src-tauri` internals.
 
@@ -128,6 +128,12 @@ bun run apps/cli/src/index.ts bot-workflow ./payload.json \
 
 Use `--telegram-bot-token`, `--media-dir`, and `--download-remote-media` only when the payload needs Telegram file resolution or remote URL downloads. Keep remote URL downloads opt-in.
 
+The postim one-shot headless fixture lives in [examples/headless-postim](../../examples/headless-postim/README.md). Validate it with:
+
+```bash
+bun run check:examples:postim
+```
+
 ## bot-worker Production Contract
 
 `bot-worker` is the supported Telegram production runtime:
@@ -149,6 +155,8 @@ postim and similar external consumers should integrate through the bot-first/hea
 2. Use `render-job` for direct render execution, or `bot-workflow`/`bot-worker` for Telegram-like intake and review sessions.
 3. Read machine-readable `BotRenderJobResult`, workflow result, session status, preview artifact, and publish result payloads.
 4. Use Rust `timeline publish ... --json` indirectly through the configured Node adapter or directly when only publish validation/upload is needed.
+
+The supported runnable handoff example is [examples/headless-postim](../../examples/headless-postim/README.md). It includes `ProjectSchema`, `render-job`, and `bot-workflow` payloads plus a validation command that checks the fixture does not depend on private repo internals.
 
 postim must not:
 

--- a/examples/headless-postim/README.md
+++ b/examples/headless-postim/README.md
@@ -1,0 +1,76 @@
+# postim Headless Integration Example
+
+This fixture shows the supported postim/headless path without depending on desktop internals. It is intentionally a contract example: the JSON files are valid handoff payloads, while the media path is a placeholder that must be replaced with a real file before rendering.
+
+## Files
+
+- `project-schema.json` is the `ProjectSchema` handoff. External TypeScript consumers should type this shape through `@timeline/shared-types/schema`.
+- `render-job.json` is the direct one-shot render request for `render-job`.
+- `bot-workflow-payload.json` is a Telegram-like payload for `bot-workflow` with `project=`, `output=`, `destination=`, and `resolution=` hints.
+
+## Validate The Contract
+
+```bash
+bun run check:examples:postim
+```
+
+The check verifies that the example JSON is parseable, points at the supported `ProjectSchema` fixture, carries file-only output handoff, and does not use private repo paths in machine-readable payloads.
+
+## TypeScript Consumer Shape
+
+```ts
+import type { ProjectSchema } from "@timeline/shared-types/schema"
+
+export async function createPostimProject(): Promise<ProjectSchema> {
+  const response = await fetch("/api/postim/project-schema")
+  return (await response.json()) as ProjectSchema
+}
+```
+
+Do not import package-private workspace files to build this object. Cross-process handoff should use the serialized `ProjectSchema` JSON.
+
+## Direct Render Handoff
+
+Build the Rust headless CLI if `timeline` is not already on `PATH`:
+
+```bash
+cargo build --manifest-path crates/Cargo.toml -p ts-cli --bin timeline
+```
+
+Replace `examples/headless-postim/media/input.mp4` in `project-schema.json` with a real video path, then run:
+
+```bash
+bun run apps/cli/src/index.ts render-job examples/headless-postim/render-job.json \
+  --pretty \
+  --rust-render \
+  --rust-render-command crates/target/debug/timeline
+```
+
+Expected output is `BotRenderJobResult` JSON. External callers should read `job.status`, `job.progress`, `job.artifact`, `job.publications`, and ordered `events`. For polling-style integrations, also write the final payload with `--status-file`.
+
+## Telegram-Like Review Handoff
+
+For one-shot bot intake without a long-running Telegram worker:
+
+```bash
+bun run apps/cli/src/index.ts bot-workflow examples/headless-postim/bot-workflow-payload.json \
+  --default-destination file \
+  --default-output .tmp/postim-headless/bot-workflow.mp4 \
+  --pretty \
+  --rust-render \
+  --rust-render-command crates/target/debug/timeline
+```
+
+Expected output is `BotWorkflowRunResult` JSON. The render status and artifact are under `result.job`; intake metadata and resolved project/output hints stay in the workflow result envelope.
+
+For production Telegram editing/review sessions, use `bot-worker` and the bot-first production contract. postim should consume the bot/headless result payloads instead of desktop state.
+
+## Unsupported Integration Surfaces
+
+postim must not integrate through `src-tauri`, root `@/*` aliases, `packages/*/src/**`, `apps/*/src/**` package-private modules, desktop React providers, or app-shell state. `apps/cli/src/index.ts` is the documented CLI launcher used by these examples.
+
+Rust publish remains the production publish path when a destination is supported by `timeline publish ... --json`. Node/TypeScript should orchestrate bot-first/headless flows and hand artifact paths/status forward, not create a second production publish backend.
+
+## Streaming Boundary
+
+This example is a command/result contract. It records the current postim handoff without implementing streaming APIs. Future `ts-stream`/postim streaming work should depend on these stable payloads and result events rather than private runtime internals.

--- a/examples/headless-postim/bot-workflow-payload.json
+++ b/examples/headless-postim/bot-workflow-payload.json
@@ -1,0 +1,11 @@
+{
+  "chat": {
+    "id": "postim-demo-chat"
+  },
+  "from": {
+    "id": "postim-demo-user"
+  },
+  "message_id": "postim-demo-message-001",
+  "text": "project=examples/headless-postim/project-schema.json output=.tmp/postim-headless/bot-workflow.mp4 destination=file resolution=1080p title=postim-demo",
+  "attachments": []
+}

--- a/examples/headless-postim/project-schema.json
+++ b/examples/headless-postim/project-schema.json
@@ -1,0 +1,113 @@
+{
+  "version": "1.0.0",
+  "metadata": {
+    "name": "postim-headless-example",
+    "description": "Contract fixture for external postim/headless consumers. Replace the media path with a real file before rendering.",
+    "created_at": "2026-06-11T00:00:00.000Z",
+    "modified_at": "2026-06-11T00:00:00.000Z",
+    "author": "postim-example"
+  },
+  "timeline": {
+    "duration": 5,
+    "fps": 30,
+    "resolution": [1920, 1080],
+    "sample_rate": 48000,
+    "aspect_ratio": "Ratio16x9"
+  },
+  "tracks": [
+    {
+      "id": "postim-video-track",
+      "track_type": "Video",
+      "name": "Postim video",
+      "enabled": true,
+      "volume": 1,
+      "locked": false,
+      "clips": [
+        {
+          "id": "postim-clip-001",
+          "source": {
+            "File": "examples/headless-postim/media/input.mp4"
+          },
+          "start_time": 0,
+          "end_time": 5,
+          "source_start": 0,
+          "source_end": 5,
+          "speed": 1,
+          "opacity": 1,
+          "effects": [],
+          "filters": [],
+          "template_id": null,
+          "template_position": null,
+          "color_correction": null,
+          "crop": null,
+          "transform": null,
+          "audio_track_index": null,
+          "properties": {
+            "notes": "Replace examples/headless-postim/media/input.mp4 with a real media file before rendering.",
+            "tags": ["postim", "headless", "contract"],
+            "custom_metadata": {
+              "integration": "postim",
+              "handoff": "headless"
+            }
+          }
+        }
+      ],
+      "effects": [],
+      "filters": []
+    }
+  ],
+  "effects": [],
+  "transitions": [],
+  "filters": [],
+  "templates": [],
+  "style_templates": [],
+  "subtitles": [],
+  "settings": {
+    "export": {
+      "format": "Mp4",
+      "quality": 85,
+      "video_bitrate": 8000,
+      "audio_bitrate": 192,
+      "hardware_acceleration": false,
+      "preferred_gpu_encoder": null,
+      "ffmpeg_args": [],
+      "encoding_profile": "main",
+      "rate_control_mode": "vbr",
+      "keyframe_interval": 60,
+      "b_frames": 2,
+      "multi_pass": 1,
+      "preset": "medium",
+      "max_bitrate": null,
+      "min_bitrate": null,
+      "crf": null,
+      "optimize_for_speed": false,
+      "optimize_for_network": false,
+      "normalize_audio": false,
+      "audio_target": -23,
+      "audio_peak": -1
+    },
+    "preview": {
+      "resolution": [640, 360],
+      "quality": 75,
+      "fps": 15,
+      "format": "Jpeg"
+    },
+    "custom": {
+      "externalConsumer": "postim",
+      "publishHandoff": "file-only"
+    },
+    "output": {
+      "format": "Mp4",
+      "quality": 85,
+      "video_bitrate": 8000,
+      "audio_bitrate": 192,
+      "duration": 5
+    },
+    "resolution": {
+      "width": 1920,
+      "height": 1080
+    },
+    "frame_rate": 30,
+    "aspect_ratio": "Ratio16x9"
+  }
+}

--- a/examples/headless-postim/render-job.json
+++ b/examples/headless-postim/render-job.json
@@ -1,0 +1,18 @@
+{
+  "source": "cli",
+  "project": {
+    "type": "file",
+    "path": "examples/headless-postim/project-schema.json"
+  },
+  "output": {
+    "format": "mp4",
+    "path": ".tmp/postim-headless/render-job.mp4",
+    "destination": "file",
+    "resolution": "1080p"
+  },
+  "params": {
+    "integration": "postim",
+    "correlationId": "postim-demo-001",
+    "publishHandoff": "file-only"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "check:boundaries:external": "node scripts/check-package-boundaries.mjs --external-contracts",
     "check:boundaries:baseline": "node scripts/check-package-boundaries.mjs --baseline=config/package-boundaries-baseline.json --max-details=0",
     "check:boundaries:strict": "node scripts/check-package-boundaries.mjs --strict",
+    "check:examples:postim": "node scripts/validate-headless-postim-example.mjs",
     "check:all": "npm run lint && npm run lint:css && npm run check:rust && npm run test && npm run test:rust",
     "fix:all": "npm run lint:fix && npm run lint:css:fix && npm run fix:rust",
     "tauri": "tauri",

--- a/scripts/validate-headless-postim-example.mjs
+++ b/scripts/validate-headless-postim-example.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+const exampleDir = path.join(repoRoot, "examples/headless-postim")
+const toPosix = (value) => value.split(path.sep).join("/")
+
+const files = {
+  readme: path.join(exampleDir, "README.md"),
+  project: path.join(exampleDir, "project-schema.json"),
+  renderJob: path.join(exampleDir, "render-job.json"),
+  botWorkflow: path.join(exampleDir, "bot-workflow-payload.json"),
+}
+
+const expectedProjectPath = "examples/headless-postim/project-schema.json"
+const errors = []
+
+function addError(message) {
+  errors.push(message)
+}
+
+async function readJson(filePath) {
+  const relativePath = toPosix(path.relative(repoRoot, filePath))
+
+  try {
+    const raw = await fs.readFile(filePath, "utf8")
+    return JSON.parse(raw)
+  } catch (error) {
+    addError(`${relativePath} is not valid JSON: ${error.message}`)
+    return null
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    addError(message)
+  }
+}
+
+function scanMachineReadablePayload(relativePath, value) {
+  const raw = typeof value === "string" ? value : JSON.stringify(value, null, 2)
+  const forbiddenPatterns = [
+    {
+      pattern: /src-tauri(?:\/|\\|\b)/,
+      message: "must not reference src-tauri internals",
+    },
+    {
+      pattern: /@\/(?:core|domains|adapters|features|components|types|config|app)(?:\/|\b)/,
+      message: "must not reference root @/* aliases",
+    },
+    {
+      pattern: /packages\/[^/\s]+\/src\//,
+      message: "must not reference package-private packages/*/src paths",
+    },
+    {
+      pattern: /apps\/(?!cli\/src\/index\.ts\b)[^/\s]+\/src\//,
+      message: "must not reference package-private apps/*/src paths",
+    },
+  ]
+
+  for (const { pattern, message } of forbiddenPatterns) {
+    if (pattern.test(raw)) {
+      addError(`${relativePath} ${message}`)
+    }
+  }
+}
+
+function validateProjectSchema(project) {
+  if (!project) {
+    return
+  }
+
+  assert(project.version === "1.0.0", "project-schema.json must use ProjectSchema version 1.0.0")
+  assert(project.metadata?.name === "postim-headless-example", "project-schema.json must name the fixture")
+  assert(project.timeline?.fps === 30, "project-schema.json must define a 30fps timeline")
+  assert(project.timeline?.resolution?.[0] === 1920, "project-schema.json must use 1920px width")
+  assert(project.timeline?.resolution?.[1] === 1080, "project-schema.json must use 1080px height")
+  assert(Array.isArray(project.tracks) && project.tracks.length === 1, "project-schema.json must contain one video track")
+
+  const track = project.tracks?.[0]
+  assert(track?.track_type === "Video", "project-schema.json track must be Video")
+  assert(Array.isArray(track?.clips) && track.clips.length === 1, "project-schema.json must contain one video clip")
+
+  const clip = track?.clips?.[0]
+  assert(
+    clip?.source?.File === "examples/headless-postim/media/input.mp4",
+    "project-schema.json clip must use the documented placeholder media path",
+  )
+  assert(clip?.end_time > clip?.start_time, "project-schema.json clip end_time must be greater than start_time")
+  assert(project.settings?.export?.format === "Mp4", "project-schema.json export format must be Mp4")
+  assert(project.settings?.custom?.externalConsumer === "postim", "project-schema.json must identify postim as consumer")
+}
+
+function validateRenderJob(renderJob) {
+  if (!renderJob) {
+    return
+  }
+
+  assert(renderJob.source === "cli", "render-job.json source must be cli")
+  assert(renderJob.project?.type === "file", "render-job.json project must be a file handoff")
+  assert(renderJob.project?.path === expectedProjectPath, "render-job.json must point at the example ProjectSchema")
+  assert(renderJob.output?.format === "mp4", "render-job.json output format must be mp4")
+  assert(renderJob.output?.destination === "file", "render-job.json destination must be file")
+  assert(renderJob.output?.path === ".tmp/postim-headless/render-job.mp4", "render-job.json must use the example output path")
+  assert(renderJob.params?.publishHandoff === "file-only", "render-job.json must keep publish handoff file-only")
+}
+
+function validateBotWorkflowPayload(payload) {
+  if (!payload) {
+    return
+  }
+
+  const text = payload.text ?? payload.caption ?? ""
+  assert(payload.chat?.id === "postim-demo-chat", "bot-workflow-payload.json must include a stable demo chat id")
+  assert(payload.from?.id === "postim-demo-user", "bot-workflow-payload.json must include a stable demo user id")
+  assert(text.includes(`project=${expectedProjectPath}`), "bot-workflow-payload.json must include the project hint")
+  assert(text.includes("destination=file"), "bot-workflow-payload.json must include file destination hint")
+  assert(text.includes("output=.tmp/postim-headless/bot-workflow.mp4"), "bot-workflow-payload.json must include output hint")
+  assert(text.includes("resolution=1080p"), "bot-workflow-payload.json must include resolution hint")
+}
+
+async function validateReadme() {
+  const raw = await fs.readFile(files.readme, "utf8")
+  const relativePath = toPosix(path.relative(repoRoot, files.readme))
+
+  assert(raw.includes("bun run check:examples:postim"), `${relativePath} must document the validation command`)
+  assert(raw.includes("@timeline/shared-types/schema"), `${relativePath} must document the public ProjectSchema import`)
+  assert(raw.includes("timeline publish ... --json"), `${relativePath} must document Rust publish ownership`)
+  assert(raw.includes("Streaming Boundary"), `${relativePath} must call out the streaming boundary`)
+  assert(raw.includes("Unsupported Integration Surfaces"), `${relativePath} must call out unsupported surfaces`)
+
+  const codeBlocks = [...raw.matchAll(/```(?:\w+)?\n([\s\S]*?)```/g)].map((match) => match[1])
+  for (const [index, block] of codeBlocks.entries()) {
+    scanMachineReadablePayload(`${relativePath} code block ${index + 1}`, block)
+  }
+}
+
+const project = await readJson(files.project)
+const renderJob = await readJson(files.renderJob)
+const botWorkflow = await readJson(files.botWorkflow)
+
+validateProjectSchema(project)
+validateRenderJob(renderJob)
+validateBotWorkflowPayload(botWorkflow)
+await validateReadme()
+
+scanMachineReadablePayload(toPosix(path.relative(repoRoot, files.project)), project)
+scanMachineReadablePayload(toPosix(path.relative(repoRoot, files.renderJob)), renderJob)
+scanMachineReadablePayload(toPosix(path.relative(repoRoot, files.botWorkflow)), botWorkflow)
+
+if (errors.length > 0) {
+  console.error("Postim headless example validation failed:")
+  for (const error of errors) {
+    console.error(`- ${error}`)
+  }
+  process.exit(1)
+}
+
+console.log("Postim headless example validation passed.")


### PR DESCRIPTION
## Summary
- add a supported postim/headless example with ProjectSchema, render-job, and bot-workflow payloads
- document the direct render and Telegram-like workflow handoffs without private workspace imports
- add `check:examples:postim` to validate fixture paths, output handoff, and unsupported internal references

## Verification
- `bun run check:examples:postim`
- `bun run check:boundaries:external`
- `git diff --check`
- changed markdown links resolve
- `bun run lint:ci`

Closes #294
