### PR TITLE
Add CI step timeouts and diagnostics

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install system dependencies
+        timeout-minutes: 25
         run: |
           sudo apt-get update
           
@@ -108,6 +109,7 @@ jobs:
           key: ${{ runner.os }}-rust-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Clean install dependencies
+        timeout-minutes: 20
         run: |
           npm config set fetch-timeout 300000
           npm config set fetch-retries 5
@@ -136,6 +138,7 @@ jobs:
         run: mkdir -p dist
 
       - name: Verify Cargo configuration
+        timeout-minutes: 5
         run: |
           cd src-tauri
           echo "=== Cargo.toml content ==="
@@ -148,6 +151,7 @@ jobs:
           grep -A 5 'name = "tauri"' Cargo.lock || echo "Tauri not found in Cargo.lock"
 
       - name: Build Rust dependencies
+        timeout-minutes: 60
         env:
           PKG_CONFIG_PATH: /usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig
           RUST_BACKTRACE: 1
@@ -180,14 +184,18 @@ jobs:
           cargo build --release --verbose
 
       - name: Generate TypeScript bindings
+        timeout-minutes: 10
         run: |
           cd src-tauri
+          echo "Generating TypeScript bindings with cargo run --bin generate_types"
           cargo run --bin generate_types
 
       - name: Build Next.js app
+        timeout-minutes: 35
         run: |
           npm run build || echo "Build failed due to known Next.js 16 bug (issue 85604), continuing workflow..."
         continue-on-error: true
 
       - name: Run tests
+        timeout-minutes: 35
         run: npm run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
 
     steps:
       - name: Free disk space
+        timeout-minutes: 10
         run: |
           # Агрессивное освобождение места (~25GB)
           sudo rm -rf /usr/share/dotnet
@@ -56,6 +57,7 @@ jobs:
             ${{ runner.os }}-bun-
 
       - name: Install dependencies
+        timeout-minutes: 20
         run: |
           export ONNXRUNTIME_DOWNLOAD_TIMEOUT=600000
           bun install --frozen-lockfile || bun install
@@ -66,6 +68,7 @@ jobs:
           toolchain: 1.90.0
 
       - name: Install Linux dependencies
+        timeout-minutes: 15
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libglib2.0-dev
@@ -79,6 +82,18 @@ jobs:
       - name: Create dist directory
         run: mkdir -p dist
 
+      - name: Print frontend CI diagnostics
+        timeout-minutes: 5
+        run: |
+          echo "Runner: $RUNNER_OS $ImageOS"
+          echo "Disk:"
+          df -h
+          echo "Bun:"
+          bun --version
+          echo "Rust:"
+          rustc --version
+          cargo --version
+
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
@@ -90,6 +105,7 @@ jobs:
           save-if: false
 
       - name: Build Rust dependencies
+        timeout-minutes: 35
         env:
           PKG_CONFIG_PATH: /usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig
           FFMPEG_SYS_DISABLE_X86ASM: "1"
@@ -99,6 +115,7 @@ jobs:
           cargo build --release
 
       - name: Clean build artifacts
+        timeout-minutes: 5
         run: |
           cd src-tauri
           # Удаляем большие временные файлы и debug артефакты
@@ -111,16 +128,19 @@ jobs:
           find target/release -type f -name "*.rlib" -delete
           find target/release -maxdepth 1 -type f ! -name "generate_types*" -delete
 
-      - name: Generate TypeScript bindings
+      - name: Generate TypeScript bindings (cargo generate_types)
+        timeout-minutes: 10
         env:
           PKG_CONFIG_PATH: /usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig
           FFMPEG_SYS_DISABLE_X86ASM: "1"
           CARGO_FEATURE_FFMPEG_SYS_DISABLE_X86ASM: "1"
         run: |
           cd src-tauri
+          echo "Generating TypeScript bindings from src-tauri"
           cargo run --bin generate_types
 
-      - name: Run frontend tests
+      - name: Run frontend tests (Vitest)
+        timeout-minutes: 35
         run: bun run test
         env:
           NODE_OPTIONS: --max-old-space-size=8192
@@ -142,6 +162,7 @@ jobs:
 
     steps:
       - name: Free disk space
+        timeout-minutes: 10
         run: |
           # Агрессивное освобождение места (~25GB)
           sudo rm -rf /usr/share/dotnet
@@ -179,6 +200,7 @@ jobs:
           save-if: false
 
       - name: Install Linux dependencies
+        timeout-minutes: 15
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file \
@@ -194,6 +216,7 @@ jobs:
         run: mkdir -p dist
 
       - name: Run Rust tests
+        timeout-minutes: 20
         env:
           PKG_CONFIG_PATH: /usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig
           CARGO_BUILD_JOBS: 2
@@ -207,6 +230,7 @@ jobs:
           fi
 
       - name: Clean test artifacts
+        timeout-minutes: 5
         run: |
           cd src-tauri
           # Удаляем временные тестовые артефакты
@@ -242,9 +266,11 @@ jobs:
             ${{ runner.os }}-bun-lint-
 
       - name: Install dependencies
