### PR TITLE
Fix AI timeline state access boundary

### DIFF
--- a/packages/core/src/services/timeline-state-access.ts
+++ b/packages/core/src/services/timeline-state-access.ts
@@ -1,0 +1,36 @@
+export interface TimelineStateAccess {
+  getCurrentProject: () => unknown
+  createProject: (project: any) => Promise<void>
+  updateProject: (updates: any) => Promise<void>
+  createSection: (section: any) => Promise<any>
+  createTrack: (track: any) => Promise<any>
+  addClip: (clip: any) => Promise<any>
+  getProjectStats: () => {
+    totalDuration: number
+    totalClips: number
+    totalTracks: number
+    totalSections: number
+  }
+  sendTimelineCommand: (command: string, params?: any) => Promise<void>
+}
+
+let timelineStateAccess: TimelineStateAccess | null = null
+
+export function setTimelineStateAccess(access: TimelineStateAccess | null): void {
+  timelineStateAccess = access
+}
+
+export function getTimelineStateAccess(): TimelineStateAccess | null {
+  return timelineStateAccess
+}
+
+export function hasTimelineStateAccess(): boolean {
+  return timelineStateAccess !== null
+}
+
+export function requireTimelineStateAccess(): TimelineStateAccess {
+  if (!timelineStateAccess) {
+    throw new Error("Timeline state access не настроен")
+  }
+  return timelineStateAccess
+}

--- a/packages/domains/src/ai-tools/tools/core/timeline/types.ts
+++ b/packages/domains/src/ai-tools/tools/core/timeline/types.ts
@@ -6,6 +6,11 @@
  */
 
 import type { TimelineClip, TimelineSection, TimelineTrack } from "@timeline-studio/domains/video-editing/types"
+export type { TimelineStateAccess } from "@timeline-studio/core/services/timeline-state-access"
+export {
+  getTimelineStateAccess,
+  setTimelineStateAccess,
+} from "@timeline-studio/core/services/timeline-state-access"
 
 /**
  * Типы для функций обратного вызова в reduce операциях
@@ -55,40 +60,4 @@ export interface TimelineToolResult {
   errors?: string[]
   warnings?: string[]
   nextActions?: string[]
-}
-
-/**
- * Интерфейс для доступа к состоянию Timeline
- */
-export interface TimelineStateAccess {
-  getCurrentProject: () => unknown
-  createProject: (project: any) => Promise<void>
-  updateProject: (updates: any) => Promise<void>
-  createSection: (section: any) => Promise<any>
-  createTrack: (track: any) => Promise<any>
-  addClip: (clip: any) => Promise<any>
-  getProjectStats: () => {
-    totalDuration: number
-    totalClips: number
-    totalTracks: number
-    totalSections: number
-  }
-  sendTimelineCommand: (command: string, params?: any) => Promise<void>
-}
-
-// Глобальная переменная для доступа к состоянию timeline
-let timelineStateAccess: TimelineStateAccess | null = null
-
-/**
- * Устанавливает доступ к состоянию timeline
- */
-export function setTimelineStateAccess(access: TimelineStateAccess | null) {
-  timelineStateAccess = access
-}
-
-/**
- * Получает доступ к состоянию timeline
- */
-export function getTimelineStateAccess(): TimelineStateAccess | null {
-  return timelineStateAccess
 }

--- a/src/features/ai-chat/hooks/use-timeline-ai-integration.ts
+++ b/src/features/ai-chat/hooks/use-timeline-ai-integration.ts
@@ -1,7 +1,4 @@
-import {
-  setTimelineStateAccess,
-  type TimelineStateAccess,
-} from "@timeline-studio/domains/ai-tools/tools/core/timeline/types"
+import { setTimelineStateAccess, type TimelineStateAccess } from "@timeline-studio/core/services/timeline-state-access"
 import { useCallback, useEffect, useMemo, useRef } from "react"
 import { createLogger, type LogContext, logError, logInfo } from "@/lib/tauri-logger"
 import { useTimeline } from "../../timeline/hooks"


### PR DESCRIPTION
Follow-up to #314 / #308.

## Summary
- move the shared timeline AI state access singleton into @timeline-studio/core/services
- keep domain timeline tools re-exporting the same API while avoiding UI -> domains imports
- update AI Chat timeline integration to depend on the core service boundary

## Tests
- bun run check:boundaries:strict
- bun run check:type
- bun run lint:ci
- bunx vitest run packages/domains/src/ai-tools/tools/core/timeline/__tests__/execution-path.test.ts src/features/ai-chat/utils/__tests__/convert-tools.test.ts