### PR TITLE
Fix legacy docs link hygiene

### DIFF
--- a/docs/02_requirements/feature-specification.md
+++ b/docs/02_requirements/feature-specification.md
@@ -121,7 +121,7 @@ Timeline Studio - профессиональный видеоредактор с
 Глобальное управление состоянием через XState машины.
 - 18 компонентов, 14 хуков, 18 сервисов
 - **228 тестов**
-- 📖 [Документация](../../src/features/app-state/README.md)
+- 📖 Документация модуля app-state перенесена в доменный слой project-management.
 
 #### User Settings - 100%
 Пользовательские настройки и персонализация.
@@ -150,13 +150,13 @@ Timeline Studio - профессиональный видеоредактор с
 Система версионирования проектов.
 - 9 компонентов, 4 хука, 3 сервиса
 - Snapshots, branches, auto-save
-- 📖 [Документация](../../src/features/version-control/README.md)
+- 📖 [Документация](../../packages/ui/src/features/version-control/README.md)
 
 #### Workspace - 100%
 Управление рабочими областями.
 - 7 компонентов, 3 хука, 4 сервиса
 - 4 preset лейаута, drag & drop
-- 📖 [Документация](../../src/features/workspace/README.md)
+- 📖 Документация workspace README отсутствует в текущей структуре.
 
 #### Motion Graphics - 100%
 Моушн графика и анимации.
@@ -283,7 +283,7 @@ AI режиссёр для анализа видео.
 ### Analysis Dashboard - 100%
 Аналитическая панель с графиками и метриками.
 - 11 компонентов, 4 хука, 6 сервисов
-- 📖 [Документация](../../src/features/analysis-dashboard/README.md)
+- 📖 Документация analysis-dashboard README отсутствует в текущей структуре.
 
 ### Montage Planner - 100%
 Планировщик автоматического монтажа.
@@ -315,57 +315,57 @@ Timeline Studio использует **Orchestrator Pattern** для всех д
 Single source of truth для состояния проекта.
 - **228 тестов**, 100% готовность
 - BackendSync для синхронизации с Rust backend
-- 📖 [Документация](../../src/domains/project-management/README.md)
+- 📖 [Документация](../../packages/domains/src/project-management/README.md)
 
 #### Media Management
 Orchestrator pattern для управления медиафайлами.
 - **15 сервисов**, 5 state machines
 - MediaManagementOrchestrator (613 строк)
-- 📖 [Документация](../../src/domains/media-management/README.md)
+- 📖 [Документация](../../packages/domains/src/media-management/README.md)
 
 #### Video Editing
 Логика видеоредактирования, компиляции, рендеринга.
 - **22 сервиса**, 5 state machines
 - Интеграция с FFmpeg через Tauri
-- 📖 [Документация](../../src/domains/video-editing/README.md)
+- 📖 [Документация](../../packages/domains/src/video-editing/README.md)
 
 #### AI Services
 Интеграция с AI провайдерами.
 - **55 сервисов**, 6 state machines
 - UnifiedOrchestrator (рейтинг 9/10)
 - Claude, OpenAI, Azure, **Ollama**
-- 📖 [Документация](../../src/domains/ai-services/README.md)
+- 📖 [Документация](../../packages/domains/src/ai-services/README.md)
 
 #### AI Tools
 82 инструмента для AI ассистента.
 - Категории: analysis, automation, content, editing, project, timeline
 - **MCP Integration** (Model Context Protocol)
-- 📖 [Документация](../../src/domains/ai-tools/README.md)
+- 📖 [Документация](../../packages/domains/src/ai-tools/README.md)
 
 #### AI Director
 AI-powered анализ и режиссура видео.
 - **7 сервисов**, анализ контента
-- 📖 [Документация](../../src/domains/ai-director/README.md)
+- 📖 [Документация](../../packages/domains/src/ai-director/README.md)
 
 #### System Integration
 Интеграция с системными API.
 - Нотификации, файлы, clipboard
 - BackendSync для двусторонней синхронизации
-- 📖 [Документация](../../src/domains/system-integration/README.md)
+- 📖 [Документация](../../packages/domains/src/system-integration/README.md)
 
 #### Browser
 Backend логика для медиа браузера.
-- 📖 [Документация](../../src/domains/browser/README.md)
+- 📖 [Документация](../../packages/domains/src/browser/README.md)
 
 #### Subtitles
 Обработка субтитров, генерация, синхронизация.
-- 📖 [Документация](../../src/domains/subtitles/README.md)
+- 📖 [Документация](../../packages/domains/src/subtitles/README.md)
 
 #### Shared
 Общие утилиты и типы для всех доменов.
 - Domain Event Bus
 - Контракты между доменами
-- 📖 [Документация](../../src/domains/shared/README.md)
+- 📖 [Документация](../../packages/domains/src/shared/README.md)
 
 ## Статус разработки
 

--- a/docs/03_architecture/backend/telemetry.md
+++ b/docs/03_architecture/backend/telemetry.md
@@ -21,24 +21,24 @@
 ## 📁 Структура документации
 
 ### Настройка и конфигурация
