### PR TITLE
Apply Montage Planner plans with backend timeline IDs

### DIFF
--- a/packages/domains/src/ai-tools/tools/automation/montage-planning/__tests__/apply-plan-to-timeline.test.ts
+++ b/packages/domains/src/ai-tools/tools/automation/montage-planning/__tests__/apply-plan-to-timeline.test.ts
@@ -10,8 +10,8 @@ import { MomentCategory, SequencePurpose, SequenceType } from "@timeline-studio/
 import { applyPlanToTimeline } from "../index"
 
 // Create persistent mocks
-const mockAddTrack = vi.fn().mockResolvedValue(undefined)
-const mockAddClip = vi.fn().mockResolvedValue(undefined)
+const mockAddTrack = vi.fn()
+const mockAddClip = vi.fn()
 const mockUpdateClip = vi.fn().mockResolvedValue(undefined)
 
 // Mock VideoEditingOrchestrator
@@ -35,9 +35,13 @@ vi.mock("@/lib/tauri-logger", () => ({
 
 describe("applyPlanToTimeline", () => {
   beforeEach(() => {
-    mockAddTrack.mockClear()
-    mockAddClip.mockClear()
-    mockUpdateClip.mockClear()
+    mockAddTrack.mockReset()
+    mockAddClip.mockReset()
+    mockUpdateClip.mockReset()
+
+    mockAddTrack.mockImplementation(async () => `backend-track-${mockAddTrack.mock.calls.length}`)
+    mockAddClip.mockImplementation(async () => `backend-clip-${mockAddClip.mock.calls.length}`)
+    mockUpdateClip.mockResolvedValue(undefined)
   })
 
   const createMockPlan = (overrides?: Partial<MontagePlan>): MontagePlan => ({
@@ -176,7 +180,7 @@ describe("applyPlanToTimeline", () => {
 
     const result = await applyPlanToTimeline(plan)
 
-    expect(mockAddClip).toHaveBeenCalled()
+    expect(mockAddClip).toHaveBeenCalledWith("backend-track-1", clip.fragment?.sourceFile, 0)
     expect(result.appliedClips).toBe(1)
   })
 
@@ -193,7 +197,7 @@ describe("applyPlanToTimeline", () => {
 
     // Should call updateClip with speed adjustments
     expect(mockUpdateClip).toHaveBeenCalledWith(
-      expect.any(String),
+      "backend-clip-1",
       expect.objectContaining({
         speed: 2.0,
         playbackRate: 2.0,
@@ -219,7 +223,7 @@ describe("applyPlanToTimeline", () => {
 
     // Should call updateClip with position (crop) adjustments
     expect(mockUpdateClip).toHaveBeenCalledWith(
-      expect.any(String),
+      "backend-clip-1",
       expect.objectContaining({
         position: expect.objectContaining({
           x: 0.1,
@@ -294,9 +298,80 @@ describe("applyPlanToTimeline", () => {
     expect(result.appliedClips).toBe(2)
   })
 
+  it("should apply a multi-clip plan with backend track and clip ids", async () => {
+    const clip1 = createMockClip({
+      sequenceOrder: 0,
+      adjustments: {
+        speedMultiplier: 2,
+      },
+    })
+    const clip2 = createMockClip({
+      fragmentId: "frag-2",
+      sequenceOrder: 1,
+    })
+    const sequence = createMockSequence({ clips: [clip1, clip2] })
+    const plan = createMockPlan({ sequences: [sequence] })
+
+    const result = await applyPlanToTimeline(plan)
+
+    expect(result.success).toBe(true)
+    expect(result.appliedClips).toBe(2)
+    expect(mockAddClip).toHaveBeenNthCalledWith(1, "backend-track-1", clip1.fragment?.sourceFile, 0)
+    expect(mockAddClip).toHaveBeenNthCalledWith(2, "backend-track-1", clip2.fragment?.sourceFile, 2.5)
+    expect(mockUpdateClip).toHaveBeenCalledWith(
+      "backend-clip-1",
+      expect.objectContaining({
+        speed: 2,
+        playbackRate: 2,
+      }),
+    )
+
+    const backendMutationIds = [
+      ...mockAddClip.mock.calls.map(([trackId]) => trackId),
+      ...mockUpdateClip.mock.calls.map(([clipId]) => clipId),
+    ]
+    expect(backendMutationIds.every((id) => !String(id).startsWith("track-") && !String(id).startsWith("clip-"))).toBe(
+      true,
+    )
+  })
+
+  it("should fail without falling back to fake track ids when backend returns no track id", async () => {
+    mockAddTrack.mockResolvedValueOnce(null)
+
+    const clip = createMockClip()
+    const sequence = createMockSequence({ clips: [clip] })
+    const plan = createMockPlan({ sequences: [sequence] })
+
+    const result = await applyPlanToTimeline(plan)
+
+    expect(result.success).toBe(false)
+    expect(result.appliedClips).toBe(0)
+    expect(mockAddClip).not.toHaveBeenCalled()
+    expect(result.errors[0]).toContain("track_id")
+  })
+
+  it("should fail without applying adjustments when backend returns no clip id", async () => {
+    mockAddClip.mockResolvedValueOnce(null)
+
+    const clip = createMockClip({
+      adjustments: {
+        speedMultiplier: 2,
+      },
+    })
+    const sequence = createMockSequence({ clips: [clip] })
+    const plan = createMockPlan({ sequences: [sequence] })
+
+    const result = await applyPlanToTimeline(plan)
+
+    expect(result.success).toBe(false)
+    expect(result.appliedClips).toBe(0)
+    expect(mockUpdateClip).not.toHaveBeenCalled()
+    expect(result.errors[0]).toContain("clip_id")
+  })
+
   it("should continue processing after error in one clip", async () => {
     // First clip fails, second succeeds
-    mockAddClip.mockRejectedValueOnce(new Error("First clip error")).mockResolvedValueOnce(undefined)
+    mockAddClip.mockRejectedValueOnce(new Error("First clip error")).mockResolvedValueOnce("backend-clip-2")
 
     const clip1 = createMockClip({ fragmentId: "frag-1" })
     const clip2 = createMockClip({ fragmentId: "frag-2" })

--- a/packages/domains/src/ai-tools/tools/automation/montage-planning/index.ts
+++ b/packages/domains/src/ai-tools/tools/automation/montage-planning/index.ts
@@ -274,11 +274,13 @@ async function applyPlanToTimeline(plan: MontagePlan): Promise<{
       const trackName = `${sequence.type} - ${sequence.purpose}`
 
       try {
-        await orchestrator.addTrack("video", trackName)
+        const trackId = await orchestrator.addTrack("video", trackName)
+        if (!trackId) {
+          errors.push(`Backend не вернул track_id для sequence ${sequence.id}`)
+          logger.error("Backend did not return track_id", { sequenceId: sequence.id, trackName })
+          continue
+        }
 
-        // После создания трека нужно получить его ID из backend
-        // Используем временное решение - генерируем ID локально
-        const trackId = `track-${sequence.id}-${Date.now()}`
         sequenceTracks.set(sequence.id, trackId)
 
         logger.debug("Created track for sequence", { trackId, trackName })
@@ -313,12 +315,17 @@ async function applyPlanToTimeline(plan: MontagePlan): Promise<{
           }
 
           // Добавляем клип на timeline
-          await orchestrator.addClip(trackId, mediaFile, currentTime)
+          const clipStartTime = currentTime
+          const clipId = await orchestrator.addClip(trackId, mediaFile, clipStartTime)
+          if (!clipId) {
+            errors.push(`Backend не вернул clip_id для фрагмента ${fragment.id}`)
+            logger.error("Backend did not return clip_id", { fragmentId: fragment.id, trackId })
+            continue
+          }
 
           // Применяем adjustments если есть
           if (plannedClip.adjustments) {
             const adjustments = plannedClip.adjustments
-            const clipId = `clip-${fragment.id}` // Временный ID, должен прийти от backend
 
             const updates: Partial<TimelineClip> = {}
 
@@ -354,14 +361,18 @@ async function applyPlanToTimeline(plan: MontagePlan): Promise<{
 
           // Обновляем позицию для следующего клипа
           const clipDuration = fragment.duration
-          currentTime += plannedClip.adjustments?.speedMultiplier
+          const effectiveDuration = plannedClip.adjustments?.speedMultiplier
             ? clipDuration / plannedClip.adjustments.speedMultiplier
             : clipDuration
+          currentTime += effectiveDuration
 
           logger.debug("Added clip to timeline", {
             fragmentId: fragment.id,
-            startTime: currentTime - clipDuration,
+            clipId,
+            trackId,
+            startTime: clipStartTime,
             duration: clipDuration,
+            effectiveDuration,
           })
         } catch (error) {
           errors.push(

--- a/packages/domains/src/video-editing/__tests__/services/video-editing-orchestrator.test.ts
+++ b/packages/domains/src/video-editing/__tests__/services/video-editing-orchestrator.test.ts
@@ -165,6 +165,26 @@ describe("VideoEditingOrchestrator", () => {
       expect(timelineState).toBeDefined()
     })
 
+    it("should return backend clip id when adding clip", async () => {
+      const executeCommandSpy = vi.spyOn(orchestrator, "executeCommand").mockResolvedValueOnce({
+        clip_id: "backend-clip-1",
+      })
+
+      const clipId = await orchestrator.addClip("track-1", mockMediaFile, 0)
+
+      expect(clipId).toBe("backend-clip-1")
+      expect(executeCommandSpy).toHaveBeenCalledWith({
+        type: "AddClip",
+        params: {
+          track_id: "track-1",
+          media_id: "media-1",
+          time: 0,
+        },
+      })
+
+      executeCommandSpy.mockRestore()
+    })
+
     it("should move clip", async () => {
       await orchestrator.moveClip("clip-1", "track-2", 5)
 

--- a/packages/domains/src/video-editing/services/video-editing-orchestrator.ts
+++ b/packages/domains/src/video-editing/services/video-editing-orchestrator.ts
@@ -441,7 +441,7 @@ export class VideoEditingOrchestrator {
   /**
    * API для управления клипами
    */
-  async addClip(trackId: string, mediaFile: any, time: number) {
+  async addClip(trackId: string, mediaFile: any, time: number): Promise<string | null> {
     const command: ProjectCommand = {
       type: "AddClip",
       params: {
@@ -451,7 +451,8 @@ export class VideoEditingOrchestrator {
       },
     }
 
-    await this.executeCommand(command)
+    const data = await this.executeCommand(command)
+    const clipId = typeof data?.clip_id === "string" ? data.clip_id : null
 
     this.timelineActor.send({
       type: "ADD_CLIP",
@@ -460,8 +461,17 @@ export class VideoEditingOrchestrator {
       time,
     })
 
-    // Публикуем событие
-    const clipId = `clip-${Date.now()}` // Временный ID
+    if (!clipId) {
+      logger.warn("[Video Editing Orchestrator] Clip created without backend clip_id; skipping CLIP_ADDED event")
+      return null
+    }
+
+    logger.info("[Video Editing Orchestrator] Clip created:", {
+      trackId,
+      clipId,
+    })
+
+    // Публикуем событие только с ID, полученным от backend.
     eventBus.publish(DOMAIN_EVENTS.VIDEO.CLIP_ADDED, "video-editing", {
       trackId,
       clip: {
@@ -473,6 +483,8 @@ export class VideoEditingOrchestrator {
         mediaId: typeof mediaFile === "string" ? mediaFile : mediaFile.id,
       },
     })
+
+    return clipId
   }
 
   async moveClip(clipId: string, newTrackId: string, newTime: number) {

--- a/src/features/montage-planner/hooks/use-timeline-integration.ts
+++ b/src/features/montage-planner/hooks/use-timeline-integration.ts
@@ -6,10 +6,8 @@ import type { MediaFile } from "@timeline-studio/core/types"
 import { useCallback, useState } from "react"
 import { useTimelineMarkers } from "@/features/timeline/hooks/markers/use-timeline-markers"
 import { useTimeline } from "@/features/timeline/hooks/state/use-timeline"
-import { useTimelineActions } from "@/features/timeline/hooks/state/use-timeline-actions"
 import { createLogger } from "@/lib/tauri-logger"
 import {
-  applyPlanToTimeline as applyPlanToTimelineService,
   createMarkersFromPlan as createMarkersFromPlanService,
   type TimelineIntegrationOptions,
 } from "../services/domain-adapters"
@@ -37,18 +35,8 @@ export interface UseTimelineIntegrationReturn {
 }
 
 export function useTimelineIntegration(): UseTimelineIntegrationReturn {
-  const { project, saveProject } = useTimeline()
-  const { addMediaToTimeline } = useTimelineActions()
+  const { project, saveProject, addTrack, addClip, updateClip } = useTimeline()
   const { addMarker } = useTimelineMarkers()
-
-  // Функция для обновления проекта
-  const updateProject = useCallback(
-    async (_updatedProject: any) => {
-      // Сохраняем проект в timeline
-      await saveProject()
-    },
-    [saveProject],
-  )
 
   // Функция для добавления маркеров
   const addMarkers = useCallback(
@@ -92,11 +80,96 @@ export function useTimelineIntegration(): UseTimelineIntegrationReturn {
           throw new Error(`Missing media files: ${missingFiles.join(", ")}`)
         }
 
-        // Применяем план к Timeline
-        const updatedProject = applyPlanToTimelineService(plan, project as any, mediaFiles, options)
+        const mediaById = new Map(mediaFiles.map((file) => [file.id, file]))
+        const sequenceTrackIds = new Map<string, string>()
+        let currentTime = options.timeOffset ?? 0
 
-        // Обновляем проект
-        await updateProject(updatedProject)
+        const getTrackTypeForClip = (clip: PlannedClip): "audio" | "image" | "video" => {
+          const mediaType = String(clip.fragment?.sourceFile?.type ?? "").toLowerCase()
+          if (["audio", "music", "voiceover", "sfx", "ambient"].some((type) => mediaType.includes(type))) {
+            return "audio"
+          }
+          if (["image", "stillimage", "imagesequence"].some((type) => mediaType.includes(type))) {
+            return "image"
+          }
+          return "video"
+        }
+
+        const getTrackForClip = async (sequence: Sequence, clip: PlannedClip) => {
+          const trackType = getTrackTypeForClip(clip)
+          const targetTrack =
+            options.useExistingTracks && trackType === "audio" ? options.targetAudioTrack : options.targetVideoTrack
+
+          if (options.useExistingTracks && targetTrack) {
+            return targetTrack
+          }
+
+          const trackKey = `${sequence.id}:${trackType}`
+          const existingTrackId = sequenceTrackIds.get(trackKey)
+          if (existingTrackId) {
+            return existingTrackId
+          }
+
+          const trackName = `${sequence.type} ${trackType} - ${sequence.purpose}`
+          const createdTrackId = await addTrack(trackType, trackName)
+          if (!createdTrackId) {
+            throw new Error(`Backend did not return track_id for sequence ${sequence.id}`)
+          }
+
+          sequenceTrackIds.set(trackKey, createdTrackId)
+          return createdTrackId
+        }
+
+        for (const sequence of plan.sequences) {
+          const sortedClips = [...sequence.clips].sort((a, b) => a.sequenceOrder - b.sequenceOrder)
+
+          for (const plannedClip of sortedClips) {
+            const fragment = plannedClip.fragment
+            const sourceFile = fragment?.sourceFile
+            if (!fragment || !sourceFile) {
+              throw new Error(`Fragment or source file not found for clip ${plannedClip.fragmentId}`)
+            }
+
+            const mediaFile = mediaById.get(sourceFile.id) ?? (sourceFile as any)
+            const trackId = await getTrackForClip(sequence, plannedClip)
+            const clipId = await addClip(trackId, mediaFile as any, currentTime)
+
+            if (!clipId) {
+              throw new Error(`Backend did not return clip_id for fragment ${fragment.id}`)
+            }
+
+            const updates: Record<string, unknown> = {}
+            if (plannedClip.adjustments?.speedMultiplier && plannedClip.adjustments.speedMultiplier !== 1) {
+              updates.speed = plannedClip.adjustments.speedMultiplier
+              updates.playbackRate = plannedClip.adjustments.speedMultiplier
+            }
+
+            if (plannedClip.adjustments?.crop) {
+              updates.position = {
+                x: plannedClip.adjustments.crop.x,
+                y: plannedClip.adjustments.crop.y,
+                width: plannedClip.adjustments.crop.width,
+                height: plannedClip.adjustments.crop.height,
+                rotation: 0,
+                scaleX: 1,
+                scaleY: 1,
+              }
+            }
+
+            if (Object.keys(updates).length > 0) {
+              await updateClip(clipId, updates as any)
+            }
+
+            const duration = fragment.duration || mediaFile.duration || 0
+            currentTime += plannedClip.adjustments?.speedMultiplier
+              ? duration / plannedClip.adjustments.speedMultiplier
+              : duration
+          }
+
+          currentTime += 0.5
+        }
+
+        await saveProject()
 
         // Добавляем маркеры если нужно
         if (options.createNewSection) {
@@ -113,7 +186,7 @@ export function useTimelineIntegration(): UseTimelineIntegrationReturn {
         setIsApplying(false)
       }
     },
-    [project, updateProject, addMarkers],
+    [project, addTrack, addClip, updateClip, saveProject, addMarkers],
   )
 
   /**

--- a/src/features/timeline/providers/timeline-providers.tsx
+++ b/src/features/timeline/providers/timeline-providers.tsx
@@ -434,7 +434,7 @@ export function useTimelineTracks() {
 // ===========================
 interface TimelineClipsContext {
   clips: TimelineClip[]
-  addClip: (trackId: string, mediaFile: MediaFile | string, time: number) => Promise<void>
+  addClip: (trackId: string, mediaFile: MediaFile | string, time: number) => Promise<string | null>
   removeClip: (clipId: string) => Promise<void>
   moveClip: (clipId: string, trackId: string, time: number) => Promise<void>
   trimClip: (clipId: string, startTime: number, endTime: number) => Promise<void>


### PR DESCRIPTION
## Summary

- Make Montage Planner application use backend-returned track IDs instead of local fake IDs.
- Make `VideoEditingOrchestrator.addClip` return backend `clip_id` and publish clip events with that real ID.
- Apply montage clip adjustments using returned backend clip IDs.
- Replace the UI montage timeline integration's legacy object-only apply path with real timeline mutations.

Fixes #310.

## Verification

- `bunx vitest run packages/domains/src/ai-tools/tools/automation/montage-planning/__tests__/apply-plan-to-timeline.test.ts --config vitest.config.ts`
- `bunx vitest run packages/domains/src/video-editing/__tests__/services/video-editing-orchestrator.test.ts --config vitest.config.ts`
- `bun run check:type`
