### PR TITLE
Align MCP AI edit tool contracts

### DIFF
--- a/packages/domains/src/ai-tools/tools/mcp/README.md
+++ b/packages/domains/src/ai-tools/tools/mcp/README.md
@@ -55,6 +55,23 @@ allAITools.forEach(tool => {
 
 ## Список MCP Tools (18)
 
+## Production Readiness
+
+AI Chat must treat MCP `success: true` as a real project mutation/result only for implemented tools. Planned tools stay visible in the schema list, but Rust returns `success: false` until they are wired to project state or render/export services.
+
+| MCP adapter | Rust tool | Status | Canonical input |
+| --- | --- | --- | --- |
+| `mcp-add-clip` | `add_clip` | Production timeline edit | `track_id`, `media_id`, `time` |
+| `mcp-move-clip` | `move_clip` | Production timeline edit | `clip_id`, `new_track_id`, `new_time` |
+| `mcp-split-clip` | `split_clip` | Production timeline edit | `clip_id`, `time` |
+| `mcp-list-media-files` | `list_media_files` | Production project query | optional `filter_type=all/video/audio/image` |
+| `mcp-apply-filter` | `apply_filter` | Planned | returns failure until implemented |
+| `mcp-add-transition` | `add_transition` | Planned | returns failure until implemented |
+| `mcp-apply-color-grading` | `apply_color_grading` | Planned | returns failure until implemented |
+| `mcp-add-text-overlay` | `add_text_overlay` | Planned | returns failure until implemented |
+| `mcp-export-video` | `export_video` | Planned | returns failure until implemented |
+| `mcp-create-preview` | `create_preview` | Planned | returns failure until implemented |
+
 ### Analysis (4)
 1. **mcp-analyze-video** - Полный анализ видео (качество, метаданные, контент)
 2. **mcp-detect-scenes** - Обнаружение сцен с анализом качества

--- a/packages/domains/src/ai-tools/tools/mcp/__tests__/mcp-contract.test.ts
+++ b/packages/domains/src/ai-tools/tools/mcp/__tests__/mcp-contract.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  MCPAddClipTool,
+  MCPAddTransitionTool,
+  MCPApplyColorGradingTool,
+  MCPApplyFilterTool,
+  MCPAddTextOverlayTool,
+  MCPCreatePreviewTool,
+  MCPExportVideoTool,
+  MCPListMediaFilesTool,
+  MCPMoveClipTool,
+  MCPSplitClipTool,
+} from "../index"
+
+describe("MCP tool contracts", () => {
+  it("keeps mcp-add-clip aligned with the Rust timeline command contract", () => {
+    const schema = new MCPAddClipTool().getSchema().input
+
+    expect(schema.required).toEqual(["track_id", "media_id", "time"])
+    expect(schema.properties).toHaveProperty("track_id")
+    expect(schema.properties).toHaveProperty("media_id")
+    expect(schema.properties).toHaveProperty("time")
+    expect(schema.properties).not.toHaveProperty("video_path")
+    expect(schema.properties).not.toHaveProperty("start_time")
+    expect(schema.properties).not.toHaveProperty("track_index")
+  })
+
+  it("documents canonical schemas for key timeline MCP edit tools", () => {
+    expect(new MCPMoveClipTool().getSchema().input.required).toEqual(["clip_id", "new_track_id", "new_time"])
+    expect(new MCPSplitClipTool().getSchema().input.required).toEqual(["clip_id", "time"])
+    expect(new MCPListMediaFilesTool().getSchema().input.properties.filter_type.enum).toEqual([
+      "all",
+      "video",
+      "audio",
+      "image",
+    ])
+  })
+
+  it("keeps planned MCP tools visible but not production-ready", () => {
+    const plannedTools = [
+      new MCPApplyFilterTool(),
+      new MCPAddTransitionTool(),
+      new MCPApplyColorGradingTool(),
+      new MCPAddTextOverlayTool(),
+      new MCPExportVideoTool(),
+      new MCPCreatePreviewTool(),
+    ]
+
+    expect(plannedTools.map((tool) => tool.metadata.name)).toEqual([
+      "mcp-apply-filter",
+      "mcp-add-transition",
+      "mcp-apply-color-grading",
+      "mcp-add-text-overlay",
+      "mcp-export-video",
+      "mcp-create-preview",
+    ])
+  })
+})

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -8622,6 +8622,7 @@ dependencies = [
  "serde_json",
  "specta",
  "tokio",
+ "ts-schema",
  "uuid",
 ]
 

--- a/src-tauri/src/mcp/README.md
+++ b/src-tauri/src/mcp/README.md
@@ -36,6 +36,23 @@
 
 ## Доступные инструменты (18 штук)
 
+## Production readiness
+
+MCP tool schemas are visible to Claude/AI Chat, but only implemented tools may return `success: true`. Planned tools must return `success: false` with a clear `not implemented` error until they mutate project state or execute the export/preview service.
+
+| Tool | Status | Canonical input |
+| --- | --- | --- |
+| `add_clip` | Production timeline edit | `track_id`, `media_id`, `time` |
+| `move_clip` | Production timeline edit | `clip_id`, `new_track_id`, `new_time` |
+| `split_clip` | Production timeline edit | `clip_id`, `time` |
+| `list_media_files` | Production project query | optional `filter_type=all/video/audio/image` |
+| `apply_filter` | Planned | returns failure until implemented |
+| `add_transition` | Planned | returns failure until implemented |
+| `apply_color_grading` | Planned | returns failure until implemented |
+| `add_text_overlay` | Planned | returns failure until implemented |
+| `export_video` | Planned | returns failure until implemented |
+| `create_preview` | Planned | returns failure until implemented |
+
 ### Анализ видео
 1. **analyze_video** - Полный анализ видео (качество, метаданные, контент)
 2. **detect_scenes** - Обнаружение сцен с анализом качества

--- a/src-tauri/src/mcp/tools.rs
+++ b/src-tauri/src/mcp/tools.rs
@@ -210,28 +210,24 @@ impl VideoTools {
   fn tool_add_clip(&self) -> MCPTool {
     MCPTool {
       name: "add_clip".to_string(),
-      description: "Добавить видео клип на timeline".to_string(),
+      description: "Добавить медиа клип на timeline".to_string(),
       input_schema: json!({
         "type": "object",
         "properties": {
-          "video_path": {
+          "track_id": {
             "type": "string",
-            "description": "Путь к видео файлу"
+            "description": "ID целевого трека"
           },
-          "start_time": {
+          "media_id": {
+            "type": "string",
+            "description": "ID медиа файла из media pool проекта"
+          },
+          "time": {
             "type": "number",
             "description": "Время начала на timeline (секунды)"
-          },
-          "duration": {
-            "type": "number",
-            "description": "Длительность клипа (секунды)"
-          },
-          "track_index": {
-            "type": "number",
-            "description": "Номер трека (0, 1, 2...)"
           }
         },
-        "required": ["video_path", "start_time"]
+        "required": ["track_id", "media_id", "time"]
       }),
     }
   }
@@ -264,16 +260,16 @@ impl VideoTools {
             "type": "string",
             "description": "ID клипа"
           },
-          "new_start_time": {
+          "new_track_id": {
+            "type": "string",
+            "description": "Новый ID трека"
+          },
+          "new_time": {
             "type": "number",
             "description": "Новое время начала (секунды)"
-          },
-          "new_track_index": {
-            "type": "number",
-            "description": "Новый номер трека"
           }
         },
-        "required": ["clip_id", "new_start_time"]
+        "required": ["clip_id", "new_track_id", "new_time"]
       }),
     }
   }
