### PR TITLE
Retire legacy root CLI service path

### DIFF
--- a/config/systemd/timeline-bot-cleanup.service
+++ b/config/systemd/timeline-bot-cleanup.service
@@ -8,7 +8,7 @@ Group=timeline-bot
 WorkingDirectory=/opt/timeline-studio
 Environment=NODE_ENV=production
 EnvironmentFile=/etc/timeline-studio/bot-worker.env
-ExecStart=/usr/bin/env bun run src/cli/index.ts bot-cleanup --delete
+ExecStart=/usr/bin/env bun run apps/cli/src/index.ts bot-cleanup --delete
 StateDirectory=timeline-studio
 CacheDirectory=timeline-studio
 NoNewPrivileges=true

--- a/config/systemd/timeline-bot-worker.service
+++ b/config/systemd/timeline-bot-worker.service
@@ -10,7 +10,7 @@ Group=timeline-bot
 WorkingDirectory=/opt/timeline-studio
 Environment=NODE_ENV=production
 EnvironmentFile=/etc/timeline-studio/bot-worker.env
-ExecStart=/usr/bin/env bun run src/cli/index.ts bot-worker --poll
+ExecStart=/usr/bin/env bun run apps/cli/src/index.ts bot-worker --poll
 Restart=on-failure
 RestartSec=10
 KillSignal=SIGINT

--- a/docs/engineering/root-compatibility-shims.md
+++ b/docs/engineering/root-compatibility-shims.md
@@ -28,6 +28,12 @@ Phase F moved core workspace ownership into `packages/*` and `apps/*`, but the r
 | `src/test` | Test infrastructure | Root Vitest setup, shared mocks, and test utilities | Split domain/package setup into workspace-local helpers under G5 | Workspace tests no longer require root global setup for package-specific services |
 | `src/hooks`, `src/i18n`, `src/global`, `src/styles`, `src/components/error-boundary.tsx` | Desktop/app-shell owners | Root app UI utilities and global app support | Move or wrap under `apps/desktop` when desktop root compatibility is reduced | Desktop root entrypoints no longer import these paths directly |
 
+## Retired Shim Groups
+
+| Retired path | Replacement | Evidence | Guardrail |
+| --- | --- | --- | --- |
+| `src/cli/index.ts` | `apps/cli/src/index.ts` | H3 migrated production systemd units to the workspace CLI entrypoint. The root CLI path has no filesystem owner and must not be used by production/headless docs or config. | `bun run check:shims:retired` |
+
 ## External Contract Rule
 
 The supported external/headless path is not a root shim path. External consumers should use:
@@ -43,3 +49,11 @@ bun run check:boundaries:external
 ```
 
 This check scans documented external/headless code examples and fails if they recommend root aliases, `src-tauri` internals, or package-private source paths.
+
+Run the root shim retirement guardrail locally:
+
+```bash
+bun run check:shims:retired
+```
+
+This check fails if production/headless docs or config reintroduce retired root CLI references.

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "check:boundaries:baseline": "node scripts/check-package-boundaries.mjs --baseline=config/package-boundaries-baseline.json --max-details=0",
     "check:boundaries:strict": "node scripts/check-package-boundaries.mjs --strict",
     "check:examples:postim": "node scripts/validate-headless-postim-example.mjs",
+    "check:shims:retired": "node scripts/validate-root-shim-retirement.mjs",
     "check:all": "npm run lint && npm run lint:css && npm run check:rust && npm run test && npm run test:rust",
     "fix:all": "npm run lint:fix && npm run lint:css:fix && npm run fix:rust",
     "tauri": "tauri",

--- a/scripts/validate-root-shim-retirement.mjs
+++ b/scripts/validate-root-shim-retirement.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+const retiredCliEntrypoint = "src/cli/index.ts"
+
+const scannedPaths = [
+  ".github",
+  "apps/cli",
+  "config",
+  "docs/06_deployment",
+  "docs/10_project_state",
+  "docs/engineering",
+  "docs/README.md",
+  "examples",
+  "package.json",
+  "scripts",
+]
+
+const skippedDirectories = new Set(["node_modules", ".git", "coverage", "dist", "build", ".next", "target"])
+const allowedDeclarationFiles = new Set([
+  "docs/engineering/root-compatibility-shims.md",
+  "scripts/validate-root-shim-retirement.mjs",
+])
+const textExtensions = new Set([".json", ".md", ".mjs", ".service", ".timer", ".ts", ".tsx", ".yml", ".yaml"])
+const errors = []
+
+async function pathExists(filePath) {
+  try {
+    await fs.access(filePath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function collectFiles(filePath, files = []) {
+  const stat = await fs.stat(filePath)
+
+  if (stat.isFile()) {
+    if (textExtensions.has(path.extname(filePath)) || path.basename(filePath) === "package.json") {
+      files.push(filePath)
+    }
+    return files
+  }
+
+  if (!stat.isDirectory()) {
+    return files
+  }
+
+  const entries = await fs.readdir(filePath, { withFileTypes: true })
+  for (const entry of entries) {
+    if (entry.isDirectory() && skippedDirectories.has(entry.name)) {
+      continue
+    }
+
+    await collectFiles(path.join(filePath, entry.name), files)
+  }
+
+  return files
+}
+
+for (const scannedPath of scannedPaths) {
+  const absolutePath = path.join(repoRoot, scannedPath)
+  if (!(await pathExists(absolutePath))) {
+    continue
+  }
+
+  const files = await collectFiles(absolutePath)
+  for (const file of files) {
+    const relativePath = path.relative(repoRoot, file)
+    if (allowedDeclarationFiles.has(relativePath)) {
+      continue
+    }
+
+    const raw = await fs.readFile(file, "utf8")
+    if (raw.includes(retiredCliEntrypoint)) {
+      errors.push(`${relativePath} still references retired ${retiredCliEntrypoint}`)
+    }
+  }
+}
+
+if (errors.length > 0) {
+  console.error("Root shim retirement validation failed:")
+  for (const error of errors) {
+    console.error(`- ${error}`)
+  }
+  process.exit(1)
+}
+
+console.log("Root shim retirement validation passed.")


### PR DESCRIPTION
## Summary
- migrate production systemd bot-worker and bot-cleanup units from retired `src/cli/index.ts` to `apps/cli/src/index.ts`
- document `src/cli/index.ts` as a retired shim group with the supported CLI replacement
- add `check:shims:retired` so production/headless docs and config do not reintroduce the retired root CLI path

## Verification
- `bun run check:shims:retired`
- `bun run check:boundaries:external`
- `bun run check:boundaries:strict`
- `git diff --check`
- changed markdown links resolve
- `bun run lint:ci`

Closes #295