+        timeout-minutes: 15
         run: bun install --frozen-lockfile || bun install
 
       - name: Run linting
+        timeout-minutes: 10
         run: bun run lint:ci
         env:
           NODE_OPTIONS: --max-old-space-size=4096
@@ -274,9 +300,11 @@ jobs:
             ${{ runner.os }}-bun-typecheck-
 
       - name: Install dependencies
+        timeout-minutes: 15
         run: bun install --frozen-lockfile || bun install
 
       - name: Install promo dependencies
+        timeout-minutes: 10
         run: |
           cd promo
           bun install --frozen-lockfile || bun install
@@ -285,10 +313,13 @@ jobs:
       - name: Run type check
         # src/types/generated/tauri-bindings.ts is committed to the repo,
         # so no Rust build or Linux system deps are needed here.
+        timeout-minutes: 10
         run: bun run check:type
 
       - name: Run workspace type checks
+        timeout-minutes: 10
         run: bun run check:workspaces
 
       - name: Run package boundary strict gate
+        timeout-minutes: 5
         run: bun run check:boundaries:strict

--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -47,6 +47,7 @@ jobs:
 
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
+        timeout-minutes: 15
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libglib2.0-dev
@@ -57,8 +58,10 @@ jobs:
 
       - name: Install Windows dependencies for Tauri bindings
         if: runner.os == 'Windows'
+        timeout-minutes: 30
         shell: pwsh
         run: |
+          Write-Host "Preparing Windows FFmpeg/pkg-config dependencies for bindings generation"
           # Install pkg-config
           choco install pkgconfiglite -y
           
@@ -88,12 +91,25 @@ jobs:
           echo "FFMPEG_NO_PKG_CONFIG=1" >> $env:GITHUB_ENV
           echo "RUSTFLAGS=-C link-arg=/LIBPATH:C:\ffmpeg\lib" >> $env:GITHUB_ENV
           echo "C:\ffmpeg\bin" >> $env:GITHUB_PATH
+          Write-Host "FFmpeg directory:"
+          Get-ChildItem -Path C:\ffmpeg | Select-Object -First 20 | Format-Table -AutoSize
+
+      - name: Print lint job diagnostics
+        timeout-minutes: 5
+        shell: pwsh
+        run: |
+          Write-Host "Runner OS: $env:RUNNER_OS"
+          node --version
+          npm --version
+          rustc --version
+          cargo --version
 
       - name: Create dist directory
         run: mkdir -p dist
 
       - name: Build Rust dependencies on Unix
         if: runner.os != 'Windows'
+        timeout-minutes: 40
         env:
           PKG_CONFIG_PATH: /usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig
         run: |
@@ -102,14 +118,17 @@ jobs:
 
       - name: Generate TypeScript bindings on Unix
         if: runner.os != 'Windows'
+        timeout-minutes: 10
         env:
           PKG_CONFIG_PATH: /usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig
         run: |
           cd src-tauri
+          echo "Generating TypeScript bindings on Unix"
           cargo run --bin generate_types
 
       - name: Build Rust dependencies on Windows
         if: runner.os == 'Windows'
+        timeout-minutes: 45
         shell: pwsh
         env:
           FFMPEG_DIR: C:\ffmpeg
@@ -127,6 +146,7 @@ jobs:
 
       - name: Generate TypeScript bindings on Windows
         if: runner.os == 'Windows'
+        timeout-minutes: 10
         shell: pwsh
         env:
           FFMPEG_DIR: C:\ffmpeg
@@ -140,10 +160,12 @@ jobs:
           CARGO_FEATURE_FFMPEG_SYS_DISABLE_LINK: "1"
         run: |
           cd src-tauri
+          Write-Host "Generating TypeScript bindings on Windows"
           cargo run --bin generate_types
 
       - name: Install dependencies on Unix
         if: runner.os != 'Windows'
+        timeout-minutes: 15
         run: |
           npm config set fetch-timeout 300000
           npm config set fetch-retries 5
@@ -151,10 +173,12 @@ jobs:
 
       - name: Install dependencies on Windows
         if: runner.os == 'Windows'
+        timeout-minutes: 20
         shell: pwsh
         run: ./scripts/windows-npm-install.ps1
 
       - name: Run lint step
+        timeout-minutes: 10
         env:
           NODE_OPTIONS: '--max-old-space-size=4096'
         run: npm run lint:ci


### PR DESCRIPTION
## Summary
- add step-level timeouts to long install, Rust build, bindings generation, frontend test, and lint steps in build/ci/lint-js workflows
- add lightweight diagnostics for frontend CI and cross-platform lint jobs
- improve Windows FFmpeg setup logging and bindings-generation labels without changing successful commands

## Verification
- parsed `.github/workflows/build.yml`, `.github/workflows/ci.yml`, `.github/workflows/lint-js.yml` with `js-yaml`
- `git diff --check`
- `bun run lint:ci`

Note: `actionlint` is not installed locally in this workspace.

Closes #300