@@ -289,12 +285,12 @@ impl VideoTools {
             "type": "string",
             "description": "ID клипа"
           },
-          "split_time": {
+          "time": {
             "type": "number",
             "description": "Время разделения внутри клипа (секунды)"
           }
         },
-        "required": ["clip_id", "split_time"]
+        "required": ["clip_id", "time"]
       }),
     }
   }
@@ -798,22 +794,6 @@ impl VideoTools {
   }
 
   async fn execute_add_clip(&self, arguments: Value) -> MCPToolResult {
-    // Проверяем наличие project state
-    let (project_state, event_bus) = match (&self.project_state, &self.event_bus) {
-      (Some(state), Some(bus)) => (state.clone(), bus.clone()),
-      _ => {
-        return MCPToolResult {
-          success: false,
-          data: None,
-          error: Some(
-            "Timeline operations require initialized project state. Please open a project first."
-              .to_string(),
-          ),
-        }
-      }
-    };
-
-    // Парсим аргументы
     let track_id = match arguments.get("track_id").and_then(|v| v.as_str()) {
       Some(id) => id.to_string(),
       None => {
@@ -836,10 +816,31 @@ impl VideoTools {
       }
     };
 
-    let time = arguments
-      .get("time")
-      .and_then(|v| v.as_f64())
-      .unwrap_or(0.0);
+    let time = match arguments.get("time").and_then(|v| v.as_f64()) {
+      Some(time) => time,
+      None => {
+        return MCPToolResult {
+          success: false,
+          data: None,
+          error: Some("Missing required parameter: time".to_string()),
+        }
+      }
+    };
+
+    // Проверяем наличие project state
+    let (project_state, event_bus) = match (&self.project_state, &self.event_bus) {
+      (Some(state), Some(bus)) => (state.clone(), bus.clone()),
+      _ => {
+        return MCPToolResult {
+          success: false,
+          data: None,
+          error: Some(
+            "Timeline operations require initialized project state. Please open a project first."
+              .to_string(),
+          ),
+        }
+      }
+    };
 
     // Используем TimelineCommands для добавления клипа
     let timeline_commands = TimelineCommands::new(project_state, event_bus);
@@ -1027,67 +1028,49 @@ impl VideoTools {
 
   async fn execute_apply_filter(&self, _arguments: Value) -> MCPToolResult {
     MCPToolResult {
-      success: true,
-      data: Some(json!({
-        "status": "not_implemented",
-        "message": "apply_filter will be implemented"
-      })),
-      error: None,
+      success: false,
+      data: None,
+      error: Some("MCP tool apply_filter is not implemented".to_string()),
     }
   }
 
   async fn execute_add_transition(&self, _arguments: Value) -> MCPToolResult {
     MCPToolResult {
-      success: true,
-      data: Some(json!({
-        "status": "not_implemented",
-        "message": "add_transition will be implemented"
-      })),
-      error: None,
+      success: false,
+      data: None,
+      error: Some("MCP tool add_transition is not implemented".to_string()),
     }
   }
 
   async fn execute_apply_color_grading(&self, _arguments: Value) -> MCPToolResult {
     MCPToolResult {
-      success: true,
-      data: Some(json!({
-        "status": "not_implemented",
-        "message": "apply_color_grading will be implemented"
-      })),
-      error: None,
+      success: false,
+      data: None,
+      error: Some("MCP tool apply_color_grading is not implemented".to_string()),
     }
   }
 
   async fn execute_add_text_overlay(&self, _arguments: Value) -> MCPToolResult {
     MCPToolResult {
-      success: true,
-      data: Some(json!({
-        "status": "not_implemented",
-        "message": "add_text_overlay will be implemented"
-      })),
-      error: None,
+      success: false,
+      data: None,
+      error: Some("MCP tool add_text_overlay is not implemented".to_string()),
     }
   }
 
   async fn execute_export_video(&self, _arguments: Value) -> MCPToolResult {
     MCPToolResult {
-      success: true,
-      data: Some(json!({
-        "status": "not_implemented",
-        "message": "export_video will be implemented"
-      })),
-      error: None,
+      success: false,
+      data: None,
+      error: Some("MCP tool export_video is not implemented".to_string()),
     }
   }
 
   async fn execute_create_preview(&self, _arguments: Value) -> MCPToolResult {
     MCPToolResult {
-      success: true,
-      data: Some(json!({
-        "status": "not_implemented",
-        "message": "create_preview will be implemented"
-      })),
-      error: None,
+      success: false,
+      data: None,
+      error: Some("MCP tool create_preview is not implemented".to_string()),
     }
   }
 
@@ -1252,5 +1235,112 @@ impl VideoTools {
 impl Default for VideoTools {
   fn default() -> Self {
     Self::new()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn tool_schema(tools: &VideoTools, name: &str) -> Value {
+    tools
+      .get_available_tools()
+      .into_iter()
+      .find(|tool| tool.name == name)
+      .unwrap_or_else(|| panic!("missing MCP tool schema for {name}"))
+      .input_schema
+  }
+
+  fn required_fields(schema: &Value) -> Vec<&str> {
+    schema["required"]
+      .as_array()
+      .expect("schema required must be an array")
+      .iter()
+      .map(|field| field.as_str().expect("required field must be a string"))
+      .collect()
+  }
+
+  #[test]
+  fn add_clip_schema_uses_canonical_timeline_contract() {
+    let schema = tool_schema(&VideoTools::new(), "add_clip");
+
+    assert_eq!(
+      required_fields(&schema),
+      vec!["track_id", "media_id", "time"]
+    );
+    assert!(schema["properties"]["track_id"].is_object());
+    assert!(schema["properties"]["media_id"].is_object());
+    assert!(schema["properties"]["time"].is_object());
+    assert!(schema["properties"]["video_path"].is_null());
+    assert!(schema["properties"]["start_time"].is_null());
+    assert!(schema["properties"]["track_index"].is_null());
+  }
+
+  #[test]
+  fn timeline_mcp_schemas_cover_key_edit_tools() {
+    let tools = VideoTools::new();
+
+    assert_eq!(
+      required_fields(&tool_schema(&tools, "move_clip")),
+      vec!["clip_id", "new_track_id", "new_time"]
+    );
+    assert_eq!(
+      required_fields(&tool_schema(&tools, "split_clip")),
+      vec!["clip_id", "time"]
+    );
+
+    let list_media_schema = tool_schema(&tools, "list_media_files");
+    let filter_enum = list_media_schema["properties"]["filter_type"]["enum"]
+      .as_array()
+      .expect("list_media_files filter_type enum must be present");
+    assert_eq!(
+      filter_enum
+        .iter()
+        .map(|value| value.as_str().expect("enum value must be a string"))
+        .collect::<Vec<_>>(),
+      vec!["all", "video", "audio", "image"]
+    );
+  }
+
+  #[tokio::test]
+  async fn add_clip_rejects_missing_time_before_timeline_execution() {
+    let result = VideoTools::new()
+      .execute_tool(
+        "add_clip",
+        json!({ "track_id": "track-1", "media_id": "media-1" }),
+      )
+      .await;
+
+    assert!(!result.success);
+    assert_eq!(
+      result.error.as_deref(),
+      Some("Missing required parameter: time")
+    );
+  }
+
+  #[tokio::test]
+  async fn planned_mcp_tools_return_failures_until_implemented() {
+    let tools = VideoTools::new();
+
+    for tool_name in [
+      "apply_filter",
+      "add_transition",
+      "apply_color_grading",
+      "add_text_overlay",
+      "export_video",
+      "create_preview",
+    ] {
+      let result = tools.execute_tool(tool_name, json!({})).await;
+      assert!(!result.success, "{tool_name} must not report success");
+      assert!(
+        result
+          .error
+          .as_deref()
+          .unwrap_or("")
+          .contains("not implemented"),
+        "{tool_name} should report not implemented, got {:?}",
+        result.error
+      );
+    }
   }
 }


### PR DESCRIPTION
## Summary
- align Rust MCP add/move/split clip schemas with the canonical timeline command inputs used by the implementations
- make planned MCP filter/transition/text/export/preview tools return failure instead of success/not_implemented payloads
- add TypeScript MCP adapter contract tests and Rust MCP schema/execution contract tests
- document production-ready vs planned MCP tool status in TS and Rust MCP docs

## Validation
- bunx vitest run packages/domains/src/ai-tools/tools/mcp/__tests__/mcp-contract.test.ts
- bun run --cwd packages/domains check:type
- bun run lint:ci
- rustfmt --check --edition 2021 src-tauri/src/mcp/tools.rs
- git diff --check
- cd src-tauri && cargo test mcp::tools --lib

Note: full Diff in /Users/aleksandrkireev/Apps/timeline-studio/src-tauri/src/analysis/engines/mod.rs:1:
 //! ДЕДУП (#97/#98): content/moment-движки — из крейта ts-analysis; scene_engine — в монолите.
-pub use ts_analysis::analysis::engines::{content_engine, moment_engine, ContentEngine, MomentEngine};
+pub use ts_analysis::analysis::engines::{
+  content_engine, moment_engine, ContentEngine, MomentEngine,
+};
 
 pub mod scene_engine;
 pub use scene_engine::SceneEngine;
Diff in /Users/aleksandrkireev/Apps/timeline-studio/src-tauri/src/analysis/mod.rs:8:
 
 pub use ts_analysis::analysis::{models, types};
 
+pub use adapters::{FFmpegAudioAdapter, MontageAudioAdapter, WhisperAudioAdapter};
 pub use engines::{ContentEngine, MomentEngine, SceneEngine};
 pub use services::{AnalysisEngineConfig, RealAnalysisEngine, UnifiedAudioAnalyzer};
-pub use adapters::{FFmpegAudioAdapter, MontageAudioAdapter, WhisperAudioAdapter};
 pub use types::{
   AudioAnalysisError, AudioAnalysisMetadata, AudioBasicMetrics, AudioDuration, AudioFFmpegAnalysis,
   AudioFloat, AudioFrequency, AudioMontageAnalysis, AudioQualityLevel, AudioSampleRate,
Diff in /Users/aleksandrkireev/Apps/timeline-studio/src-tauri/src/analysis/services/analysis_engine.rs:866:
   }
 }
 
-
 /// Результаты анализа проекта
 #[derive(Debug)]
 pub struct AnalysisProjectResults {
Diff in /Users/aleksandrkireev/Apps/timeline-studio/src-tauri/src/analysis/services/content_classification_engine.rs:405:
     }
   }
 }
-
 
Diff in /Users/aleksandrkireev/Apps/timeline-studio/src-tauri/src/headless_bridge.rs:18:
 /// Serialises the event to JSON and emits it on the `"ts://project-event"`
 /// channel so the front-end can subscribe with `listen("ts://project-event", ...)`.
 pub struct TauriEventSink {
-    app: AppHandle,
+  app: AppHandle,
 }
 
 impl TauriEventSink {
Diff in /Users/aleksandrkireev/Apps/timeline-studio/src-tauri/src/headless_bridge.rs:25:
-    pub fn new(app: AppHandle) -> Self {
-        Self { app }
-    }
+  pub fn new(app: AppHandle) -> Self {
+    Self { app }
+  }
 }
 
 impl EventSink for TauriEventSink {
Diff in /Users/aleksandrkireev/Apps/timeline-studio/src-tauri/src/headless_bridge.rs:31:
-    fn send(
-        &self,
-        event: ProjectEvent,
-        source: String,
-        version: u32,
-    ) -> SinkFuture {
-        let app = self.app.clone();
-        Box::pin(async move {
-            let payload = serde_json::json!({
-                "event": event,
-                "source": source,
-                "version": version,
-            });
-            // Best-effort: ignore errors (e.g. window closed during shutdown)
-            let _ = app.emit("ts://project-event", payload);
-        })
-    }
+  fn send(&self, event: ProjectEvent, source: String, version: u32) -> SinkFuture {
+    let app = self.app.clone();
+    Box::pin(async move {
+      let payload = serde_json::json!({
+          "event": event,
+          "source": source,
+          "version": version,
+      });
+      // Best-effort: ignore errors (e.g. window closed during shutdown)
+      let _ = app.emit("ts://project-event", payload);
+    })
+  }
 }
 
 /// Build a `ts_state::StateManager` wired to the Tauri window.
Diff in /Users/aleksandrkireev/Apps/timeline-studio/src-tauri/src/headless_bridge.rs:53:
 /// The returned manager is registered as managed state so every Tauri
 /// command can access it via `State<'_, HeadlessState>`.
 pub fn build_headless_state(app: AppHandle) -> HeadlessState {
-    let sink = Arc::new(TauriEventSink::new(app));
-    let manager = ts_state::StateManager::new(sink);
-    HeadlessState { manager }
+  let sink = Arc::new(TauriEventSink::new(app));
+  let manager = ts_state::StateManager::new(sink);
+  HeadlessState { manager }
 }
 
 /// Tauri managed state wrapper for the headless state manager.
Diff in /Users/aleksandrkireev/Apps/timeline-studio/src-tauri/src/headless_bridge.rs:62:
 #[derive(Clone)]
 pub struct HeadlessState {
-    pub manager: ts_state::StateManager,
+  pub manager: ts_state::StateManager,
 }
 
Diff in /Users/aleksandrkireev/Apps/timeline-studio/src-tauri/src/media/mod.rs:3:
 //! Tauri-команды, registry, processor и файлы с AppHandle (video_compiler/registry).
 pub use ts_media::media::*;
 
-pub mod commands;
 pub mod additional_commands;
-pub mod phase5_commands;
-pub mod registry;
-pub mod processor;
+pub mod commands;
 pub mod file_scanner;
 pub mod metadata_extractor;
-pub mod thumbnail_generator;
+pub mod phase5_commands;
 pub mod preview_manager;
+pub mod processor;
+pub mod registry;
+pub mod thumbnail_generator;
 
 pub use processor::{MediaProcessor, ThumbnailOptions};
 
Diff in /Users/aleksandrkireev/Apps/timeline-studio/src-tauri/src/montage_planner/types.rs:1:
 //! ДЕДУП (#98): типы монтажа — из крейта `ts-montage`. Плюс composition-типы из
 //! оставшегося в монолите `composition_analyzer` (их использует analysis-модуль).
-pub use ts_montage::montage_planner::types::*;
 pub use super::services::composition_analyzer::{CompositionEnhancedDetection, CompositionWeights};
+pub use ts_montage::montage_planner::types::*;
  still reports pre-existing formatting drift outside this PR; this PR checked the modified Rust file directly.

Closes #309