### PR TITLE
Route bot audio media onto a dedicated Audio track

### DIFF
--- a/packages/core/src/services/__tests__/bot-project-assembler.test.ts
+++ b/packages/core/src/services/__tests__/bot-project-assembler.test.ts
@@ -104,6 +104,87 @@ describe("bot project assembler", () => {
     })
   })
 
+  it("splits audio media onto a dedicated Audio track and keeps the image on the Video track", () => {
+    const request: BotRenderJobRequest = {
+      source: "bot",
+      media: [
+        {
+          type: "file",
+          value: "/tmp/photo.jpg",
+          name: "photo.jpg",
+          mimeType: "image/jpeg",
+        },
+        {
+          type: "file",
+          value: "/tmp/music.mp3",
+          name: "music.mp3",
+          mimeType: "audio/mpeg",
+          metadata: { duration: 30 },
+        },
+      ],
+      params: { clipDurationSeconds: "5" },
+      output: { format: "mp4" },
+    }
+
+    const schema = createBotProjectSchemaFromRenderJob(request, {
+      now: () => "2026-06-08T00:00:00.000Z",
+    })
+
+    expect(schema?.tracks).toHaveLength(2)
+
+    const videoTrack = schema?.tracks[0]
+    expect(videoTrack).toMatchObject({ id: "bot-video-track", track_type: "Video" })
+    expect(videoTrack?.clips).toHaveLength(1)
+    expect(videoTrack?.clips[0]).toMatchObject({
+      source: { File: "/tmp/photo.jpg" },
+      start_time: 0,
+      end_time: 5,
+      source_start: 0,
+      source_end: 5,
+      properties: { custom_metadata: { mediaType: "image" } },
+    })
+
+    const audioTrack = schema?.tracks[1]
+    expect(audioTrack).toMatchObject({ id: "bot-audio-track", track_type: "Audio" })
+    expect(audioTrack?.clips).toHaveLength(1)
+    expect(audioTrack?.clips[0]).toMatchObject({
+      source: { File: "/tmp/music.mp3" },
+      start_time: 0,
+      source_start: 0,
+      source_end: 30,
+      end_time: 30,
+      template_id: null,
+      template_position: null,
+      properties: { custom_metadata: { mediaType: "audio" } },
+    })
+
+    // Timeline spans the longer music clip so the looping image is fully scored.
+    expect(schema?.timeline.duration).toBe(30)
+  })
+
+  it("detects audio media by file extension when no mimeType is provided", () => {
+    const request: BotRenderJobRequest = {
+      source: "bot",
+      media: [
+        { type: "file", value: "/tmp/slide.png" },
+        { type: "url", value: "https://cdn.example.com/score.wav?token=abc" },
+      ],
+      output: { format: "mp4" },
+    }
+
+    const schema = createBotProjectSchemaFromRenderJob(request)
+
+    expect(schema?.tracks).toHaveLength(2)
+    expect(schema?.tracks[0].track_type).toBe("Video")
+    expect(schema?.tracks[0].clips).toHaveLength(1)
+    expect(schema?.tracks[1].track_type).toBe("Audio")
+    expect(schema?.tracks[1].clips).toHaveLength(1)
+    expect(schema?.tracks[1].clips[0]).toMatchObject({
+      source: { Stream: "https://cdn.example.com/score.wav?token=abc" },
+      start_time: 0,
+    })
+  })
+
   it("hydrates render jobs without an explicit project", () => {
     const request: BotRenderJobRequest = {
       source: "bot",

--- a/packages/core/src/services/bot-project-assembler.ts
+++ b/packages/core/src/services/bot-project-assembler.ts
@@ -12,6 +12,11 @@ const DEFAULT_CLIP_DURATION_SECONDS = 5
 const DEFAULT_FPS = 30
 const DEFAULT_SAMPLE_RATE = 48000
 
+type MediaKind = "video" | "image" | "audio"
+
+const AUDIO_EXTENSIONS = new Set(["mp3", "wav", "aac", "m4a", "flac", "ogg"])
+const IMAGE_EXTENSIONS = new Set(["jpg", "jpeg", "png", "bmp", "webp"])
+
 export function withBotProjectSchema(
   request: BotRenderJobRequest,
   options: BotProjectAssemblyOptions = {},
@@ -43,18 +48,47 @@ export function createBotProjectSchemaFromRenderJob(
   const aspectRatio = resolveAspectRatio(resolution)
   const fps = options.fps ?? DEFAULT_FPS
   const sampleRate = options.sampleRate ?? DEFAULT_SAMPLE_RATE
-  const clips = media.map((item, index) => createClip(item, index, request, clipDuration))
-  const duration = Math.max(...clips.map((clip) => clip.end_time), clipDuration)
-  const track: Track = {
-    id: "bot-video-track",
-    track_type: "Video",
-    name: "Bot Video",
-    enabled: true,
-    volume: 1,
-    locked: false,
-    clips,
-    effects: [],
-    filters: [],
+
+  // Audio/music media must live on a dedicated Audio track, otherwise the Rust
+  // renderer treats it as a video input on the no-AI fallback path. Visual media
+  // (video + image) stays on the Video track and lays out sequentially.
+  const visualClips: Clip[] = []
+  const audioClips: Clip[] = []
+  media.forEach((item, index) => {
+    const kind = detectMediaKind(item)
+    if (kind === "audio") {
+      audioClips.push(createClip(item, index, audioClips.length, kind, request, clipDuration))
+    } else {
+      visualClips.push(createClip(item, index, visualClips.length, kind, request, clipDuration))
+    }
+  })
+
+  const duration = Math.max(...[...visualClips, ...audioClips].map((clip) => clip.end_time), clipDuration)
+  const tracks: Track[] = [
+    {
+      id: "bot-video-track",
+      track_type: "Video",
+      name: "Bot Video",
+      enabled: true,
+      volume: 1,
+      locked: false,
+      clips: visualClips,
+      effects: [],
+      filters: [],
+    },
+  ]
+  if (audioClips.length > 0) {
+    tracks.push({
+      id: "bot-audio-track",
+      track_type: "Audio",
+      name: "Bot Audio",
+      enabled: true,
+      volume: 1,
+      locked: false,
+      clips: audioClips,
+      effects: [],
+      filters: [],
+    })
   }
 
   return {
@@ -73,7 +107,7 @@ export function createBotProjectSchemaFromRenderJob(
       sample_rate: sampleRate,
       aspect_ratio: aspectRatio,
     },
-    tracks: [track],
+    tracks,
     effects: [],
     transitions: [],
     filters: [],
@@ -123,12 +157,19 @@ export function createBotProjectSchemaFromRenderJob(
 function createClip(
   media: BotRenderJobMediaInput,
   index: number,
+  position: number,
+  kind: MediaKind,
   request: BotRenderJobRequest,
-  duration: number,
+  clipDuration: number,
 ): Clip {
-  const start = index * duration
+  const isAudio = kind === "audio"
+  // Audio clips span the whole track from 0 for the music length; visual clips
+  // lay out sequentially by their position on the Video track.
+  const duration = isAudio ? resolveMediaDuration(media, clipDuration) : clipDuration
+  const start = isAudio ? 0 : position * clipDuration
   const customMetadata: Record<string, unknown> = {
     source: "bot",
+    mediaType: kind,
   }
 
   if (media.name) customMetadata.name = media.name
@@ -146,8 +187,8 @@ function createClip(
     opacity: 1,
     effects: [],
     filters: [],
-    template_id: request.templateId ?? null,
-    template_position: request.templateId ? index : null,
+    template_id: isAudio ? null : (request.templateId ?? null),
+    template_position: !isAudio && request.templateId ? position : null,
     color_correction: null,
     crop: null,
     transform: null,
@@ -158,6 +199,32 @@ function createClip(
       custom_metadata: customMetadata,
     },
   }
+}
+
+function detectMediaKind(media: BotRenderJobMediaInput): MediaKind {
+  const mimeType = media.mimeType?.toLowerCase().trim()
+  if (mimeType) {
+    if (mimeType.startsWith("audio/")) return "audio"
+    if (mimeType.startsWith("image/")) return "image"
+    if (mimeType.startsWith("video/")) return "video"
+  }
+
+  const extension = fileExtension(media.name ?? media.value)
+  if (AUDIO_EXTENSIONS.has(extension)) return "audio"
+  if (IMAGE_EXTENSIONS.has(extension)) return "image"
+
+  return "video"
+}
+
+function fileExtension(pathOrName: string): string {
+  const withoutQuery = pathOrName.split(/[?#]/, 1)[0]
+  const base = withoutQuery.slice(Math.max(withoutQuery.lastIndexOf("/"), withoutQuery.lastIndexOf("\\")) + 1)
+  const dot = base.lastIndexOf(".")
+  return dot >= 0 ? base.slice(dot + 1).toLowerCase() : ""
+}
+
+function resolveMediaDuration(media: BotRenderJobMediaInput, fallback: number): number {
+  return positiveNumber(media.metadata?.duration) ?? fallback
 }
 
 function createClipSource(media: BotRenderJobMediaInput): Clip["source"] {


### PR DESCRIPTION
## Что и зачем

Детерминированный fallback-ассемблер бот-проектов `createBotProjectSchemaFromRenderJob` (`packages/core/src/services/bot-project-assembler.ts`) клал **все** входные медиа — включая музыку/аудио — клипами на единственный Video-трек. Из-за этого Rust-рендер на no-AI пути воспринимал музыку как видео-вход (`scale=...` падает, аудио не муксится).

Это последний TS-side пробел no-AI пути: сам Rust-движок уже починен для зацикливания изображений и одиночного аудио-трека (`crates/ts-render/.../ffmpeg_builder/{inputs,filters}.rs`).

## Изменения

- **`detectMediaKind`** — определяет тип медиа по префиксу `mimeType`, затем по расширению файла:
  - audio: `mp3/wav/aac/m4a/flac/ogg`
  - image: `jpg/jpeg/png/bmp/webp`
  - иначе video
- **Аудио** → отдельный трек `bot-audio-track` (`track_type: "Audio"`), клип со `start_time 0`, `source_start 0`, `source_end = metadata.duration ?? clipDuration`.
- **Видео/изображения** остаются на `bot-video-track` и раскладываются последовательно, как раньше.
- Audio-трек добавляется только при наличии аудио (видео-only джобы без изменений). Длительность таймлайна теперь покрывает оба трека — зацикленное фото полностью озвучивается музыкой.
- В `custom_metadata` каждого клипа добавлен `mediaType`.

Изменения минимальны и не выходят за существующий контракт `ProjectSchema` (`src/types/contracts/project-schema.ts`) — правок схемы не требуется.

## Тесты

Расширены unit-тесты `bot-project-assembler`:
1. photo (`image/jpeg`) + music (`audio/mpeg`, `metadata.duration: 30`) → один Video-трек (image, 0–5с) + один Audio-трек (music, 0–30с), длительность таймлайна 30.
2. Определение аудио только по расширению (без mimeType): `slide.png` → Video, `score.wav?token=abc` (URL) → Audio как `Stream`.

## Проверка

- `vitest` bot-project-assembler → 5/5 ✅
- Полный `src/services` → 69/69 ✅
- `npm run check:type` (tsc) → чисто (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)