-- [**Configuration Guide**](configuration.md) - Настройка системы телеметрии
-- [**Installation Guide**](installation.md) - Установка и интеграция
-- [**Environment Setup**](environment.md) - Настройка окружения для dev/prod
+- **Configuration Guide** - Настройка системы телеметрии (планируется)
+- **Installation Guide** - Установка и интеграция (планируется)
+- **Environment Setup** - Настройка окружения для dev/prod (планируется)
 
 ### Мониторинг и наблюдение
-- [**Monitoring Setup**](monitoring.md) - Настройка мониторинга в production
-- [**Dashboards**](dashboards.md) - Готовые dashboard'ы для Grafana
-- [**Alerting Rules**](alerting.md) - Правила алертов и уведомлений
+- [**Monitoring and Metrics**](monitoring-and-metrics.md) - Мониторинг и метрики backend
+- **Dashboards** - Готовые dashboard'ы для Grafana (планируется)
+- **Alerting Rules** - Правила алертов и уведомлений (планируется)
 
 ### Разработка и интеграция
-- [**OpenTelemetry Guide**](opentelemetry.md) - Работа с OpenTelemetry
-- [**Custom Metrics**](custom-metrics.md) - Создание пользовательских метрик
-- [**Distributed Tracing**](tracing.md) - Настройка distributed tracing
+- **OpenTelemetry Guide** - Работа с OpenTelemetry (планируется)
+- **Custom Metrics** - Создание пользовательских метрик (планируется)
+- **Distributed Tracing** - Настройка distributed tracing (планируется)
 
 ### Troubleshooting и оптимизация
-- [**Performance Analysis**](performance-analysis.md) - Анализ производительности
-- [**Troubleshooting Guide**](troubleshooting.md) - Решение проблем
-- [**Best Practices**](best-practices.md) - Лучшие практики
+- **Performance Analysis** - Анализ производительности (планируется)
+- **Troubleshooting Guide** - Решение проблем (планируется)
+- **Best Practices** - Лучшие практики (планируется)
 
 ## 🚀 Быстрый старт
 
