### PR TITLE
Fix AI timeline tool execution path

### DIFF
--- a/packages/domains/src/ai-tools/tools/core/timeline/__tests__/execution-path.test.ts
+++ b/packages/domains/src/ai-tools/tools/core/timeline/__tests__/execution-path.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import { setTimelineStateAccess } from "../types"
+import { trackCreationTool } from "../create-tracks"
+import { clipManagementTool } from "../manage-clips"
+import { clipPlacementTool } from "../place-clips"
+
+describe("timeline AI tool execution path", () => {
+  let project: any
+
+  beforeEach(() => {
+    project = {
+      id: "project-1",
+      name: "AI Timeline Test",
+      globalTracks: [],
+      sections: [],
+    }
+
+    setTimelineStateAccess({
+      getCurrentProject: () => project,
+      createProject: async (nextProject: any) => {
+        project = nextProject
+      },
+      updateProject: async (updates: any) => {
+        project = { ...project, ...updates }
+      },
+      createSection: async (section: any) => section,
+      createTrack: async (track: any) => track,
+      addClip: async (clip: any) => clip,
+      getProjectStats: () => ({
+        totalDuration: 0,
+        totalClips: 0,
+        totalTracks: project.globalTracks.length,
+        totalSections: project.sections.length,
+      }),
+      sendTimelineCommand: async () => undefined,
+    })
+  })
+
+  afterEach(() => {
+    setTimelineStateAccess(null)
+  })
+
+  it("creates tracks when execute() is called from AI Chat", async () => {
+    const result = await trackCreationTool.execute({
+      tracks: [{ type: "video", name: "AI Video" }],
+    })
+
+    expect(result.success).toBe(true)
+    expect(project.globalTracks).toHaveLength(1)
+    expect(project.globalTracks[0]).toMatchObject({
+      name: "AI Video",
+      type: "video",
+      clips: [],
+    })
+  })
+
+  it("places clips into a real timeline track when execute() is called from AI Chat", async () => {
+    project.globalTracks.push({
+      id: "track-video-1",
+      name: "Video 1",
+      type: "video",
+      order: 0,
+      clips: [],
+    })
+
+    const result = await clipPlacementTool.execute({
+      clips: [{ resourceId: "media-1", name: "Clip 1", duration: 3, startTime: 1 }],
+      strategy: "manual",
+      trackAssignment: "smart",
+    })
+
+    expect(result.success).toBe(true)
+    expect(project.globalTracks[0].clips).toHaveLength(1)
+    expect(project.globalTracks[0].clips[0]).toMatchObject({
+      name: "Clip 1",
+      trackId: "track-video-1",
+      mediaId: "media-1",
+      startTime: 1,
+      duration: 3,
+    })
+  })
+
+  it("fails clearly when execute() cannot place clips", async () => {
+    const result = await clipPlacementTool.execute({
+      clips: [{ resourceId: "media-1", name: "Clip 1", duration: 3, startTime: 1 }],
+      strategy: "manual",
+      trackAssignment: "smart",
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.errors?.[0]).toContain("Нет доступных треков")
+  })
+
+  it("analyzes real timeline clips when manage-clips execute() is called from AI Chat", async () => {
+    project.globalTracks.push({
+      id: "track-video-1",
+      name: "Video 1",
+      type: "video",
+      order: 0,
+      clips: [
+        {
+          id: "clip-1",
+          name: "Clip 1",
+          trackId: "track-video-1",
+          mediaId: "media-1",
+          startTime: 0,
+          duration: 3,
+          effects: [],
+          filters: [],
+          transitions: [],
+        },
+      ],
+    })
+
+    const result = await clipManagementTool.execute({
+      operation: "analyze",
+      scope: "all",
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.data).toMatchObject({
+      operation: "analyze",
+      processedClips: 1,
+      clipAnalysis: {
+        totalClips: 1,
+      },
+    })
+  })
+
+  it("returns a clear failure for unsupported timeline operations", async () => {
+    const result = await clipManagementTool.execute({
+      operation: "unsupported",
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.errors).toContain("Неподдерживаемая операция: unsupported")
+  })
+})

--- a/packages/domains/src/ai-tools/tools/core/timeline/create-tracks.ts
+++ b/packages/domains/src/ai-tools/tools/core/timeline/create-tracks.ts
@@ -71,8 +71,7 @@ export class TrackCreationTool extends BaseAITool {
   }
 
   async execute(input: any, options?: AIToolExecutionOptions): Promise<AIToolResult> {
-    // Delegate to main method - will be implemented by the specific tool
-    return this.executeWithErrorHandling(async () => ({}), input, options)
+    return this.createTrackStructure(input as CreateTracksInput, options)
   }
 
   /**
@@ -127,6 +126,17 @@ export class TrackCreationTool extends BaseAITool {
         errors,
       }
     })
+
+    if (!validation.isValid) {
+      return {
+        success: false,
+        errors: validation.errors,
+        message: "Ошибка валидации параметров создания треков",
+        executionTime: 1,
+        toolName: this.metadata.name,
+        executionId: `${this.metadata.name}_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+      }
+    }
 
     // Устанавливаем значения по умолчанию
     const tracks = input.tracks

--- a/packages/domains/src/ai-tools/tools/core/timeline/manage-clips.ts
+++ b/packages/domains/src/ai-tools/tools/core/timeline/manage-clips.ts
@@ -124,8 +124,7 @@ export class ClipManagementTool extends BaseAITool {
   }
 
   async execute(input: any, options?: AIToolExecutionOptions): Promise<AIToolResult> {
-    // Delegate to main method - will be implemented by the specific tool
-    return this.executeWithErrorHandling(async () => ({}), input, options)
+    return this.manageTimelineClips(input as ClipManagementInput, options)
   }
 
   /**
@@ -167,6 +166,17 @@ export class ClipManagementTool extends BaseAITool {
         errors,
       }
     })
+
+    if (!validation.isValid) {
+      return {
+        success: false,
+        errors: validation.errors,
+        message: "Ошибка валидации параметров управления клипами",
+        executionTime: 1,
+        toolName: this.metadata.name,
+        executionId: `${this.metadata.name}_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+      }
+    }
 
     const operation = input.operation
     const scope = input.scope || "all"

--- a/packages/domains/src/ai-tools/tools/core/timeline/place-clips.ts
+++ b/packages/domains/src/ai-tools/tools/core/timeline/place-clips.ts
@@ -11,7 +11,7 @@ import {
   BaseAITool,
 } from "../../../base"
 import { generateClipId } from "./utils/generators"
-import { getCurrentTimelineProject, saveTimelineProject } from "./utils/helpers"
+import { assignTrackForClip, getCurrentTimelineProject, saveTimelineProject } from "./utils/helpers"
 
 // Типы для размещения клипов
 export interface ClipPlacementConfig {
@@ -77,8 +77,7 @@ export class ClipPlacementTool extends BaseAITool {
   }
 
   async execute(input: any, options?: AIToolExecutionOptions): Promise<AIToolResult> {
-    // Delegate to main method - will be implemented by the specific tool
-    return this.executeWithErrorHandling(async () => ({}), input, options)
+    return this.placeClipsOnTimeline(input as PlaceClipsInput, options)
   }
 
   /**
@@ -125,6 +124,17 @@ export class ClipPlacementTool extends BaseAITool {
       }
     })
 
+    if (!validation.isValid) {
+      return {
+        success: false,
+        errors: validation.errors,
+        message: "Ошибка валидации параметров размещения клипов",
+        executionTime: 1,
+        toolName: this.metadata.name,
+        executionId: `${this.metadata.name}_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+      }
+    }
+
     const clips = input.clips
     const strategy = input.strategy || "sequential"
     const trackAssignment = input.trackAssignment || "smart"
@@ -154,6 +164,10 @@ export class ClipPlacementTool extends BaseAITool {
         const skippedClips: PlaceClipsResult["skippedClips"] = []
         const trackDistribution: Record<string, number> = {}
         let currentTime = 0
+        const allTracks = [
+          ...(currentProject.globalTracks || []),
+          ...(currentProject.sections || []).flatMap((section) => section.tracks || []),
+        ]
 
         // Сортируем клипы если стратегия chronological
         const clipsToPlace = [...clips]
@@ -163,13 +177,38 @@ export class ClipPlacementTool extends BaseAITool {
 
         for (const clipConfig of clipsToPlace) {
           try {
+            const targetTrackId =
+              clipConfig.targetTrackId || assignTrackForClip(allTracks, clipConfig, trackAssignment) || undefined
+            const targetTrack = allTracks.find((track) => track.id === targetTrackId)
+
+            if (!targetTrack) {
+              throw new Error(
+                targetTrackId
+                  ? `Трек с ID ${targetTrackId} не найден`
+                  : "Нет доступных треков для размещения клипа",
+              )
+            }
+
+            const startTime = clipConfig.startTime ?? currentTime
+            if (preventOverlaps) {
+              const hasOverlap = targetTrack.clips?.some(
+                (existingClip) =>
+                  startTime < existingClip.startTime + existingClip.duration &&
+                  startTime + clipConfig.duration > existingClip.startTime,
+              )
+
+              if (hasOverlap) {
+                throw new Error(`Клип пересекается с существующим клипом на треке ${targetTrack.id}`)
+              }
+            }
+
             // Создаем и размещаем клип (упрощенная версия оригинальной логики)
             const clip: TimelineClip = {
               id: generateClipId(),
               name: clipConfig.name || `Clip ${placedClips.length + 1}`,
-              trackId: clipConfig.targetTrackId || "default-track",
+              trackId: targetTrack.id,
               mediaId: clipConfig.resourceId,
-              startTime: clipConfig.startTime || currentTime,
+              startTime,
               duration: clipConfig.duration,
               sourceIn: clipConfig.trimStart || 0,
               sourceOut: (clipConfig.trimStart || 0) + clipConfig.duration,
@@ -201,6 +240,7 @@ export class ClipPlacementTool extends BaseAITool {
               updatedAt: new Date(),
             }
 
+            targetTrack.clips = [...(targetTrack.clips || []), clip].sort((a, b) => a.startTime - b.startTime)
             placedClips.push(clip)
             trackDistribution[clip.trackId] = (trackDistribution[clip.trackId] || 0) + 1
 
@@ -220,6 +260,12 @@ export class ClipPlacementTool extends BaseAITool {
         const warnings: string[] = []
         if (skippedClips.length > 0) {
           warnings.push(`Пропущено ${skippedClips.length} клипов из-за ошибок`)
+        }
+
+        if (placedClips.length === 0 && skippedClips.length > 0) {
+          throw new Error(
+            `Не удалось разместить клипы: ${skippedClips.map((clip) => clip.reason).join("; ")}`,
+          )
         }
 
         const result: PlaceClipsResult = {

--- a/packages/domains/src/ai-tools/tools/core/timeline/utils/detectors.ts
+++ b/packages/domains/src/ai-tools/tools/core/timeline/utils/detectors.ts
@@ -50,10 +50,10 @@ export function determineContentType(clip: TimelineClip): string {
   }
 
   // Fallback: анализ по track ID
-  if (clip.trackId.includes("video")) return "Video"
-  if (clip.trackId.includes("audio")) return "Audio"
-  if (clip.trackId.includes("music")) return "Music"
-  if (clip.trackId.includes("image")) return "Image"
+  if (clip.trackId?.includes("video")) return "Video"
+  if (clip.trackId?.includes("audio")) return "Audio"
+  if (clip.trackId?.includes("music")) return "Music"
+  if (clip.trackId?.includes("image")) return "Image"
 
   return "Unknown"
 }

--- a/src/features/ai-chat/hooks/use-timeline-ai-integration.ts
+++ b/src/features/ai-chat/hooks/use-timeline-ai-integration.ts
@@ -1,27 +1,13 @@
+import {
+  setTimelineStateAccess,
+  type TimelineStateAccess,
+} from "@timeline-studio/domains/ai-tools/tools/core/timeline/types"
 import { useCallback, useEffect, useMemo, useRef } from "react"
 import { createLogger, type LogContext, logError, logInfo } from "@/lib/tauri-logger"
 import { useTimeline } from "../../timeline/hooks"
 import type { TimelineClip, TimelineSection, TimelineTrack } from "../../timeline/types"
 
 const logger = createLogger({ module: "UseTimelineAiIntegration" })
-
-// Временно определяем типы локально
-interface TimelineStateAccess {
-  getCurrentProject: () => any
-  createProject: (project: any) => Promise<void>
-  updateProject: (updates: any) => Promise<void>
-  createSection: (section: any) => Promise<any>
-  createTrack: (track: any) => Promise<any>
-  addClip: (clip: any) => Promise<any>
-  getProjectStats: () => any
-  sendTimelineCommand: (command: string, params?: any) => Promise<void>
-}
-
-// Временная заглушка для setTimelineStateAccess
-let timelineStateAccess: TimelineStateAccess | null = null
-const setTimelineStateAccess = (access: TimelineStateAccess | null) => {
-  timelineStateAccess = access
-}
 
 /**
  * Хук для интеграции Timeline с AI функциональностью

--- a/src/features/ai-chat/utils/__tests__/convert-tools.test.ts
+++ b/src/features/ai-chat/utils/__tests__/convert-tools.test.ts
@@ -3,7 +3,8 @@
  */
 
 import type { AIToolResult, IAITool } from "@timeline-studio/core/types/ai-tools"
-import { describe, expect, it } from "vitest"
+import { clipPlacementTool, setTimelineStateAccess } from "@timeline-studio/domains/ai-tools/tools/core/timeline"
+import { afterEach, describe, expect, it } from "vitest"
 import {
   convertToolsToUnifiedFormat,
   convertToUnifiedAITool,
@@ -326,6 +327,10 @@ describe("Function Calling Integration", () => {
   })
 
   describe("executeToolByName", () => {
+    afterEach(() => {
+      setTimelineStateAccess(null)
+    })
+
     it("должен выполнить инструмент по имени", async () => {
       const mockTools = [new MockTool()]
       const result = await executeToolByName(mockTools, "mock-tool", { testParam: "test" })
@@ -379,6 +384,56 @@ describe("Function Calling Integration", () => {
       const result = await executeToolByName(mockTools, "mock-tool", input)
 
       expect(result.result).toBe("Executed with custom-value")
+    })
+
+    it("должен выполнять реальные timeline mutations для AI Chat timeline tools", async () => {
+      const project: any = {
+        id: "project-1",
+        name: "AI Chat Timeline Test",
+        globalTracks: [
+          {
+            id: "track-video-1",
+            name: "Video 1",
+            type: "video",
+            order: 0,
+            clips: [],
+          },
+        ],
+        sections: [],
+      }
+
+      setTimelineStateAccess({
+        getCurrentProject: () => project,
+        createProject: async () => undefined,
+        updateProject: async () => undefined,
+        createSection: async (section: any) => section,
+        createTrack: async (track: any) => track,
+        addClip: async (clip: any) => clip,
+        getProjectStats: () => ({
+          totalDuration: 0,
+          totalClips: project.globalTracks[0].clips.length,
+          totalTracks: project.globalTracks.length,
+          totalSections: 0,
+        }),
+        sendTimelineCommand: async () => undefined,
+      })
+
+      const result = await executeToolByName([clipPlacementTool], "place-clips", {
+        clips: [{ resourceId: "media-1", name: "Clip 1", duration: 3, startTime: 1 }],
+        strategy: "manual",
+        trackAssignment: "smart",
+      })
+
+      expect(result.analysis).toMatchObject({
+        placedCount: 1,
+        skippedCount: 0,
+      })
+      expect(project.globalTracks[0].clips).toHaveLength(1)
+      expect(project.globalTracks[0].clips[0]).toMatchObject({
+        mediaId: "media-1",
+        trackId: "track-video-1",
+        startTime: 1,
+      })
     })
 
     it("должен обрабатывать инструменты с пустым результатом", async () => {


### PR DESCRIPTION
Closes #308

## Summary
- wire core timeline AI tool execute() methods to their real operations instead of empty success payloads
- connect AI Chat timeline integration to the shared timeline AI state singleton
- place clips into real tracks, surface clear placement failures, and validate unsupported clip operations
- add focused execution-path coverage plus AI Chat executeToolByName coverage

## Tests
- bunx vitest run packages/domains/src/ai-tools/tools/core/timeline/__tests__/execution-path.test.ts src/features/ai-chat/utils/__tests__/convert-tools.test.ts
- bun run lint:ci