### PR TITLE
Implement real AI music workflow

### DIFF
--- a/packages/core/src/services/timeline-state-access.ts
+++ b/packages/core/src/services/timeline-state-access.ts
@@ -3,8 +3,23 @@ export interface TimelineStateAccess {
   createProject: (project: any) => Promise<void>
   updateProject: (updates: any) => Promise<void>
   createSection: (section: any) => Promise<any>
-  createTrack: (track: any) => Promise<any>
-  addClip: (clip: any) => Promise<any>
+  createTrack: (track: {
+    type?: string
+    name?: string
+    sectionId?: string
+    [key: string]: unknown
+  }) => Promise<any>
+  addClip: (clip: {
+    trackId?: string
+    targetTrackId?: string
+    mediaId?: string
+    resourceId?: string
+    mediaFile?: any
+    startTime?: number
+    time?: number
+    duration?: number
+    [key: string]: unknown
+  }) => Promise<any>
   getProjectStats: () => {
     totalDuration: number
     totalClips: number

--- a/packages/domains/src/ai-tools/tools/core/timeline/__tests__/execution-path.test.ts
+++ b/packages/domains/src/ai-tools/tools/core/timeline/__tests__/execution-path.test.ts
@@ -3,17 +3,27 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { setTimelineStateAccess } from "../types"
 import { trackCreationTool } from "../create-tracks"
 import { clipManagementTool } from "../manage-clips"
+import { musicWorkflowTool } from "../music-workflow"
 import { clipPlacementTool } from "../place-clips"
+import { musicSyncTool } from "../sync-music"
 
 describe("timeline AI tool execution path", () => {
   let project: any
+  let nextTrackId: number
+  let nextClipId: number
 
   beforeEach(() => {
+    nextTrackId = 1
+    nextClipId = 1
     project = {
       id: "project-1",
       name: "AI Timeline Test",
       globalTracks: [],
       sections: [],
+      resources: {
+        music: [],
+        media: [],
+      },
     }
 
     setTimelineStateAccess({
@@ -25,8 +35,33 @@ describe("timeline AI tool execution path", () => {
         project = { ...project, ...updates }
       },
       createSection: async (section: any) => section,
-      createTrack: async (track: any) => track,
-      addClip: async (clip: any) => clip,
+      createTrack: async (track: any) => {
+        const createdTrack = {
+          id: track.id ?? `music-track-${nextTrackId++}`,
+          name: track.name ?? "Music",
+          type: track.type,
+          order: project.globalTracks.length,
+          clips: [],
+        }
+        project.globalTracks.push(createdTrack)
+        return createdTrack
+      },
+      addClip: async (clip: any) => {
+        const targetTrack = project.globalTracks.find((track: any) => track.id === clip.trackId)
+        if (!targetTrack) {
+          throw new Error(`Track not found: ${clip.trackId}`)
+        }
+        const createdClip = {
+          id: clip.id ?? `music-clip-${nextClipId++}`,
+          trackId: clip.trackId,
+          mediaId: clip.mediaId ?? clip.resourceId,
+          startTime: clip.startTime ?? clip.time ?? 0,
+          duration: clip.duration ?? clip.mediaFile?.duration ?? 5,
+          mediaFile: clip.mediaFile,
+        }
+        targetTrack.clips.push(createdClip)
+        return createdClip
+      },
       getProjectStats: () => ({
         totalDuration: 0,
         totalClips: 0,
@@ -135,5 +170,73 @@ describe("timeline AI tool execution path", () => {
 
     expect(result.success).toBe(false)
     expect(result.errors).toContain("Неподдерживаемая операция: unsupported")
+  })
+
+  it("inserts an existing audio resource into a real Music track", async () => {
+    project.resources.music.push({
+      id: "audio-1",
+      name: "Launch theme",
+      path: "/media/launch-theme.mp3",
+      type: "audio",
+      isAudio: true,
+      duration: 18,
+    })
+
+    const result = await musicWorkflowTool.execute({
+      operation: "insert_music",
+      mediaId: "audio-1",
+      trackName: "AI Music",
+      startTime: 2,
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.data).toMatchObject({
+      selected: { id: "audio-1" },
+      trackId: "music-track-1",
+      clipId: "music-clip-1",
+      createdTrack: true,
+    })
+    expect(project.globalTracks[0]).toMatchObject({
+      id: "music-track-1",
+      name: "AI Music",
+      type: "music",
+    })
+    expect(project.globalTracks[0].clips[0]).toMatchObject({
+      id: "music-clip-1",
+      mediaId: "audio-1",
+      startTime: 2,
+      duration: 18,
+    })
+  })
+
+  it("fails music sync auto beat detection instead of generating heuristic beats", async () => {
+    project.globalTracks.push({
+      id: "music-track-1",
+      name: "Music",
+      type: "music",
+      order: 0,
+      clips: [
+        {
+          id: "music-clip-1",
+          trackId: "music-track-1",
+          mediaId: "audio-1",
+          startTime: 0,
+          duration: 18,
+          mediaFile: {
+            id: "audio-1",
+            isAudio: true,
+            type: "audio",
+          },
+        },
+      ],
+    })
+
+    const result = await musicSyncTool.execute({
+      musicTrackId: "music-track-1",
+      syncOptions: { beatDetection: "auto" },
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.errors?.join(" ")).toContain("Real beat detection is not configured")
   })
 })

--- a/packages/domains/src/ai-tools/tools/core/timeline/index.ts
+++ b/packages/domains/src/ai-tools/tools/core/timeline/index.ts
@@ -12,6 +12,7 @@ import { trackCreationTool } from "./create-tracks"
 import { sceneDetectionTool } from "./detect-scenes"
 import { timelineExportTool } from "./export-data"
 import { clipManagementTool } from "./manage-clips"
+import { musicWorkflowTool } from "./music-workflow"
 import { timelineOptimizationTool } from "./optimize-timeline"
 import { clipPlacementTool } from "./place-clips"
 import { smartTemplatesTools } from "./smart-templates"
@@ -40,6 +41,7 @@ export {
 } from "./detect-scenes"
 export { exportTimelineData, timelineExportTool } from "./export-data"
 export { clipManagementTool, manageTimelineClips } from "./manage-clips"
+export { musicWorkflowTool, runMusicWorkflow } from "./music-workflow"
 export {
   optimizeTimelinePerformance,
   timelineOptimizationTool,
@@ -72,6 +74,7 @@ export const timelineTools = [
   enhancementApplicationTool,
   storyAnalysisTool,
   sceneDetectionTool,
+  musicWorkflowTool,
   musicSyncTool,
   improvementsSuggestionTool,
   timelineExportTool,
@@ -96,6 +99,8 @@ export async function executeTimelineTool(operation: string, params: any, option
     apply_enhancements: enhancementApplicationTool,
     analyze_story: storyAnalysisTool,
     detect_scenes: sceneDetectionTool,
+    music_workflow: musicWorkflowTool,
+    insert_music: musicWorkflowTool,
     sync_music: musicSyncTool,
     suggest_improvements: improvementsSuggestionTool,
     export_data: timelineExportTool,

--- a/packages/domains/src/ai-tools/tools/core/timeline/music-workflow.ts
+++ b/packages/domains/src/ai-tools/tools/core/timeline/music-workflow.ts
@@ -1,0 +1,371 @@
+/**
+ * AI tool for selecting and inserting existing music/audio media on the timeline.
+ */
+
+import type { TimelineTrack } from "@timeline-studio/domains/video-editing/types"
+import {
+  type AIToolExecutionOptions,
+  type AIToolLogger,
+  type AIToolMetadata,
+  type AIToolResult,
+  BaseAITool,
+} from "../../../base"
+import { getTimelineStateAccess } from "./types"
+
+export type MusicWorkflowOperation = "list_audio_media" | "select_audio_media" | "insert_music"
+
+export interface MusicWorkflowInput {
+  operation: MusicWorkflowOperation
+  mediaId?: string
+  mood?: string
+  bpm?: number
+  minDuration?: number
+  maxDuration?: number
+  trackId?: string
+  trackName?: string
+  startTime?: number
+  createTrackIfMissing?: boolean
+}
+
+export interface MusicMediaCandidate {
+  id: string
+  name: string
+  duration?: number
+  mood?: string
+  bpm?: number
+  path?: string
+  source: "resources.music" | "resources.media" | "media_pool"
+  file?: any
+}
+
+export interface MusicWorkflowResult {
+  operation: MusicWorkflowOperation
+  candidates?: MusicMediaCandidate[]
+  selected?: MusicMediaCandidate
+  trackId?: string
+  clipId?: string
+  createdTrack?: boolean
+  warnings?: string[]
+}
+
+export class MusicWorkflowTool extends BaseAITool {
+  public readonly metadata: AIToolMetadata = {
+    name: "music-workflow",
+    displayName: "Music Workflow Tool",
+    description: "Select and insert existing music/audio media on the timeline",
+    domain: "core",
+    category: "timeline",
+    version: "1.0.0",
+  }
+
+  constructor(logger?: AIToolLogger) {
+    super(undefined, logger)
+  }
+
+  validate(input: any): boolean {
+    return input && typeof input === "object" && typeof input.operation === "string"
+  }
+
+  getSchema() {
+    return {
+      input: {
+        operation: ["list_audio_media", "select_audio_media", "insert_music"],
+        mediaId: "string",
+        trackId: "string",
+        startTime: "number",
+      },
+      output: {},
+    }
+  }
+
+  async execute(input: any, options?: AIToolExecutionOptions): Promise<AIToolResult<MusicWorkflowResult>> {
+    return this.runMusicWorkflow(input as MusicWorkflowInput, options)
+  }
+
+  public async runMusicWorkflow(
+    input: MusicWorkflowInput,
+    options: AIToolExecutionOptions = {},
+  ): Promise<AIToolResult<MusicWorkflowResult>> {
+    return this.executeWithErrorHandling(
+      async () => {
+        const timelineAccess = getTimelineStateAccess()
+        if (!timelineAccess) {
+          throw new Error("Timeline state access is not configured")
+        }
+
+        const project = timelineAccess.getCurrentProject() as any
+        if (!project?.id) {
+          throw new Error("No active timeline project for music workflow")
+        }
+
+        const candidates = filterCandidates(findAudioMediaCandidates(project), input)
+
+        switch (input.operation) {
+          case "list_audio_media":
+            return {
+              operation: input.operation,
+              candidates,
+              warnings: candidates.length === 0 ? ["No audio/music media candidates found"] : undefined,
+            }
+          case "select_audio_media": {
+            const selected = selectMusicCandidate(candidates, input)
+            return {
+              operation: input.operation,
+              candidates,
+              selected,
+            }
+          }
+          case "insert_music":
+            return insertMusicCandidate(project, timelineAccess, candidates, input)
+          default:
+            throw new Error(`Unsupported music workflow operation: ${input.operation}`)
+        }
+      },
+      input,
+      {
+        timeout: options.timeout || 45000,
+        retries: options.retries || 1,
+        retryDelay: options.retryDelay || 1000,
+        enableLogging: options.enableLogging !== false,
+        metadata: {
+          operation: input.operation,
+          ...options.metadata,
+        },
+      },
+    )
+  }
+}
+
+async function insertMusicCandidate(
+  project: any,
+  timelineAccess: NonNullable<ReturnType<typeof getTimelineStateAccess>>,
+  candidates: MusicMediaCandidate[],
+  input: MusicWorkflowInput,
+): Promise<MusicWorkflowResult> {
+  const selected = selectMusicCandidate(candidates, input)
+  const warnings: string[] = []
+  const { trackId, createdTrack } = await resolveMusicTrack(project, timelineAccess, input)
+  const startTime = finiteOptionalNumber(input.startTime, "startTime") ?? 0
+
+  const clipResult = await timelineAccess.addClip({
+    trackId,
+    mediaId: selected.id,
+    resourceId: selected.id,
+    mediaFile: selected.file ?? selected.id,
+    startTime,
+    time: startTime,
+    duration: selected.duration,
+    contentType: "audio",
+  })
+  const clipId = extractId(clipResult, ["id", "clipId", "clip_id"])
+
+  if (!clipId) {
+    warnings.push("Music clip insertion completed without a returned clip id")
+  }
+
+  return {
+    operation: input.operation,
+    selected,
+    trackId,
+    clipId,
+    createdTrack,
+    warnings: warnings.length > 0 ? warnings : undefined,
+  }
+}
+
+async function resolveMusicTrack(
+  project: any,
+  timelineAccess: NonNullable<ReturnType<typeof getTimelineStateAccess>>,
+  input: MusicWorkflowInput,
+): Promise<{ trackId: string; createdTrack: boolean }> {
+  if (input.trackId?.trim()) {
+    return { trackId: input.trackId.trim(), createdTrack: false }
+  }
+
+  const existingMusicTrack = getAllTracks(project).find((track) => String(track.type).toLowerCase() === "music")
+  if (existingMusicTrack?.id) {
+    return { trackId: existingMusicTrack.id, createdTrack: false }
+  }
+
+  if (input.createTrackIfMissing === false) {
+    throw new Error("No Music track exists and createTrackIfMissing is false")
+  }
+
+  const trackResult = await timelineAccess.createTrack({
+    type: "music",
+    name: input.trackName || "Music",
+  })
+  const trackId = extractId(trackResult, ["id", "trackId", "track_id"])
+  if (!trackId) {
+    throw new Error("Music track creation did not return a track id")
+  }
+
+  return { trackId, createdTrack: true }
+}
+
+function findAudioMediaCandidates(project: any): MusicMediaCandidate[] {
+  const candidates = new Map<string, MusicMediaCandidate>()
+
+  addCandidates(candidates, project.resources?.music, "resources.music")
+  addCandidates(candidates, project.resources?.media, "resources.media")
+
+  const mediaPoolItems = project.media_pool?.items ?? project.mediaPool?.items
+  if (mediaPoolItems && typeof mediaPoolItems === "object") {
+    for (const item of Object.values(mediaPoolItems)) {
+      const candidate = candidateFromMediaPoolItem(item)
+      if (candidate) {
+        candidates.set(candidate.id, candidate)
+      }
+    }
+  }
+
+  return Array.from(candidates.values())
+}
+
+function addCandidates(
+  candidates: Map<string, MusicMediaCandidate>,
+  resources: unknown,
+  source: MusicMediaCandidate["source"],
+): void {
+  if (!Array.isArray(resources)) return
+
+  for (const resource of resources) {
+    const candidate = candidateFromResource(resource, source)
+    if (candidate) {
+      candidates.set(candidate.id, candidate)
+    }
+  }
+}
+
+function candidateFromResource(
+  resource: any,
+  source: MusicMediaCandidate["source"],
+): MusicMediaCandidate | null {
+  if (!resource || typeof resource !== "object") return null
+
+  const file = resource.file && typeof resource.file === "object" ? resource.file : resource
+  const id = String(resource.resourceId ?? resource.id ?? file.id ?? "").trim()
+  if (!id || !isAudioLikeResource(resource, file)) return null
+
+  return {
+    id,
+    name: String(resource.name ?? file.name ?? id),
+    duration: finiteOptionalNumber(file.duration ?? resource.duration, "duration"),
+    mood: readOptionalString(resource.params?.mood ?? resource.metadata?.mood ?? file.mood ?? file.metadata?.mood),
+    bpm: finiteOptionalNumber(resource.params?.bpm ?? resource.metadata?.bpm ?? file.bpm ?? file.metadata?.bpm, "bpm"),
+    path: typeof file.path === "string" ? file.path : typeof resource.path === "string" ? resource.path : undefined,
+    source,
+    file,
+  }
+}
+
+function candidateFromMediaPoolItem(item: any): MusicMediaCandidate | null {
+  if (!item || typeof item !== "object") return null
+
+  const mediaType = String(item.media_type ?? item.mediaType ?? item.type ?? "").toLowerCase()
+  if (!["audio", "music"].some((type) => mediaType.includes(type))) return null
+
+  const id = String(item.id ?? "").trim()
+  if (!id) return null
+
+  const file = {
+    id,
+    name: item.name ?? id,
+    path: item.path,
+    type: "audio",
+    isAudio: true,
+    isVideo: false,
+    isImage: false,
+    duration: item.duration ?? 0,
+  }
+
+  return {
+    id,
+    name: String(item.name ?? id),
+    duration: finiteOptionalNumber(item.duration, "duration"),
+    mood: readOptionalString(item.metadata?.mood),
+    bpm: finiteOptionalNumber(item.metadata?.bpm, "bpm"),
+    path: typeof item.path === "string" ? item.path : undefined,
+    source: "media_pool",
+    file,
+  }
+}
+
+function isAudioLikeResource(resource: any, file: any): boolean {
+  if (resource.type === "music" || file.type === "music" || file.type === "audio") return true
+  if (file.isAudio === true || resource.isAudio === true) return true
+
+  const path = String(file.path ?? resource.path ?? "").toLowerCase()
+  return [".mp3", ".wav", ".aac", ".flac", ".ogg", ".m4a"].some((extension) => path.endsWith(extension))
+}
+
+function filterCandidates(candidates: MusicMediaCandidate[], input: MusicWorkflowInput): MusicMediaCandidate[] {
+  const minDuration = finiteOptionalNumber(input.minDuration, "minDuration")
+  const maxDuration = finiteOptionalNumber(input.maxDuration, "maxDuration")
+  const targetBpm = finiteOptionalNumber(input.bpm, "bpm")
+  const targetMood = input.mood?.trim().toLowerCase()
+
+  return candidates.filter((candidate) => {
+    if (minDuration !== undefined && (candidate.duration ?? 0) < minDuration) return false
+    if (maxDuration !== undefined && candidate.duration !== undefined && candidate.duration > maxDuration) return false
+    if (targetBpm !== undefined && (candidate.bpm === undefined || Math.abs(candidate.bpm - targetBpm) > 5)) {
+      return false
+    }
+    if (targetMood && !candidate.mood?.toLowerCase().includes(targetMood)) return false
+    return true
+  })
+}
+
+function selectMusicCandidate(candidates: MusicMediaCandidate[], input: MusicWorkflowInput): MusicMediaCandidate {
+  if (input.mediaId?.trim()) {
+    const mediaId = input.mediaId.trim()
+    const selected = candidates.find((candidate) => candidate.id === mediaId)
+    if (!selected) {
+      throw new Error(`Audio/music media candidate not found: ${mediaId}`)
+    }
+    return selected
+  }
+
+  const selected = candidates[0]
+  if (!selected) {
+    throw new Error("No audio/music media candidates found")
+  }
+  return selected
+}
+
+function getAllTracks(project: any): TimelineTrack[] {
+  return [
+    ...(Array.isArray(project.globalTracks) ? project.globalTracks : []),
+    ...(Array.isArray(project.sections) ? project.sections.flatMap((section: any) => section.tracks || []) : []),
+  ]
+}
+
+function finiteOptionalNumber(value: unknown, field: string): number | undefined {
+  if (value === undefined || value === null || value === "") return undefined
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`${field} must be a finite number`)
+  }
+  return value
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined
+}
+
+function extractId(value: any, keys: string[]): string | undefined {
+  if (typeof value === "string" && value.trim()) return value.trim()
+  if (!value || typeof value !== "object") return undefined
+
+  for (const key of keys) {
+    const id = value[key]
+    if (typeof id === "string" && id.trim()) return id.trim()
+  }
+
+  return undefined
+}
+
+export const musicWorkflowTool = new MusicWorkflowTool()
+
+export async function runMusicWorkflow(params: MusicWorkflowInput): Promise<AIToolResult<MusicWorkflowResult>> {
+  return musicWorkflowTool.runMusicWorkflow(params)
+}

--- a/packages/domains/src/ai-tools/tools/core/timeline/sync-music.ts
+++ b/packages/domains/src/ai-tools/tools/core/timeline/sync-music.ts
@@ -19,6 +19,7 @@ export interface MusicSyncInput {
     syncTransitions?: boolean
     beatDetection?: "auto" | "manual" | "bpm-based"
     targetBPM?: number
+    manualBeats?: BeatMarker[]
   }
 }
 
@@ -93,8 +94,7 @@ export class MusicSyncTool extends BaseAITool {
   }
 
   async execute(input: any, options?: AIToolExecutionOptions): Promise<AIToolResult> {
-    // Delegate to main method - will be implemented by the specific tool
-    return this.executeWithErrorHandling(async () => ({}), input, options)
+    return this.synchronizeTimelineWithMusic(input as MusicSyncInput, options)
   }
 
   /**
@@ -273,19 +273,30 @@ export class MusicSyncTool extends BaseAITool {
     musicClip: any,
     syncOptions: MusicSyncInput["syncOptions"],
   ): Promise<MusicAnalysis> {
-    const duration = musicClip.duration
-    const detectionMethod = syncOptions?.beatDetection || "auto"
+    const duration = this.readFiniteNumber(musicClip.duration, "musicClip.duration")
+    const startOffset = this.readFiniteNumber(musicClip.startTime ?? 0, "musicClip.startTime")
+    const detectionMethod = syncOptions?.beatDetection || (syncOptions?.targetBPM ? "bpm-based" : "auto")
 
-    // Определяем BPM
     let bpm: number
-    if (syncOptions?.targetBPM) {
-      bpm = syncOptions.targetBPM
-    } else {
-      bpm = this.estimateBPMFromClip(musicClip)
-    }
+    let beats: BeatMarker[]
 
-    // Генерируем массив битов на основе BPM
-    const beats = this.generateBeatMarkers(bpm, duration, musicClip.startTime)
+    if (detectionMethod === "manual") {
+      if (!syncOptions?.manualBeats?.length) {
+        throw new Error("Manual beat sync requires syncOptions.manualBeats")
+      }
+      beats = syncOptions.manualBeats.map((beat, index) => this.normalizeManualBeat(beat, index))
+      bpm = syncOptions.targetBPM ?? this.estimateBPMFromManualBeats(beats)
+    } else if (detectionMethod === "bpm-based") {
+      if (!syncOptions?.targetBPM) {
+        throw new Error("BPM-based beat sync requires syncOptions.targetBPM")
+      }
+      bpm = syncOptions.targetBPM
+      beats = this.generateBeatMarkers(bpm, duration, startOffset)
+    } else {
+      throw new Error(
+        "Real beat detection is not configured for sync-music; provide targetBPM with beatDetection=bpm-based or manualBeats with beatDetection=manual",
+      )
+    }
 
     // Определяем ритмическую сложность
     const rhythmComplexity = this.calculateRhythmComplexity(bpm, duration)
@@ -393,37 +404,60 @@ export class MusicSyncTool extends BaseAITool {
   // Вспомогательные методы
 
   /**
-   * Оценивает BPM на основе клипа
-   */
-  private estimateBPMFromClip(clip: any): number {
-    const duration = clip.duration
-
-    // Простая эвристика для оценки BPM
-    if (duration < 60) {
-      return 140 // Быстрая музыка
-    }
-    if (duration < 180) {
-      return 120 // Умеренная
-    }
-    return 80 // Медленная
-  }
-
-  /**
    * Генерирует маркеры битов
    */
   private generateBeatMarkers(bpm: number, duration: number, startOffset = 0): BeatMarker[] {
+    if (!Number.isFinite(bpm) || bpm <= 0 || bpm > 300) {
+      throw new Error("BPM must be a finite number between 1 and 300")
+    }
+
     const beats: BeatMarker[] = []
     const beatInterval = 60 / bpm // Интервал между битами в секундах
 
     for (let time = startOffset; time < startOffset + duration; time += beatInterval) {
+      const isDownbeat = beats.length % 4 === 0
       beats.push({
         time,
-        strength: Math.random() * 0.5 + 0.5, // Случайная сила бита от 0.5 до 1
-        isDownbeat: beats.length % 4 === 0, // Каждый 4-й бит - сильная доля
+        strength: isDownbeat ? 1 : 0.65,
+        isDownbeat,
       })
     }
 
     return beats
+  }
+
+  private normalizeManualBeat(beat: BeatMarker, index: number): BeatMarker {
+    return {
+      time: this.readFiniteNumber(beat.time, `manualBeats.${index}.time`),
+      strength:
+        beat.strength === undefined ? 1 : this.readFiniteNumber(beat.strength, `manualBeats.${index}.strength`),
+      isDownbeat: beat.isDownbeat === true,
+    }
+  }
+
+  private estimateBPMFromManualBeats(beats: BeatMarker[]): number {
+    if (beats.length < 2) {
+      throw new Error("At least two manualBeats are required when targetBPM is not provided")
+    }
+
+    const sortedBeats = [...beats].sort((a, b) => a.time - b.time)
+    const intervals = sortedBeats
+      .slice(1)
+      .map((beat, index) => beat.time - sortedBeats[index].time)
+      .filter((interval) => interval > 0)
+    if (intervals.length === 0) {
+      throw new Error("manualBeats must contain increasing beat times")
+    }
+
+    const averageInterval = intervals.reduce((sum, interval) => sum + interval, 0) / intervals.length
+    return 60 / averageInterval
+  }
+
+  private readFiniteNumber(value: unknown, field: string): number {
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+      throw new Error(`${field} must be a finite number`)
+    }
+    return value
   }
 
   /**

--- a/src/features/ai-chat/hooks/use-timeline-ai-integration.ts
+++ b/src/features/ai-chat/hooks/use-timeline-ai-integration.ts
@@ -319,7 +319,9 @@ function findMediaFileForClip(project: any, mediaId: string | undefined): any | 
       name: mediaPoolItem.name ?? mediaId,
       path: mediaPoolItem.path,
       type: String(mediaPoolItem.media_type ?? mediaPoolItem.mediaType ?? "audio").toLowerCase(),
-      isAudio: String(mediaPoolItem.media_type ?? mediaPoolItem.mediaType ?? "").toLowerCase().includes("audio"),
+      isAudio: String(mediaPoolItem.media_type ?? mediaPoolItem.mediaType ?? "")
+        .toLowerCase()
+        .includes("audio"),
       duration: mediaPoolItem.duration ?? 0,
     }
   }

--- a/src/features/ai-chat/hooks/use-timeline-ai-integration.ts
+++ b/src/features/ai-chat/hooks/use-timeline-ai-integration.ts
@@ -180,8 +180,10 @@ export function useTimelineAIIntegration() {
       createTrack: async (track: any) => {
         logInfo("[useTimelineAIIntegration] Создание трека", { trackType: track.type })
         try {
-          const id = `track_${Date.now()}`
-          await timelineRef.current.addTrack(track.type, undefined, track.name)
+          const id = await timelineRef.current.addTrack(track.type, track.name, track.sectionId)
+          if (!id) {
+            throw new Error("Timeline addTrack did not return track id")
+          }
           logInfo("[useTimelineAIIntegration] Трек создан", { id })
           return { ...track, id, clips: [] }
         } catch (error) {
@@ -190,13 +192,25 @@ export function useTimelineAIIntegration() {
         }
       },
       addClip: async (clip: any) => {
-        logInfo("[useTimelineAIIntegration] Добавление клипа", { clipId: clip.id })
+        const trackId = clip.trackId || clip.targetTrackId
+        const mediaId = clip.mediaId || clip.resourceId
+        const startTime = clip.startTime ?? clip.time ?? 0
+        logInfo("[useTimelineAIIntegration] Добавление клипа", { clipId: clip.id, trackId, mediaId })
         try {
-          const id = `clip_${Date.now()}`
-          // TODO: Need mediaFile parameter in addClip
-          logger.warn("addClip needs proper implementation")
+          if (!trackId) {
+            throw new Error("trackId is required for AI timeline addClip")
+          }
+          if (!mediaId && !clip.mediaFile) {
+            throw new Error("mediaId or mediaFile is required for AI timeline addClip")
+          }
+
+          const mediaFile = clip.mediaFile ?? findMediaFileForClip(timelineRef.current.project, mediaId)
+          const id = await timelineRef.current.addClip(trackId, mediaFile ?? mediaId, startTime)
+          if (!id) {
+            throw new Error("Timeline addClip did not return clip id")
+          }
           logInfo("[useTimelineAIIntegration] Клип добавлен", { id })
-          return { ...clip, id }
+          return { ...clip, id, trackId, mediaId }
         } catch (error) {
           logError("[useTimelineAIIntegration] Ошибка добавления клипа", error as LogContext)
           throw error
@@ -279,4 +293,36 @@ export function useTimelineAIIntegration() {
   }, [timeline.isReady, timeline.project, getAllClips, getAllTracks, getProjectDuration])
 
   return result
+}
+
+function findMediaFileForClip(project: any, mediaId: string | undefined): any | undefined {
+  if (!project || !mediaId) return undefined
+
+  const resourceGroups = [project.resources?.music, project.resources?.media]
+  for (const resources of resourceGroups) {
+    if (!Array.isArray(resources)) continue
+
+    const resource = resources.find((item: any) => {
+      const file = item?.file && typeof item.file === "object" ? item.file : item
+      return item?.resourceId === mediaId || item?.id === mediaId || file?.id === mediaId
+    })
+    if (resource) {
+      return resource.file && typeof resource.file === "object" ? resource.file : resource
+    }
+  }
+
+  const mediaPoolItems = project.media_pool?.items ?? project.mediaPool?.items
+  const mediaPoolItem = mediaPoolItems?.[mediaId]
+  if (mediaPoolItem) {
+    return {
+      id: mediaPoolItem.id ?? mediaId,
+      name: mediaPoolItem.name ?? mediaId,
+      path: mediaPoolItem.path,
+      type: String(mediaPoolItem.media_type ?? mediaPoolItem.mediaType ?? "audio").toLowerCase(),
+      isAudio: String(mediaPoolItem.media_type ?? mediaPoolItem.mediaType ?? "").toLowerCase().includes("audio"),
+      duration: mediaPoolItem.duration ?? 0,
+    }
+  }
+
+  return undefined
 }


### PR DESCRIPTION
## Summary
- add music-workflow timeline AI tool for listing/selecting existing audio media and inserting it into a real Music track
- wire AI Chat TimelineStateAccess createTrack/addClip to real timeline mutations instead of fake local ids
- make sync-music fail clearly without real beat detection or explicit BPM/manual beat input, removing heuristic BPM and random beat markers

Stacked on #318.

Closes #312

## Validation
- bunx vitest run packages/domains/src/ai-tools/tools/core/timeline/__tests__/execution-path.test.ts src/features/ai-chat/hooks/__tests__/use-timeline-ai-integration.test.tsx src/features/ai-chat/utils/__tests__/convert-tools.test.ts
- bun run check:type
- bun run check:boundaries:strict
- git diff --check