@@ -760,10 +760,10 @@ tracer.trace_async("debug_video_processing", |span| async move {
 
 ## 🔗 Связанные разделы
 
-- [**Backend Architecture**](../02-architecture/backend.md) - Архитектура backend
-- [**Performance Optimization**](../08-roadmap/planned/performance-optimization.md) - Оптимизация производительности
-- [**Backend Testing**](../08-roadmap/in-progress/backend-testing-architecture.md) - Тестирование backend
-- [**Development Commands**](../05-development/development-commands.md) - Команды разработки
+- [**Backend Architecture**](README.md) - Архитектура backend
+- [**Performance Optimization**](../../08_tasks/planned/performance-optimization.md) - Оптимизация производительности
+- [**Backend Testing**](../../12_testing/backend-testing.md) - Тестирование backend
+- [**Development Commands**](../../05_development/development-commands.md) - Команды разработки
 
 ---
 

--- a/docs/03_architecture/frontend/state-management.md
+++ b/docs/03_architecture/frontend/state-management.md
@@ -16,57 +16,57 @@ Timeline Studio использует комбинацию XState v5 для уп�
 ## 🤖 XState машины состояний
 
 ### 1. **AI Chat Machine**
-📍 [`src/features/ai-chat/services/chat-machine.ts`](../../src/features/ai-chat/services/chat-machine.ts)
+📍 [`packages/domains/src/ai-services/machines/chat-machine.ts`](../../../packages/domains/src/ai-services/machines/chat-machine.ts)
 
 Управляет состоянием AI чата: сообщения, модели, контекст, загрузка.
 
 ### 2. **App Settings Machine**
-📍 [`src/features/app-state/services/app-settings-machine.ts`](../../src/features/app-state/services/app-settings-machine.ts)
+📍 [`packages/domains/src/project-management/machines/app-machine.ts`](../../../packages/domains/src/project-management/machines/app-machine.ts)
 
 Глобальные настройки приложения: язык, тема, пути, конфигурация.
 
 ### 3. **Browser State Machine**
-📍 [`src/features/browser/services/browser-state-machine.ts`](../../src/features/browser/services/browser-state-machine.ts)
+📍 [`packages/domains/src/browser/machines/browser-machine.ts`](../../../packages/domains/src/browser/machines/browser-machine.ts)
 
 Состояние файлового браузера: вкладки, выбранные файлы, навигация.
 
 ### 4. **Modal Machine**
-📍 [`src/features/modals/services/modal-machine.ts`](../../src/features/modals/services/modal-machine.ts)
+📍 [`packages/domains/src/system-integration/machines/modal-machine.ts`](../../../packages/domains/src/system-integration/machines/modal-machine.ts)
 
 Управление модальными окнами: открытие, закрытие, стек модалок.
 
 ### 5. **Project Settings Machine**
-📍 [`src/features/project-settings/services/project-settings-machine.ts`](../../src/features/project-settings/services/project-settings-machine.ts)
+📍 Project settings currently uses provider/service state instead of a dedicated XState machine.
 
 Настройки текущего проекта: разрешение, FPS, аудио параметры.
 
 ### 6. **Resources Machine**
-📍 [`src/features/resources/services/resources-machine.ts`](../../src/features/resources/services/resources-machine.ts)
+📍 Resources state is exposed through timeline resource providers; a standalone resources machine is not present.
 
 Управление ресурсами: эффекты, фильтры, переходы, шаблоны.
 
 ### 7. **Timeline Machine**
-📍 [`src/features/timeline/services/timeline-machine.ts`](../../src/features/timeline/services/timeline-machine.ts)
+📍 [`packages/domains/src/video-editing/machines/timeline-machine.ts`](../../../packages/domains/src/video-editing/machines/timeline-machine.ts)
 
 Центральная машина для редактирования: треки, клипы, выделение, история.
 
 ### 8. **User Settings Machine**
-📍 [`src/features/user-settings/services/user-settings-machine.ts`](../../src/features/user-settings/services/user-settings-machine.ts)
+📍 [`packages/domains/src/project-management/machines/user-settings-machine.ts`](../../../packages/domains/src/project-management/machines/user-settings-machine.ts)
 
 Пользовательские настройки: персонализация, API ключи, производительность.
 
 ### 9. **Player Machine**
-📍 [`src/features/video-player/services/player-machine.ts`](../../src/features/video-player/services/player-machine.ts)
+📍 [`packages/domains/src/video-editing/machines/player-machine.ts`](../../../packages/domains/src/video-editing/machines/player-machine.ts)
 
 Состояние видео плеера: воспроизведение, позиция, громкость, полноэкранный режим.
 
 ### 10. **Montage Planner Machine**
-📍 [`src/features/montage-planner/services/montage-planner-machine.ts`](../../src/features/montage-planner/services/montage-planner-machine.ts)
+📍 [`packages/domains/src/ai-services/machines/montage-planner-machine.ts`](../../../packages/domains/src/ai-services/machines/montage-planner-machine.ts)
 
 Управление Smart Montage Planner: анализ контента, планирование монтажа, автоматическая обработка.
 
 ### 11. **AI Intelligence Machine**
-📍 [`src/features/ai-content-intelligence/shared/services/ai-intelligence-machine.ts`](../../src/features/ai-content-intelligence/shared/services/ai-intelligence-machine.ts)
+📍 [`packages/domains/src/ai-services/machines/ai-intelligence-machine.ts`](../../../packages/domains/src/ai-services/machines/ai-intelligence-machine.ts)
 
 Состояние AI анализа контента: 4 движка анализа, обработка через 257 AI инструмент, координация workflow.
 
@@ -75,86 +75,86 @@ Timeline Studio использует комбинацию XState v5 для уп�
 ### Основные провайдеры функций
 
 #### 1. **AI Chat Provider**
-📍 [`src/features/ai-chat/services/chat-provider.tsx`](../../src/features/ai-chat/services/chat-provider.tsx)
+📍 [`src/features/ai-chat/services/chat-provider.ts`](../../../src/features/ai-chat/services/chat-provider.ts)
 
 Предоставляет доступ к chat-machine и методам управления чатом.
 
 #### 2. **App Settings Provider**
-📍 [`src/features/app-state/services/app-settings-provider.tsx`](../../src/features/app-state/services/app-settings-provider.tsx)
+📍 [`packages/domains/src/project-management/providers/app-provider.tsx`](../../../packages/domains/src/project-management/providers/app-provider.tsx)
 
 Контекст для глобальных настроек приложения.
 
 #### 3. **Browser State Provider**
-📍 [`src/features/browser/services/browser-state-provider.tsx`](../../src/features/browser/services/browser-state-provider.tsx)
+📍 [`src/features/browser/services/browser-state-provider.tsx`](../../../src/features/browser/services/browser-state-provider.tsx)
 
 Контекст состояния файлового браузера.
 
 #### 4. **Modal Provider**
-📍 [`src/features/modals/services/modal-provider.tsx`](../../src/features/modals/services/modal-provider.tsx)
+📍 [`src/features/modals/services/modal-provider.tsx`](../../../src/features/modals/services/modal-provider.tsx)
 
 Управление модальными окнами через контекст.
 
 #### 5. **Project Settings Provider**
-📍 [`src/features/project-settings/services/project-settings-provider.tsx`](../../src/features/project-settings/services/project-settings-provider.tsx)
+📍 [`packages/domains/src/project-management/providers/project-settings-provider.tsx`](../../../packages/domains/src/project-management/providers/project-settings-provider.tsx)
 
 Контекст настроек текущего проекта.
 
 #### 6. **Resources Provider**
-📍 [`src/features/resources/services/resources-provider.tsx`](../../src/features/resources/services/resources-provider.tsx)
+📍 [`src/features/timeline/providers/resources-provider.tsx`](../../../src/features/timeline/providers/resources-provider.tsx)
 
 Доступ к ресурсам проекта (эффекты, фильтры и т.д.).
 
 #### 7. **Timeline Provider**
-📍 [`src/features/timeline/services/timeline-provider.tsx`](../../src/features/timeline/services/timeline-provider.tsx)
+📍 [`src/features/timeline/providers/timeline-providers.tsx`](../../../src/features/timeline/providers/timeline-providers.tsx)
 
 Центральный провайдер для timeline функциональности.
 
 #### 8. **User Settings Provider**
-📍 [`src/features/user-settings/services/user-settings-provider.tsx`](../../src/features/user-settings/services/user-settings-provider.tsx)
+📍 [`src/features/user-settings/services/user-settings-provider.tsx`](../../../src/features/user-settings/services/user-settings-provider.tsx)
 
 Контекст пользовательских настроек.
 
 #### 9. **Player Provider**
-📍 [`src/features/video-player/services/player-provider.tsx`](../../src/features/video-player/services/player-provider.tsx)
+📍 [`src/features/timeline/providers/player-provider.tsx`](../../../src/features/timeline/providers/player-provider.tsx)
 
 Управление состоянием видео плеера.
 
 #### 10. **Montage Planner Provider**
-📍 [`src/features/montage-planner/services/montage-planner-provider.tsx`](../../src/features/montage-planner/services/montage-planner-provider.tsx)
+📍 [`src/features/montage-planner/services/montage-planner-provider.tsx`](../../../src/features/montage-planner/services/montage-planner-provider.tsx)
 
 Контекст для Smart Montage Planner с интеграцией Tauri событий.
 
 #### 11. **AI Intelligence Provider**
-📍 [`src/features/ai-content-intelligence/services/ai-intelligence-provider.tsx`](../../src/features/ai-content-intelligence/services/ai-intelligence-provider.tsx)
+📍 AI intelligence state is owned by the AI services domain machine.
 
 Управление состоянием AI анализа контента и 4 движков обработки.
 
 ### Дополнительные провайдеры
 
 #### 12. **Keyboard Shortcuts Provider**
-📍 [`src/features/keyboard-shortcuts/services/shortcuts-provider.tsx`](../../src/features/keyboard-shortcuts/services/shortcuts-provider.tsx)
+📍 [`src/features/keyboard-shortcuts/services/shortcuts-provider.tsx`](../../../src/features/keyboard-shortcuts/services/shortcuts-provider.tsx)
 
 Регистрация и управление горячими клавишами (без XState машины).
 
 #### 13. **Drag-Drop Provider**
-📍 [`src/features/timeline/components/drag-drop-provider.tsx`](../../src/features/timeline/components/drag-drop-provider.tsx)
+📍 [`src/features/timeline/components/drag-drop-provider.tsx`](../../../src/features/timeline/components/drag-drop-provider.tsx)
 
 Специализированный провайдер для drag-and-drop в timeline.
 
 #### 14. **I18n Provider**
-📍 [`src/i18n/services/i18n-provider.tsx`](../../src/i18n/services/i18n-provider.tsx)
+📍 [`src/i18n/services/i18n-provider.tsx`](../../../src/i18n/services/i18n-provider.tsx)
 
 Интернационализация и локализация приложения.
 
 ### Агрегаторы провайдеров
 
 #### 15. **Media Studio Providers**
-📍 [`src/features/media-studio/services/providers.tsx`](../../src/features/media-studio/services/providers.tsx)
+📍 [`src/features/media-studio/services/providers.tsx`](../../../src/features/media-studio/services/providers.tsx)
 
 Объединяет все необходимые провайдеры для Media Studio.
 
 #### 16. **Tauri Mock Provider**
-📍 [`src/features/media-studio/services/tauri-mock-provider.tsx`](../../src/features/media-studio/services/tauri-mock-provider.tsx)
+📍 [`src/test/providers/tauri-mock-provider.tsx`](../../../src/test/providers/tauri-mock-provider.tsx)
 
 Mock провайдер для тестирования без Tauri.
 
@@ -243,9 +243,9 @@ export function MyComponent() {
 ## 📚 Дополнительные ресурсы
 
 - [XState v5 документация](https://stately.ai/docs)
-- [Тестирование XState машин](../05-development/testing.md#тестирование-xstate)
-- [Архитектура frontend](frontend.md)
+- [Тестирование XState машин](../../05_development/testing.md#тестирование-xstate)
+- [Архитектура frontend](README.md)
 
 ---
 
-[← Назад к архитектуре](README.md) | [Далее: Взаимодействие компонентов →](communication.md)
+[← Назад к архитектуре](README.md) | [Далее: Взаимодействие компонентов →](../communication.md)

--- a/docs/04_api_reference/README.md
+++ b/docs/04_api_reference/README.md
@@ -18,71 +18,72 @@
 ### 🎯 Timeline и редактирование
 
 - [**Timeline API**](timeline-api.md) - Управление таймлайном и клипами
-- [**Clips API**](clips-api.md) - Операции с клипами
-- [**Tracks API**](tracks-api.md) - Управление треками
-- [**Effects API**](effects-api.md) - Применение и настройка эффектов
-- [**Filters API**](filters-api.md) - Работа с фильтрами
+- **Clips API** - Операции с клипами (планируется)
+- **Tracks API** - Управление треками (планируется)
+- **Effects API** - Применение и настройка эффектов (планируется)
+- **Filters API** - Работа с фильтрами (планируется)
 
 ### 🤖 AI и автоматизация
 
 - [**AI Chat API**](ai-chat-api.md) - Интеграция с AI ассистентами (Claude, GPT)
-- [**AI Tools API**](ai-tools-api.md) - 257 AI инструмент для автоматизации
+- **AI Tools API** - 257 AI инструмент для автоматизации (планируется)
 - [**Recognition API**](recognition-api.md) - Распознавание объектов и лиц
-- [**AI Content Intelligence API**](ai-content-intelligence-api.md) - Интеллектуальный анализ контента
-- [**Montage Planner API**](montage-planner-api.md) - Автоматическое планирование монтажа
+- **AI Content Intelligence API** - Интеллектуальный анализ контента (планируется)
+- **Montage Planner API** - Автоматическое планирование монтажа (планируется)
 
 ### 🎨 Профессиональные инструменты
 
-- [**Color Grading API**](color-grading-api.md) - Цветокоррекция
-- [**Fairlight Audio API**](fairlight-audio-api.md) - Профессиональный аудиомикшер
-- [**Motion Graphics API**](motion-graphics-api.md) - Анимация и графика
-- [**Multicam API**](multicam-api.md) - Многокамерное редактирование
+- **Color Grading API** - Цветокоррекция (планируется)
+- **Fairlight Audio API** - Профессиональный аудиомикшер (планируется)
+- **Motion Graphics API** - Анимация и графика (планируется)
+- **Multicam API** - Многокамерное редактирование (планируется)
 
 ### 📤 Экспорт и публикация
 
 - [**Export API**](export-api.md) - Экспорт видео с GPU ускорением
-- [**Social Media API**](social-media-api.md) - Публикация в социальные сети
+- **Social Media API** - Публикация в социальные сети (планируется)
 - [**Video Compiler API**](video-compiler-api.md) - Низкоуровневый API компиляции
 
 ### 🎥 Захват и запись
 
-- [**Camera Capture API**](camera-capture-api.md) - Захват с камеры
-- [**Voice Recording API**](voice-recording-api.md) - Запись голоса
-- [**Screen Recording API**](screen-recording-api.md) - Запись экрана
+- **Camera Capture API** - Захват с камеры (планируется)
+- **Voice Recording API** - Запись голоса (планируется)
+- **Screen Recording API** - Запись экрана (планируется)
 
 ### 🔧 Утилиты и хелперы
 
-- [**State Management API**](state-management-api.md) - XState машины состояний
-- [**Storage API**](storage-api.md) - Локальное хранилище и кэширование
-- [**Theme API**](theme-api.md) - Управление темами
-- [**Localization API**](localization-api.md) - Интернационализация
+- **State Management API** - XState машины состояний (планируется)
+- **Storage API** - Локальное хранилище и кэширование (планируется)
+- **Theme API** - Управление темами (планируется)
+- **Localization API** - Интернационализация (планируется)
 
 ## Backend API (Tauri Commands)
 
 ### 📁 Файловая система
 
-- [**File System Commands**](backend/filesystem-commands.md) - Работа с файлами
-- [**Project Commands**](backend/project-commands.md) - Управление проектами
-- [**Media Import Commands**](backend/media-import-commands.md) - Импорт медиафайлов
+- [**Backend Commands Overview**](backend/README.md) - Общий справочник backend API
+- **File System Commands** - Работа с файлами (планируется)
+- **Project Commands** - Управление проектами (планируется)
+- **Media Import Commands** - Импорт медиафайлов (планируется)
 
 ### 🎬 Обработка видео
 
-- [**FFmpeg Commands**](backend/ffmpeg-commands.md) - FFmpeg операции
-- [**Frame Extraction Commands**](backend/frame-extraction-commands.md) - Извлечение кадров
-- [**Rendering Commands**](backend/rendering-commands.md) - Рендеринг видео
-- [**GPU Commands**](backend/gpu-commands.md) - GPU ускорение
+- **FFmpeg Commands** - FFmpeg операции (планируется)
+- **Frame Extraction Commands** - Извлечение кадров (планируется)
+- **Rendering Commands** - Рендеринг видео (планируется)
+- **GPU Commands** - GPU ускорение (планируется)
 
 ### 🤖 AI обработка
 
-- [**Recognition Commands**](backend/recognition-commands.md) - YOLO распознавание
-- [**Whisper Commands**](backend/whisper-commands.md) - Транскрипция аудио
-- [**AI Processing Commands**](backend/ai-processing-commands.md) - AI обработка
+- **Recognition Commands** - YOLO распознавание (планируется)
+- **Whisper Commands** - Транскрипция аудио (планируется)
+- **AI Processing Commands** - AI обработка (планируется)
 
 ### 🔧 Системные команды
 
-- [**System Info Commands**](backend/system-info-commands.md) - Информация о системе
-- [**Performance Commands**](backend/performance-commands.md) - Мониторинг производительности
-- [**Plugin Commands**](backend/plugin-commands.md) - Управление плагинами
+- **System Info Commands** - Информация о системе (планируется)
+- **Performance Commands** - Мониторинг производительности (планируется)
+- **Plugin Commands** - Управление плагинами (планируется)
 
 ## 🔌 Интеграции
 
@@ -97,20 +98,20 @@
 
 - [**Claude API Integration**](integrations/claude-api.md)
 - [**OpenAI API Integration**](integrations/openai-api.md)
-- [**Anthropic API Integration**](integrations/anthropic-api.md)
+- **Anthropic API Integration** - объединено с Claude/OpenAI интеграциями
 
 ## 🌐 WebSocket API
 
-- [**Real-time Events**](websocket/events.md) - События в реальном времени
-- [**Progress Tracking**](websocket/progress.md) - Отслеживание прогресса
-- [**Collaboration**](websocket/collaboration.md) - Совместная работа (планируется)
+- **Real-time Events** - События в реальном времени (планируется)
+- **Progress Tracking** - Отслеживание прогресса (планируется)
+- **Collaboration** - Совместная работа (планируется)
 
 ## 📚 Дополнительные ресурсы
 
-- [Примеры использования](examples/README.md)
-- [Миграция с v1 на v2](migration-guide.md)
-- [Troubleshooting](troubleshooting.md)
-- [Performance Best Practices](performance.md)
+- Примеры использования (планируется)
+- Миграция с v1 на v2 (планируется)
+- Troubleshooting (планируется)
+- Performance Best Practices (планируется)
 
 ---
 

--- a/docs/05_development/README.md
+++ b/docs/05_development/README.md
@@ -258,9 +258,9 @@ cargo build
 ## 🔗 Дополнительные ресурсы
 
 ### Внутренние
-- [Создание нового модуля](creating-features.md)
-- [Работа с XState](xstate-patterns.md)
-- [Оптимизация производительности](../07-guides/performance.md)
+- [Чеклист разработки](development-checklist.md)
+- [Работа с XState](../03_architecture/frontend/state-management.md)
+- [Оптимизация производительности](performance.md)
 
 ### Внешние
 - [Tauri Documentation](https://tauri.app/v2/guides/)
@@ -270,4 +270,4 @@ cargo build
 
 ---
 
-[← Функциональность](../03-features/README.md) | [Далее: Настройка окружения →](setup.md)
+[← Функциональность](../02_requirements/feature-specification.md) | [Далее: Настройка окружения →](setup.md)

--- a/docs/14_quality_assurance/README.md
+++ b/docs/14_quality_assurance/README.md
@@ -7,9 +7,9 @@
 ## 📋 Содержание
 
 - [alpha-testing-guide.md](alpha-testing-guide.md) - Руководство по альфа-тестированию ✨ NEW
-- [bug-reporting.md](bug-reporting.md) - Как правильно репортить баги
-- [test-scenarios.md](test-scenarios.md) - Тестовые сценарии для альфа-версии
-- [performance-testing.md](performance-testing.md) - Тестирование производительности
+- bug-reporting.md - Как правильно репортить баги (планируется)
+- test-scenarios.md - Тестовые сценарии для альфа-версии (планируется)
+- performance-testing.md - Тестирование производительности (планируется)
 
 ## 🎯 Процессы QA для альфа-версии
 
@@ -146,4 +146,4 @@
 
 *Спасибо за помощь в тестировании Timeline Studio!*
 
-[← К CI/CD](../13_ci_cd/README.md) | [К проекту →](../10_project_state/README.md)
+[← К CI/CD](../13_ci_cd/README.md) | [К проекту →](../10_project_state/current-status.md)

--- a/docs/14_quality_assurance/module-finalization-checklist.md
+++ b/docs/14_quality_assurance/module-finalization-checklist.md
@@ -167,7 +167,7 @@ module-name/
 
 ### 3.3 Архитектурная документация
 
-- [ ] **Наличие в `/docs/ru/03_architecture/`**
+- [ ] **Наличие в `/docs/03_architecture/`**
   - [ ] Документ с описанием архитектуры модуля
   - [ ] Диаграммы компонентов (если сложный модуль)
   - [ ] Описание state machines (если есть)
@@ -176,7 +176,7 @@ module-name/
 ### 3.4 Migration guide (если нужен)
 
 - [ ] **При breaking changes**
-  - [ ] Документ в `/docs/ru/05_development/`
+  - [ ] Документ в `/docs/05_development/`
   - [ ] Описание изменений
   - [ ] Примеры миграции кода
   - [ ] Checklist для миграции
@@ -525,7 +525,7 @@ describe('Timeline Machine', () => {
 
 1. Определите приоритет задач
 2. Оцените время на каждую задачу
-3. Создайте plan в `/docs/ru/08_tasks/active/`
+3. Создайте plan в `/docs/08_tasks/active/`
 
 ### Шаг 3: Реализация
 
@@ -552,11 +552,11 @@ describe('Timeline Machine', () => {
 
 ## 12. 📖 СВЯЗАННЫЕ ДОКУМЕНТЫ
 
-- [Руководство по разработке](/docs/ru/05_development/README.md)
-- [Стандарты кодирования](/docs/ru/05_development/coding-standards.md)
-- [Руководство по тестированию](/docs/ru/05_development/testing.md)
-- [Архитектура проекта](/docs/ru/03_architecture/README.md)
-- [Прогресс финализации модулей](/docs/ru/14_quality_assurance/modules-finalization-progress.md)
+- [Руководство по разработке](../05_development/README.md)
+- [Стандарты кодирования](../05_development/coding-standards.md)
+- [Руководство по тестированию](../05_development/testing.md)
+- [Архитектура проекта](../03_architecture/README.md)
+- [Прогресс финализации модулей](modules-finalization-progress.md)
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "check:boundaries:external": "node scripts/check-package-boundaries.mjs --external-contracts",
     "check:boundaries:baseline": "node scripts/check-package-boundaries.mjs --baseline=config/package-boundaries-baseline.json --max-details=0",
     "check:boundaries:strict": "node scripts/check-package-boundaries.mjs --strict",
+    "check:docs:links": "node scripts/validate-docs-links.mjs",
     "check:examples:postim": "node scripts/validate-headless-postim-example.mjs",
     "check:shims:retired": "node scripts/validate-root-shim-retirement.mjs",
     "check:all": "npm run lint && npm run lint:css && npm run check:rust && npm run test && npm run test:rust",

--- a/packages/core/src/services/timeline-state-access.ts
+++ b/packages/core/src/services/timeline-state-access.ts
@@ -1,0 +1,36 @@
+export interface TimelineStateAccess {
+  getCurrentProject: () => unknown
+  createProject: (project: any) => Promise<void>
+  updateProject: (updates: any) => Promise<void>
+  createSection: (section: any) => Promise<any>
+  createTrack: (track: any) => Promise<any>
+  addClip: (clip: any) => Promise<any>
+  getProjectStats: () => {
+    totalDuration: number
+    totalClips: number
+    totalTracks: number
+    totalSections: number
+  }
+  sendTimelineCommand: (command: string, params?: any) => Promise<void>
+}
+
+let timelineStateAccess: TimelineStateAccess | null = null
+
+export function setTimelineStateAccess(access: TimelineStateAccess | null): void {
+  timelineStateAccess = access
+}
+
+export function getTimelineStateAccess(): TimelineStateAccess | null {
+  return timelineStateAccess
+}
+
+export function hasTimelineStateAccess(): boolean {
+  return timelineStateAccess !== null
+}
+
+export function requireTimelineStateAccess(): TimelineStateAccess {
+  if (!timelineStateAccess) {
+    throw new Error("Timeline state access не настроен")
+  }
+  return timelineStateAccess
+}

--- a/packages/domains/src/ai-tools/tools/core/timeline/types.ts
+++ b/packages/domains/src/ai-tools/tools/core/timeline/types.ts
@@ -6,6 +6,11 @@
  */
 
 import type { TimelineClip, TimelineSection, TimelineTrack } from "@timeline-studio/domains/video-editing/types"
+export type { TimelineStateAccess } from "@timeline-studio/core/services/timeline-state-access"
+export {
+  getTimelineStateAccess,
+  setTimelineStateAccess,
+} from "@timeline-studio/core/services/timeline-state-access"
 
 /**
  * Типы для функций обратного вызова в reduce операциях
@@ -55,40 +60,4 @@ export interface TimelineToolResult {
   errors?: string[]
   warnings?: string[]
   nextActions?: string[]
-}
-
-/**
- * Интерфейс для доступа к состоянию Timeline
- */
-export interface TimelineStateAccess {
-  getCurrentProject: () => unknown
-  createProject: (project: any) => Promise<void>
-  updateProject: (updates: any) => Promise<void>
-  createSection: (section: any) => Promise<any>
-  createTrack: (track: any) => Promise<any>
-  addClip: (clip: any) => Promise<any>
-  getProjectStats: () => {
-    totalDuration: number
-    totalClips: number
-    totalTracks: number
-    totalSections: number
-  }
-  sendTimelineCommand: (command: string, params?: any) => Promise<void>
-}
-
-// Глобальная переменная для доступа к состоянию timeline
-let timelineStateAccess: TimelineStateAccess | null = null
-
-/**
- * Устанавливает доступ к состоянию timeline
- */
-export function setTimelineStateAccess(access: TimelineStateAccess | null) {
-  timelineStateAccess = access
-}
-
-/**
- * Получает доступ к состоянию timeline
- */
-export function getTimelineStateAccess(): TimelineStateAccess | null {
-  return timelineStateAccess
 }

--- a/scripts/validate-docs-links.mjs
+++ b/scripts/validate-docs-links.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs"
+import path from "node:path"
+
+const rootDir = process.cwd()
+
+const defaultFiles = [
+  "docs/README.md",
+  "docs/10_project_state/current-status.md",
+  "docs/10_project_state/roadmap.md",
+  "docs/04_api_reference/README.md",
+  "docs/03_architecture/frontend/state-management.md",
+  "docs/03_architecture/backend/telemetry.md",
+  "docs/02_requirements/feature-specification.md",
+  "docs/05_development/README.md",
+  "docs/14_quality_assurance/README.md",
+  "docs/14_quality_assurance/module-finalization-checklist.md",
+]
+
+const args = new Set(process.argv.slice(2).filter((arg) => arg.startsWith("--")))
+const positionalFiles = process.argv.slice(2).filter((arg) => !arg.startsWith("--"))
+const scanAll = args.has("--all")
+const reportOnly = args.has("--report")
+const jsonOutput = args.has("--json")
+
+function collectMarkdownFiles(dir) {
+  const entries = readdirSync(dir, { withFileTypes: true })
+  const files = []
+
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name)
+
+    if (entry.isDirectory()) {
+      files.push(...collectMarkdownFiles(entryPath))
+      continue
+    }
+
+    if (entry.isFile() && entry.name.endsWith(".md")) {
+      files.push(path.relative(rootDir, entryPath))
+    }
+  }
+
+  return files
+}
+
+function stripCodeBlocks(markdown) {
+  return markdown.replace(/```[\s\S]*?```/g, "")
+}
+
+function parseHref(rawHref) {
+  const trimmed = rawHref.trim()
+
+  if (trimmed.startsWith("<")) {
+    const end = trimmed.indexOf(">")
+    return end === -1 ? trimmed.slice(1) : trimmed.slice(1, end)
+  }
+
+  const quoteIndex = trimmed.search(/\s["']/)
+  return quoteIndex === -1 ? trimmed : trimmed.slice(0, quoteIndex)
+}
+
+function extractLinks(markdown) {
+  const links = []
+  const text = stripCodeBlocks(markdown)
+  const inlineLinkPattern = /!?\[[^\]\n]*\]\(([^)\n]+)\)/g
+  const referenceLinkPattern = /^\s*\[[^\]\n]+\]:\s*(\S+)/gm
+
+  for (const match of text.matchAll(inlineLinkPattern)) {
+    if (match[0].startsWith("!")) continue
+    links.push(parseHref(match[1]))
+  }
+
+  for (const match of text.matchAll(referenceLinkPattern)) {
+    links.push(parseHref(match[1]))
+  }
+
+  return links
+}
+
+function isExternalHref(href) {
+  return (
+    href.startsWith("#") ||
+    href.startsWith("mailto:") ||
+    href.startsWith("tel:") ||
+    /^[a-z][a-z0-9+.-]*:/i.test(href)
+  )
+}
+
+function localTargetFor(file, href) {
+  if (!href || isExternalHref(href)) return null
+
+  const withoutAnchor = href.split("#")[0]
+  if (!withoutAnchor) return null
+
+  const withoutQuery = withoutAnchor.split("?")[0]
+  const decodedHref = safeDecodeUri(withoutQuery)
+
+  if (decodedHref.startsWith("/")) {
+    return path.join(rootDir, decodedHref.slice(1))
+  }
+
+  return path.resolve(rootDir, path.dirname(file), decodedHref)
+}
+
+function safeDecodeUri(value) {
+  try {
+    return decodeURI(value)
+  } catch {
+    return value
+  }
+}
+
+function targetExists(target) {
+  if (existsSync(target)) return true
+  if (existsSync(`${target}.md`)) return true
+  if (existsSync(path.join(target, "README.md"))) return true
+  return false
+}
+
+function filesToScan() {
+  if (scanAll) return collectMarkdownFiles(path.join(rootDir, "docs")).sort()
+  if (positionalFiles.length > 0) return positionalFiles
+  return defaultFiles
+}
+
+const brokenLinks = []
+const scannedFiles = filesToScan().filter((file) => {
+  const target = path.resolve(rootDir, file)
+  return existsSync(target) && statSync(target).isFile()
+})
+
+for (const file of scannedFiles) {
+  const absoluteFile = path.resolve(rootDir, file)
+  const markdown = readFileSync(absoluteFile, "utf8")
+
+  for (const href of extractLinks(markdown)) {
+    const target = localTargetFor(file, href)
+
+    if (target && !targetExists(target)) {
+      brokenLinks.push({
+        file,
+        href,
+        target: path.relative(rootDir, target),
+      })
+    }
+  }
+}
+
+if (jsonOutput) {
+  console.log(
+    JSON.stringify(
+      {
+        scannedFiles: scannedFiles.length,
+        brokenLinks,
+      },
+      null,
+      2,
+    ),
+  )
+} else if (brokenLinks.length === 0) {
+  console.log(`Docs link check passed: ${scannedFiles.length} files scanned.`)
+} else {
+  console.error(`Docs link check found ${brokenLinks.length} broken link(s) in ${scannedFiles.length} file(s):`)
+
+  for (const brokenLink of brokenLinks) {
+    console.error(`- ${brokenLink.file}: ${brokenLink.href} -> ${brokenLink.target}`)
+  }
+}
+
+if (brokenLinks.length > 0 && !reportOnly) {
+  process.exitCode = 1
+}

--- a/src/features/ai-chat/hooks/use-timeline-ai-integration.ts
+++ b/src/features/ai-chat/hooks/use-timeline-ai-integration.ts
@@ -1,7 +1,4 @@
-import {
-  setTimelineStateAccess,
-  type TimelineStateAccess,
-} from "@timeline-studio/domains/ai-tools/tools/core/timeline/types"
+import { setTimelineStateAccess, type TimelineStateAccess } from "@timeline-studio/core/services/timeline-state-access"
 import { useCallback, useEffect, useMemo, useRef } from "react"
 import { createLogger, type LogContext, logError, logInfo } from "@/lib/tauri-logger"
 import { useTimeline } from "../../timeline/hooks"


### PR DESCRIPTION
## Summary
- retarget moved feature/domain links to current package paths
- convert stale planned API/docs entries to plain text instead of broken markdown links
- add check:docs:links with a scoped fail gate and full --all --report audit mode

## Validation
- bun run check:docs:links
- node --check scripts/validate-docs-links.mjs
- git diff --check
- node scripts/validate-docs-links.mjs --all --report --json (222 docs scanned, 60 legacy broken links remain outside the scoped gate)

Note: this branch is stacked on #318 until the timeline boundary fix merges. The #301 docs change is commit ae59e654325.

Closes #301