### PR TITLE
Define Rust/Node AI edit parity boundary

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,7 @@
 Документация всех API:
 - **[External And Headless Integration Contracts](engineering/external-headless-contracts.md)** - Supported `ProjectSchema`, Rust `timeline`, `render-job`, `bot-workflow`, `bot-worker`, and postim/headless integration surface
 - **[Bot-First Production Contract](engineering/bot-first-production-contract.md)** - Supported Telegram bot-first production workflow, state, retry, cleanup and Rust publish boundary
+- **[Rust/Node AI Edit Parity](engineering/rust-node-ai-edit-parity.md)** - Current AI edit ownership boundary and future Rust `llm-edit` parity path
 - **[Media API](04_api_reference/media-api.md)** - API для работы с медиафайлами
 - **[AI Chat API](04_api_reference/ai-chat-api.md)** - API для AI чат функциональности
 - **[Export API](04_api_reference/export-api.md)** - API для экспорта проектов

--- a/docs/engineering/bot-first-production-contract.md
+++ b/docs/engineering/bot-first-production-contract.md
@@ -1,7 +1,7 @@
 # Bot-First Production Contract
 
 **Status:** Completed Phase G contract hardening for closed [#288](https://github.com/chatman-media/timeline-studio/issues/288)
-**Related:** [External And Headless Integration Contracts](external-headless-contracts.md), [Telegram Bot Worker Production Runbook](../06_deployment/telegram-bot-worker-production.md), [Telegram AI Review Sandbox Smoke](../06_deployment/telegram-ai-review-sandbox-smoke.md), [Timeline Studio CLI](../../apps/cli/COMMANDS.md)
+**Related:** [External And Headless Integration Contracts](external-headless-contracts.md), [Rust/Node AI Edit Parity](rust-node-ai-edit-parity.md), [Telegram Bot Worker Production Runbook](../06_deployment/telegram-bot-worker-production.md), [Telegram AI Review Sandbox Smoke](../06_deployment/telegram-ai-review-sandbox-smoke.md), [Timeline Studio CLI](../../apps/cli/COMMANDS.md)
 
 This contract defines the supported bot-first/headless production path for Telegram AI review. Operators and external consumers should be able to understand this path without reading package internals.
 

--- a/docs/engineering/external-headless-contracts.md
+++ b/docs/engineering/external-headless-contracts.md
@@ -1,7 +1,7 @@
 # External And Headless Integration Contracts
 
 **Status:** Completed Phase G contract hardening for closed [#282](https://github.com/chatman-media/timeline-studio/issues/282)
-**Related:** [G1](https://github.com/chatman-media/timeline-studio/issues/283), [G2](https://github.com/chatman-media/timeline-studio/issues/284), [Bot-First Production Contract](bot-first-production-contract.md), [Telegram AI Review Sandbox Smoke](../06_deployment/telegram-ai-review-sandbox-smoke.md), [postim Headless Integration Example](../../examples/headless-postim/README.md), [Package Boundaries](package-boundaries.md), [Root Compatibility Shims](root-compatibility-shims.md), [Agent Contract Reference](AGENT_CONTRACT_REFERENCE.md)
+**Related:** [G1](https://github.com/chatman-media/timeline-studio/issues/283), [G2](https://github.com/chatman-media/timeline-studio/issues/284), [Bot-First Production Contract](bot-first-production-contract.md), [Rust/Node AI Edit Parity](rust-node-ai-edit-parity.md), [Telegram AI Review Sandbox Smoke](../06_deployment/telegram-ai-review-sandbox-smoke.md), [postim Headless Integration Example](../../examples/headless-postim/README.md), [Package Boundaries](package-boundaries.md), [Root Compatibility Shims](root-compatibility-shims.md), [Agent Contract Reference](AGENT_CONTRACT_REFERENCE.md)
 
 This document defines the supported integration surface for external consumers after the workspace extraction. It is intentionally narrow: consumers should build against `ProjectSchema`, the Rust `timeline` CLI, and the headless Node CLI commands. They should not import private package files, root aliases, or `src-tauri` internals.
 

--- a/docs/engineering/rust-node-ai-edit-parity.md
+++ b/docs/engineering/rust-node-ai-edit-parity.md
@@ -1,0 +1,88 @@
+# Rust/Node AI Edit Parity
+
+**Status:** Phase H ownership decision for [#296](https://github.com/chatman-media/timeline-studio/issues/296)
+**Related:** [Bot-First Production Contract](bot-first-production-contract.md), [External And Headless Integration Contracts](external-headless-contracts.md), [Timeline Studio CLI](../../apps/cli/COMMANDS.md)
+
+This document defines the current production boundary for Telegram AI review editing and the parity path for a future Rust-backed `llm-edit` command. It does not require a broad rewrite before bot-first production rollout.
+
+## Current Ownership
+
+| Capability | Production owner now | Evidence | Decision |
+| --- | --- | --- | --- |
+| Telegram intake, review routing, sessions, retries, approval gate | Node `bot-worker` | `NodeTelegramBotWorker`, bot edit session store, `/approve`, `/versions`, retry/cancel handling | Keep in Node. It is orchestration, state and user messaging, not media execution. |
+| Text, voice and video-note feedback normalization | Node adapters | `IBotFeedbackTranscriber`, Telegram file resolution and session routing | Keep in Node. It is provider glue and Telegram runtime handling. |
+| Iterative AI project editing | Node `IAIProjectEditor` | `runAIProjectEdit`, `NodeAIProjectEditor`, validation/repair around `AIProjectEditorResult` | Node remains the supported production editor until Rust has an equivalent `llm-edit` contract and fixture parity. |
+| Project mutation contract | Core `ProjectSchema` + `AIProjectEditorResult` | `ProjectSchema` validation and edit result validation in core services | Keep the contract language-neutral. Editors must return a full next `ProjectSchema`, not desktop state or partial UI mutations. |
+| First-cut planning | Rust CLI through Node adapter | `NodeRustFirstCutPlanner` calls `timeline montage-plan` or `timeline llm-plan` | Rust owns production first-cut planning when configured. Node may fall back deterministically. |
+| Preview/final rendering | Rust render through Node adapter where configured | `NodeRustRenderVideoService`, `render-job --rust-render`, `bot-worker --rust-render` | Rust owns production render where the Rust command is configured. |
+| Final publish | Rust publish through Node adapter where supported | `NodeRustPublishService` calls `timeline publish ... --json` | Rust owns Telegram/YouTube-style publish. TypeScript must not become a second production publish backend for Rust-supported destinations. |
+
+## Supported Short-Term Contract
+
+The current production path is:
+
+1. Node `bot-worker` stores the edit session and current `ProjectSchema`.
+2. User text, voice or video-note feedback becomes one normalized instruction.
+3. Node `IAIProjectEditor` receives `currentProject`, `userInstruction`, `sourceMedia`, optional revision history, target platform, constraints and metadata.
+4. The editor returns `AIProjectEditorResult` with `nextProject`, summary, changed areas, edit commands, diagnostics and metadata.
+5. Core validation rejects malformed requests/results before a revision is persisted.
+6. Preview render and final publish use Rust-backed adapters when configured.
+
+This means Node owns the AI edit provider glue today, but the persisted mutation contract is still `ProjectSchema`. External consumers should call the bot/headless entrypoints instead of importing the Node editor directly.
+
+## Future Rust `llm-edit` Contract
+
+Rust parity should be added as a new CLI/editor implementation, not as a replacement for bot-worker orchestration.
+
+Candidate command shape:
+
+```bash
+timeline llm-edit \
+  --current-project ./current.project.json \
+  --instruction ./instruction.txt \
+  --source-media ./source-media.json \
+  --revision-history ./revisions.json \
+  --target-platform youtube \
+  --output ./next-edit-result.json \
+  --json
+```
+
+Required input fields:
+
+- `currentProject`: full `ProjectSchema`.
+- `instruction`: normalized text feedback from the bot.
+- `sourceMedia`: media paths, Telegram file metadata or URLs already accepted by policy.
+- `revisionHistory`: compact prior revision summaries.
+- `targetPlatform`, `constraints` and metadata where available.
+
+Required output shape:
+
+- `nextProject`: full next `ProjectSchema`.
+- `summary`: user-facing edit summary.
+- `changedAreas`: paths or conceptual areas changed.
+- `commands`: machine-readable edit commands compatible with `AIProjectEditCommand`.
+- `diagnostics`: info/warning/error diagnostics.
+- `metadata`: redacted provider/model/prompt/attempt data.
+
+Node should consume Rust `llm-edit` through a future `NodeRustAIProjectEditor` adapter that implements `IAIProjectEditor` and then runs the same `runAIProjectEdit` validation/repair gate. Bot-worker, sessions, `/status`, `/versions`, preview render and publish behavior should not need to change.
+
+## Blockers Before Rust Can Own Iterative Edit
+
+- Rust `timeline llm-plan` is first-cut oriented; it does not currently accept `currentProject + instruction + revisionHistory` and return `AIProjectEditorResult`.
+- The edit command vocabulary must stay compatible with `AIProjectEditCommand` so Node status/revision diagnostics remain stable.
+- Parity fixtures must prove that common review corrections return valid `ProjectSchema` and useful diagnostics.
+- Provider secrets and raw prompts must stay redacted in both Rust command metadata and Node session state.
+
+These blockers do not block current production bot usage because Node `IAIProjectEditor` is the supported short-term production editor.
+
+## Follow-Up Work
+
+Concrete parity tasks when Rust edit ownership becomes a priority:
+
+1. Add `timeline llm-edit` with the input/output contract above and JSON fixture tests.
+2. Add `NodeRustAIProjectEditor` behind an explicit `TIMELINE_BOT_AI_EDITOR_PROVIDER=rust-llm-edit` or equivalent CLI/env option.
+3. Add parity fixtures for at least: shorten intro, remove clip, add caption/title, adapt to platform, and invalid provider output.
+4. Keep publish destination behavior under the separate destination matrix task [#297](https://github.com/chatman-media/timeline-studio/issues/297).
+5. Keep operator-facing session/revision diagnostics under the observability task [#298](https://github.com/chatman-media/timeline-studio/issues/298).
+
+Do not start a broad Rust/Node rewrite under this parity track. The migration is complete only when the Rust editor passes fixture parity and can be selected without changing the bot-worker state machine.


### PR DESCRIPTION
## Summary
- add a Rust/Node AI edit parity decision document for Phase H
- document current ownership for Node bot orchestration, Node `IAIProjectEditor`, Rust first-cut/render/publish, and shared `ProjectSchema` mutation contracts
- define the future `timeline llm-edit` contract shape, blockers, and concrete parity follow-up tasks without making this a broad rewrite

## Verification
- changed markdown links resolve
- `bun run check:boundaries:external`
- `git diff --check`
- `bun run lint:ci`

Closes #296
