### PR TITLE
Add bot/headless SDK quickstart

### DIFF
--- a/config/package-boundaries.json
+++ b/config/package-boundaries.json
@@ -63,6 +63,7 @@
     "documents": [
       "docs/engineering/external-headless-contracts.md",
       "docs/engineering/bot-first-production-contract.md",
+      "docs/09_examples/bot-headless-sdk-quickstart.md",
       "docs/engineering/package-boundaries.md",
       "docs/engineering/AGENT_CONTRACT_REFERENCE.md",
       "docs/06_deployment/telegram-bot-worker-production.md",

--- a/docs/09_examples/bot-headless-sdk-quickstart.md
+++ b/docs/09_examples/bot-headless-sdk-quickstart.md
@@ -1,0 +1,137 @@
+# Bot/Headless SDK Quickstart
+
+This quickstart is for external consumers that need to create, render, review, or publish Timeline Studio projects without opening the desktop UI. The supported integration surface is intentionally small: serialized `ProjectSchema` payloads, the Rust `timeline` CLI, and the Node CLI entrypoints in `apps/cli`.
+
+Use the fixture set in [examples/headless-postim](../../examples/headless-postim/README.md) as the runnable sample payloads. The fixture is postim-named because it was the first consumer, but the contract applies to any headless integration.
+
+## Stable Entrypoints
+
+| Entrypoint | Use it for | Contract output | Local validation |
+| --- | --- | --- | --- |
+| `ProjectSchema` | Cross-process project handoff | JSON matching the Rust schema and TypeScript type | `bun run check:examples:headless-sdk` |
+| Rust `timeline` | Schema emission, render, publish validation/upload | JSON for schema/publish operations where `--json` is available | `timeline emit-schema`, `timeline publish ... --validate-only --json` |
+| `render-job` | Direct one-shot render from a render job JSON file | `BotRenderJobResult` | `bun run apps/cli/src/index.ts render-job ... --pretty` |
+| `bot-workflow` | One-shot Telegram-like intake without polling | `BotWorkflowRunResult` | `bun run apps/cli/src/index.ts bot-workflow ... --pretty` |
+| `bot-worker` | Production Telegram polling and AI review loop | Telegram messages plus persisted session/job state | sandbox env + `bot-worker --poll` |
+| `bot-cleanup` | Retention cleanup for runtime state | cleanup summary JSON | dry-run cleanup command |
+
+Do not integrate through desktop React state, root aliases, package-private workspace files, or `src-tauri` internals. Missing capabilities should become a core port, package export, or CLI contract before external use.
+
+## ProjectSchema Handoff
+
+TypeScript consumers should treat `ProjectSchema` as serialized data:
+
+```ts
+import type { ProjectSchema } from "@timeline/shared-types/schema"
+
+export async function loadProjectSchema(): Promise<ProjectSchema> {
+  const response = await fetch("/api/timeline/project-schema")
+  return (await response.json()) as ProjectSchema
+}
+```
+
+For a local fixture:
+
+```bash
+bun run check:examples:headless-sdk
+```
+
+For Rust-generated schema and sample payloads:
+
+```bash
+cargo build --manifest-path crates/Cargo.toml -p ts-cli --bin timeline
+crates/target/debug/timeline emit-schema > project-schema.schema.json
+crates/target/debug/timeline emit-example ./input.mp4 > project.json
+```
+
+## render-job
+
+Use `render-job` when the external service already has a render job JSON payload and wants a machine-readable result:
+
+```bash
+bun run apps/cli/src/index.ts render-job examples/headless-postim/render-job.json \
+  --pretty \
+  --rust-render \
+  --rust-render-command crates/target/debug/timeline
+```
+
+Read these stable result fields first:
+
+- `job.status`
+- `job.progress`
+- `job.artifact`
+- `job.publications`
+- ordered `events`
+
+Use `--status-file <path>` when the caller needs a durable final JSON payload for polling or audit.
+
+## bot-workflow
+
+Use `bot-workflow` for one-shot Telegram-like intake without running the long-lived worker:
+
+```bash
+bun run apps/cli/src/index.ts bot-workflow examples/headless-postim/bot-workflow-payload.json \
+  --default-destination file \
+  --default-output .tmp/headless-sdk/bot-workflow.mp4 \
+  --pretty \
+  --rust-render \
+  --rust-render-command crates/target/debug/timeline
+```
+
+The input payload may carry hints such as:
+
+```json
+{
+  "chat": { "id": "external-demo-chat" },
+  "from": { "id": "external-demo-user" },
+  "text": "project=examples/headless-postim/project-schema.json output=.tmp/headless-sdk/out.mp4 destination=file resolution=1080p"
+}
+```
+
+Keep remote downloads opt-in. Use `--telegram-bot-token`, `--media-dir`, and `--download-remote-media` only when the payload must resolve Telegram file ids or remote URLs.
+
+## bot-worker
+
+Use `bot-worker` for production Telegram review/editing:
+
+```bash
+cp config/bot-worker.sandbox.env.example .env.telegram-ai-review-sandbox
+chmod 0600 .env.telegram-ai-review-sandbox
+
+set -a
+. ./.env.telegram-ai-review-sandbox
+set +a
+
+bun run apps/cli/src/index.ts bot-worker --poll --async-workflows --rust-render --pretty
+```
+
+Start with `TIMELINE_BOT_DEFAULT_DESTINATION=file` and `TIMELINE_BOT_RUST_PUBLISH=false`. After the file-only approval loop is proven, switch to a real destination and enable Rust publish in the env file.
+
+Production configuration starts from [config/bot-worker.production.env.example](../../config/bot-worker.production.env.example). Runtime behavior and recovery rules are documented in [Bot-First Production Contract](../engineering/bot-first-production-contract.md) and [Telegram Bot Worker Production Runbook](../06_deployment/telegram-bot-worker-production.md).
+
+## Publish Validation
+
+Publishing is Rust-first for supported destinations. Use file output for sandbox review, then validate credentials before real uploads:
+
+```bash
+crates/target/debug/timeline publish telegram \
+  -i .tmp/headless-sdk/out.mp4 \
+  --token "$TELEGRAM_BOT_TOKEN" \
+  --chat "$CHAT_ID" \
+  --validate-only \
+  --json
+```
+
+Destination support and user-facing errors are defined in [Publish Destination Support Matrix](../engineering/publish-destination-support-matrix.md). Unsupported destinations must fail before final render/publish starts.
+
+## Guardrails
+
+Before sending changes to an external consumer:
+
+```bash
+bun run check:examples:headless-sdk
+bun run check:examples:postim
+bun run check:boundaries:external
+```
+
+These checks prove the documented examples stay parseable and avoid private import paths. They do not run a real render or Telegram upload; use the sandbox runbook for that operator-owned validation.

--- a/docs/10_project_state/current-status.md
+++ b/docs/10_project_state/current-status.md
@@ -68,7 +68,7 @@ Supported external/headless entrypoints are intentionally narrow:
 - Node CLI `bot-worker`.
 - Node CLI `bot-cleanup`.
 
-The contract is documented in [External And Headless Integration Contracts](../engineering/external-headless-contracts.md). Production Telegram review state/retry/cleanup/publish behavior is documented in [Bot-First Production Contract](../engineering/bot-first-production-contract.md).
+The contract is documented in [External And Headless Integration Contracts](../engineering/external-headless-contracts.md). Production Telegram review state/retry/cleanup/publish behavior is documented in [Bot-First Production Contract](../engineering/bot-first-production-contract.md). External consumer examples and validation commands are documented in [Bot/Headless SDK Quickstart](../09_examples/bot-headless-sdk-quickstart.md).
 
 Important boundary: external consumers such as `postim` should use the bot-first/headless layer and Rust CLI publish/render paths. They should not import root aliases, `src-tauri`, `packages/*/src`, or desktop internals.
 
@@ -106,6 +106,7 @@ No active project blocker is tracked in the GitHub project after Phase G. Remain
 - Root compatibility shims are documented but not yet retired.
 - Rust `llm-plan` is still first-cut oriented; edit-capable Rust `llm-edit` remains a future parity track.
 - External consumer integration, especially `postim`, needs a concrete example contract and migration path.
+- External consumers should start from [Bot/Headless SDK Quickstart](../09_examples/bot-headless-sdk-quickstart.md) and [examples/headless-postim](../../examples/headless-postim/README.md) instead of reading internal source.
 - Streaming should stay separate from Phase G and depend on stable headless boundaries.
 
 ## Recommended Next Roadmap
@@ -128,6 +129,7 @@ Keep streaming as a separate future `ts-stream`/postim track that depends on Pha
 
 - [Roadmap](roadmap.md)
 - [External And Headless Integration Contracts](../engineering/external-headless-contracts.md)
+- [Bot/Headless SDK Quickstart](../09_examples/bot-headless-sdk-quickstart.md)
 - [Bot-First Production Contract](../engineering/bot-first-production-contract.md)
 - [Root Compatibility Shims](../engineering/root-compatibility-shims.md)
 - [Package Boundaries](../engineering/package-boundaries.md)

--- a/docs/10_project_state/roadmap.md
+++ b/docs/10_project_state/roadmap.md
@@ -118,6 +118,7 @@ Current baseline:
 - `main` is green after PR [#290](https://github.com/chatman-media/timeline-studio/pull/290).
 - Issues [#282](https://github.com/chatman-media/timeline-studio/issues/282)-[#289](https://github.com/chatman-media/timeline-studio/issues/289) are closed and `Done`.
 - Supported headless boundaries are now documented and enforced for docs examples.
+- External consumer quickstarts are tracked in [Bot/Headless SDK Quickstart](../09_examples/bot-headless-sdk-quickstart.md) and guarded by `bun run check:examples:headless-sdk`.
 
 ## Далее: Phase H proposal
 
@@ -198,6 +199,8 @@ Acceptance:
 - `bot-worker` production/sandbox config example.
 - Docs examples pass boundary guardrails.
 
+The working quickstart is [Bot/Headless SDK Quickstart](../09_examples/bot-headless-sdk-quickstart.md).
+
 ## Separate Future Track
 
 Streaming should remain separate from Phase H.
@@ -226,6 +229,7 @@ bun run test
 
 - [Current Status](current-status.md)
 - [External And Headless Integration Contracts](../engineering/external-headless-contracts.md)
+- [Bot/Headless SDK Quickstart](../09_examples/bot-headless-sdk-quickstart.md)
 - [Bot-First Production Contract](../engineering/bot-first-production-contract.md)
 - [Telegram AI Review Sandbox Smoke](../06_deployment/telegram-ai-review-sandbox-smoke.md)
 - [Root Compatibility Shims](../engineering/root-compatibility-shims.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -95,6 +95,12 @@
 - **[completed/](08_tasks/completed/)** - Выполненные задачи
 - **[planned/](08_tasks/planned/)** - Будущие задачи
 
+### [09_examples/](09_examples/)
+Проверяемые примеры и quickstarts:
+- **[Bot/Headless SDK Quickstart](09_examples/bot-headless-sdk-quickstart.md)** - Supported `ProjectSchema`, `render-job`, `bot-workflow`, `bot-worker`, and publish validation path for external consumers
+- **[AI Director Usage](09_examples/ai-director-usage.md)** - Пример использования AI Director
+- **[Peaks.js Usage Examples](09_examples/peaks-js-usage-examples.md)** - Примеры waveform-интеграции
+
 ### [09_architectural_decisions/](09_architectural_decisions/)
 Архитектурные решения:
 - **[Исследование DI](09_architectural_decisions/adr_di_research.md)** - Исследование dependency injection

--- a/docs/engineering/bot-first-production-contract.md
+++ b/docs/engineering/bot-first-production-contract.md
@@ -1,7 +1,7 @@
 # Bot-First Production Contract
 
 **Status:** Completed Phase G contract hardening for closed [#288](https://github.com/chatman-media/timeline-studio/issues/288)
-**Related:** [External And Headless Integration Contracts](external-headless-contracts.md), [Rust/Node AI Edit Parity](rust-node-ai-edit-parity.md), [Telegram Bot Worker Production Runbook](../06_deployment/telegram-bot-worker-production.md), [Telegram AI Review Sandbox Smoke](../06_deployment/telegram-ai-review-sandbox-smoke.md), [Timeline Studio CLI](../../apps/cli/COMMANDS.md)
+**Related:** [External And Headless Integration Contracts](external-headless-contracts.md), [Bot/Headless SDK Quickstart](../09_examples/bot-headless-sdk-quickstart.md), [Rust/Node AI Edit Parity](rust-node-ai-edit-parity.md), [Telegram Bot Worker Production Runbook](../06_deployment/telegram-bot-worker-production.md), [Telegram AI Review Sandbox Smoke](../06_deployment/telegram-ai-review-sandbox-smoke.md), [Timeline Studio CLI](../../apps/cli/COMMANDS.md)
 
 This contract defines the supported bot-first/headless production path for Telegram AI review. Operators and external consumers should be able to understand this path without reading package internals.
 
@@ -82,5 +82,7 @@ External consumers such as postim should use this layer through documented entry
 - `bot-workflow` for one-shot Telegram-like intake without polling.
 - `bot-worker` for production Telegram polling and AI review.
 - Rust `timeline publish ... --json` directly only for standalone publish validation/upload.
+
+The copy-pasteable external examples and validation command live in [Bot/Headless SDK Quickstart](../09_examples/bot-headless-sdk-quickstart.md).
 
 Do not import root aliases, desktop providers, `src-tauri` internals or package-private source files. If a capability is missing from the supported surfaces, add a core port, package export or CLI contract before integrating.

--- a/docs/engineering/external-headless-contracts.md
+++ b/docs/engineering/external-headless-contracts.md
@@ -1,7 +1,7 @@
 # External And Headless Integration Contracts
 
 **Status:** Completed Phase G contract hardening for closed [#282](https://github.com/chatman-media/timeline-studio/issues/282)
-**Related:** [G1](https://github.com/chatman-media/timeline-studio/issues/283), [G2](https://github.com/chatman-media/timeline-studio/issues/284), [Bot-First Production Contract](bot-first-production-contract.md), [Rust/Node AI Edit Parity](rust-node-ai-edit-parity.md), [Telegram AI Review Sandbox Smoke](../06_deployment/telegram-ai-review-sandbox-smoke.md), [postim Headless Integration Example](../../examples/headless-postim/README.md), [Package Boundaries](package-boundaries.md), [Root Compatibility Shims](root-compatibility-shims.md), [Agent Contract Reference](AGENT_CONTRACT_REFERENCE.md)
+**Related:** [G1](https://github.com/chatman-media/timeline-studio/issues/283), [G2](https://github.com/chatman-media/timeline-studio/issues/284), [Bot-First Production Contract](bot-first-production-contract.md), [Bot/Headless SDK Quickstart](../09_examples/bot-headless-sdk-quickstart.md), [Rust/Node AI Edit Parity](rust-node-ai-edit-parity.md), [Telegram AI Review Sandbox Smoke](../06_deployment/telegram-ai-review-sandbox-smoke.md), [postim Headless Integration Example](../../examples/headless-postim/README.md), [Package Boundaries](package-boundaries.md), [Root Compatibility Shims](root-compatibility-shims.md), [Agent Contract Reference](AGENT_CONTRACT_REFERENCE.md)
 
 This document defines the supported integration surface for external consumers after the workspace extraction. It is intentionally narrow: consumers should build against `ProjectSchema`, the Rust `timeline` CLI, and the headless Node CLI commands. They should not import private package files, root aliases, or `src-tauri` internals.
 
@@ -128,9 +128,10 @@ bun run apps/cli/src/index.ts bot-workflow ./payload.json \
 
 Use `--telegram-bot-token`, `--media-dir`, and `--download-remote-media` only when the payload needs Telegram file resolution or remote URL downloads. Keep remote URL downloads opt-in.
 
-The postim one-shot headless fixture lives in [examples/headless-postim](../../examples/headless-postim/README.md). Validate it with:
+The general external quickstart is [Bot/Headless SDK Quickstart](../09_examples/bot-headless-sdk-quickstart.md). The postim one-shot headless fixture lives in [examples/headless-postim](../../examples/headless-postim/README.md). Validate both with:
 
 ```bash
+bun run check:examples:headless-sdk
 bun run check:examples:postim
 ```
 
@@ -156,7 +157,7 @@ postim and similar external consumers should integrate through the bot-first/hea
 3. Read machine-readable `BotRenderJobResult`, workflow result, session status, preview artifact, and publish result payloads.
 4. Use Rust `timeline publish ... --json` indirectly through the configured Node adapter or directly when only publish validation/upload is needed.
 
-The supported runnable handoff example is [examples/headless-postim](../../examples/headless-postim/README.md). It includes `ProjectSchema`, `render-job`, and `bot-workflow` payloads plus a validation command that checks the fixture does not depend on private repo internals.
+The supported runnable handoff examples are documented in [Bot/Headless SDK Quickstart](../09_examples/bot-headless-sdk-quickstart.md) and [examples/headless-postim](../../examples/headless-postim/README.md). They include `ProjectSchema`, `render-job`, and `bot-workflow` payloads plus validation commands that check the fixtures do not depend on private repo internals.
 
 postim must not:
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "check:boundaries:baseline": "node scripts/check-package-boundaries.mjs --baseline=config/package-boundaries-baseline.json --max-details=0",
     "check:boundaries:strict": "node scripts/check-package-boundaries.mjs --strict",
     "check:examples:postim": "node scripts/validate-headless-postim-example.mjs",
+    "check:examples:headless-sdk": "node scripts/validate-bot-headless-sdk-docs.mjs",
     "check:shims:retired": "node scripts/validate-root-shim-retirement.mjs",
     "check:all": "npm run lint && npm run lint:css && npm run check:rust && npm run test && npm run test:rust",
     "fix:all": "npm run lint:fix && npm run lint:css:fix && npm run fix:rust",

--- a/packages/core/src/services/timeline-state-access.ts
+++ b/packages/core/src/services/timeline-state-access.ts
@@ -1,0 +1,36 @@
+export interface TimelineStateAccess {
+  getCurrentProject: () => unknown
+  createProject: (project: any) => Promise<void>
+  updateProject: (updates: any) => Promise<void>
+  createSection: (section: any) => Promise<any>
+  createTrack: (track: any) => Promise<any>
+  addClip: (clip: any) => Promise<any>
+  getProjectStats: () => {
+    totalDuration: number
+    totalClips: number
+    totalTracks: number
+    totalSections: number
+  }
+  sendTimelineCommand: (command: string, params?: any) => Promise<void>
+}
+
+let timelineStateAccess: TimelineStateAccess | null = null
+
+export function setTimelineStateAccess(access: TimelineStateAccess | null): void {
+  timelineStateAccess = access
+}
+
+export function getTimelineStateAccess(): TimelineStateAccess | null {
+  return timelineStateAccess
+}
+
+export function hasTimelineStateAccess(): boolean {
+  return timelineStateAccess !== null
+}
+
+export function requireTimelineStateAccess(): TimelineStateAccess {
+  if (!timelineStateAccess) {
+    throw new Error("Timeline state access не настроен")
+  }
+  return timelineStateAccess
+}

--- a/packages/domains/src/ai-tools/tools/core/timeline/types.ts
+++ b/packages/domains/src/ai-tools/tools/core/timeline/types.ts
@@ -6,6 +6,11 @@
  */
 
 import type { TimelineClip, TimelineSection, TimelineTrack } from "@timeline-studio/domains/video-editing/types"
+export type { TimelineStateAccess } from "@timeline-studio/core/services/timeline-state-access"
+export {
+  getTimelineStateAccess,
+  setTimelineStateAccess,
+} from "@timeline-studio/core/services/timeline-state-access"
 
 /**
  * Типы для функций обратного вызова в reduce операциях
@@ -55,40 +60,4 @@ export interface TimelineToolResult {
   errors?: string[]
   warnings?: string[]
   nextActions?: string[]
-}
-
-/**
- * Интерфейс для доступа к состоянию Timeline
- */
-export interface TimelineStateAccess {
-  getCurrentProject: () => unknown
-  createProject: (project: any) => Promise<void>
-  updateProject: (updates: any) => Promise<void>
-  createSection: (section: any) => Promise<any>
-  createTrack: (track: any) => Promise<any>
-  addClip: (clip: any) => Promise<any>
-  getProjectStats: () => {
-    totalDuration: number
-    totalClips: number
-    totalTracks: number
-    totalSections: number
-  }
-  sendTimelineCommand: (command: string, params?: any) => Promise<void>
-}
-
-// Глобальная переменная для доступа к состоянию timeline
-let timelineStateAccess: TimelineStateAccess | null = null
-
-/**
- * Устанавливает доступ к состоянию timeline
- */
-export function setTimelineStateAccess(access: TimelineStateAccess | null) {
-  timelineStateAccess = access
-}
-
-/**
- * Получает доступ к состоянию timeline
- */
-export function getTimelineStateAccess(): TimelineStateAccess | null {
-  return timelineStateAccess
 }

--- a/scripts/validate-bot-headless-sdk-docs.mjs
+++ b/scripts/validate-bot-headless-sdk-docs.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+const toPosix = (value) => value.split(path.sep).join("/")
+
+const files = {
+  quickstart: "docs/09_examples/bot-headless-sdk-quickstart.md",
+  docsIndex: "docs/README.md",
+  currentStatus: "docs/10_project_state/current-status.md",
+  roadmap: "docs/10_project_state/roadmap.md",
+  externalContracts: "docs/engineering/external-headless-contracts.md",
+  botContract: "docs/engineering/bot-first-production-contract.md",
+  packageJson: "package.json",
+  projectFixture: "examples/headless-postim/project-schema.json",
+  renderJobFixture: "examples/headless-postim/render-job.json",
+  botWorkflowFixture: "examples/headless-postim/bot-workflow-payload.json",
+}
+
+const errors = []
+
+function addError(message) {
+  errors.push(message)
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    addError(message)
+  }
+}
+
+async function readText(relativePath) {
+  return fs.readFile(path.join(repoRoot, relativePath), "utf8")
+}
+
+async function readJson(relativePath) {
+  try {
+    return JSON.parse(await readText(relativePath))
+  } catch (error) {
+    addError(`${relativePath} is not valid JSON: ${error.message}`)
+    return null
+  }
+}
+
+function extractCodeBlocks(source) {
+  return [...source.matchAll(/```(?:\w+)?\n([\s\S]*?)```/g)].map((match) => match[1])
+}
+
+function scanCodeBlocks(relativePath, source) {
+  const forbiddenPatterns = [
+    {
+      pattern: /from\s+["']@\//,
+      message: "must not import root aliases",
+    },
+    {
+      pattern: /import\(["']@\//,
+      message: "must not dynamically import root aliases",
+    },
+    {
+      pattern: /from\s+["']packages\/[^"']+\/src\//,
+      message: "must not import package-private package source",
+    },
+    {
+      pattern: /import\(["']packages\/[^"']+\/src\//,
+      message: "must not dynamically import package-private package source",
+    },
+    {
+      pattern: /src-tauri\//,
+      message: "must not reference src-tauri internals in runnable snippets",
+    },
+  ]
+
+  for (const [index, block] of extractCodeBlocks(source).entries()) {
+    for (const { pattern, message } of forbiddenPatterns) {
+      if (pattern.test(block)) {
+        addError(`${relativePath} code block ${index + 1} ${message}`)
+      }
+    }
+  }
+}
+
+const quickstart = await readText(files.quickstart)
+const docsIndex = await readText(files.docsIndex)
+const currentStatus = await readText(files.currentStatus)
+const roadmap = await readText(files.roadmap)
+const externalContracts = await readText(files.externalContracts)
+const botContract = await readText(files.botContract)
+const packageJson = await readJson(files.packageJson)
+const projectFixture = await readJson(files.projectFixture)
+const renderJobFixture = await readJson(files.renderJobFixture)
+const botWorkflowFixture = await readJson(files.botWorkflowFixture)
+
+for (const required of [
+  "ProjectSchema",
+  "render-job",
+  "bot-workflow",
+  "bot-worker",
+  "bot-cleanup",
+  "@timeline/shared-types/schema",
+  "examples/headless-postim/project-schema.json",
+  "examples/headless-postim/render-job.json",
+  "examples/headless-postim/bot-workflow-payload.json",
+  "config/bot-worker.sandbox.env.example",
+  "config/bot-worker.production.env.example",
+  "timeline publish telegram",
+  "--validate-only",
+  "bun run check:examples:headless-sdk",
+]) {
+  assert(quickstart.includes(required), `${files.quickstart} must mention ${required}`)
+}
+
+scanCodeBlocks(files.quickstart, quickstart)
+
+const quickstartLink = "09_examples/bot-headless-sdk-quickstart.md"
+assert(docsIndex.includes(quickstartLink), `${files.docsIndex} must link the SDK quickstart`)
+assert(currentStatus.includes("../09_examples/bot-headless-sdk-quickstart.md"), `${files.currentStatus} must link the SDK quickstart`)
+assert(roadmap.includes("../09_examples/bot-headless-sdk-quickstart.md"), `${files.roadmap} must link the SDK quickstart`)
+assert(externalContracts.includes("../09_examples/bot-headless-sdk-quickstart.md"), `${files.externalContracts} must link the SDK quickstart`)
+assert(botContract.includes("../09_examples/bot-headless-sdk-quickstart.md"), `${files.botContract} must link the SDK quickstart`)
+
+assert(
+  packageJson?.scripts?.["check:examples:headless-sdk"] === "node scripts/validate-bot-headless-sdk-docs.mjs",
+  "package.json must expose check:examples:headless-sdk",
+)
+
+assert(projectFixture?.version === "1.0.0", `${files.projectFixture} must be a ProjectSchema fixture`)
+assert(renderJobFixture?.project?.path === "examples/headless-postim/project-schema.json", `${files.renderJobFixture} must point at ProjectSchema fixture`)
+assert(
+  (botWorkflowFixture?.text ?? botWorkflowFixture?.caption ?? "").includes("project=examples/headless-postim/project-schema.json"),
+  `${files.botWorkflowFixture} must include a project hint`,
+)
+
+if (errors.length > 0) {
+  console.error("Bot/headless SDK docs validation failed:")
+  for (const error of errors) {
+    console.error(`- ${error}`)
+  }
+  process.exit(1)
+}
+
+console.log(`Bot/headless SDK docs validation passed for ${toPosix(files.quickstart)}.`)

--- a/src/features/ai-chat/hooks/use-timeline-ai-integration.ts
+++ b/src/features/ai-chat/hooks/use-timeline-ai-integration.ts
@@ -1,7 +1,4 @@
-import {
-  setTimelineStateAccess,
-  type TimelineStateAccess,
-} from "@timeline-studio/domains/ai-tools/tools/core/timeline/types"
+import { setTimelineStateAccess, type TimelineStateAccess } from "@timeline-studio/core/services/timeline-state-access"
 import { useCallback, useEffect, useMemo, useRef } from "react"
 import { createLogger, type LogContext, logError, logInfo } from "@/lib/tauri-logger"
 import { useTimeline } from "../../timeline/hooks"


### PR DESCRIPTION
Closes #299

Depends on #318 for the shared main boundary fix. This branch is stacked on that fix so strict boundary checks can run; once #318 is merged, this PR should show the #299 docs/validator changes only.

## Summary
- add a Bot/Headless SDK quickstart for ProjectSchema, render-job, bot-workflow, bot-worker, bot-cleanup, and Rust publish validation
- add a lightweight validation command for the quickstart and fixture links
- link the quickstart from docs index, roadmap/status, and external/bot production contract docs
- include the quickstart in external contract guardrails

## Tests
- bun run check:examples:headless-sdk
- bun run check:examples:postim
- bun run check:boundaries:external
- bun run check:boundaries:strict
- bun run check:type
- bun run lint:ci