### PR TITLE
Fix Telegram bot video render: photo, music, subtitles

### DIFF
--- a/crates/ts-render/src/video_compiler/core/ffmpeg_builder/builder.rs
+++ b/crates/ts-render/src/video_compiler/core/ffmpeg_builder/builder.rs
@@ -61,16 +61,28 @@ impl FFmpegBuilder {
   pub async fn build_render_command(&self, output_path: &Path) -> Result<Command> {
     let mut cmd = Command::new(&self.settings.ffmpeg_path);
 
+    // Субтитры выжигаются фильтром drawtext, которого нет, если ffmpeg собран без libfreetype.
+    // Чтобы из-за этого не падал ВЕСЬ рендер ("No such filter: 'drawtext'"), при отсутствии
+    // фильтра рендерим без субтитров. Проба ffmpeg делается только когда субтитры реально есть.
+    let drawtext_ok = self.project.subtitles.is_empty() || self.drawtext_available();
+    if !drawtext_ok {
+      log::warn!(
+        "FFmpeg '{}' не содержит фильтр drawtext (нет libfreetype) — рендер без выжженных субтитров",
+        self.settings.ffmpeg_path
+      );
+    }
+    let project = project_without_unsupported_subtitles(&self.project, drawtext_ok);
+
     // Добавляем входные файлы
-    let input_builder = InputBuilder::new(&self.project);
+    let input_builder = InputBuilder::new(&project);
     input_builder.add_input_sources(&mut cmd).await?;
 
     // Добавляем фильтры
-    let filter_builder = FilterBuilder::new(&self.project);
+    let filter_builder = FilterBuilder::new(&project);
     filter_builder.add_filter_complex(&mut cmd).await?;
 
     // Добавляем настройки вывода
-    let output_builder = OutputBuilder::new(&self.project, &self.settings);
+    let output_builder = OutputBuilder::new(&project, &self.settings);
     output_builder
       .add_output_settings(&mut cmd, output_path)
       .await?;
@@ -79,6 +91,20 @@ impl FFmpegBuilder {
     self.add_global_options(&mut cmd);
 
     Ok(cmd)
+  }
+
+  /// Доступен ли в текущем ffmpeg фильтр `drawtext` (нужен libfreetype) для выжигания субтитров.
+  /// Переопределяется переменной окружения `TIMELINE_ASSUME_DRAWTEXT` (1/0) — например, чтобы
+  /// не запускать пробу в окружении без ffmpeg.
+  fn drawtext_available(&self) -> bool {
+    if let Ok(v) = std::env::var("TIMELINE_ASSUME_DRAWTEXT") {
+      return !(v == "0" || v.eq_ignore_ascii_case("false"));
+    }
+    std::process::Command::new(&self.settings.ffmpeg_path)
+      .args(["-hide_banner", "-loglevel", "error", "-filters"])
+      .output()
+      .map(|o| String::from_utf8_lossy(&o.stdout).contains("drawtext"))
+      .unwrap_or(false)
   }
 
   /// Построить команду для генерации превью
@@ -177,6 +203,21 @@ impl FFmpegBuilder {
   /// Получить проект
   pub fn project(&self) -> &ProjectSchema {
     &self.project
+  }
+}
+
+/// Вернуть проект без субтитров, если их выжигание невозможно (нет фильтра drawtext).
+/// Заимствует исходный проект без копирования, когда субтитров нет или они поддерживаются.
+fn project_without_unsupported_subtitles(
+  project: &ProjectSchema,
+  drawtext_available: bool,
+) -> std::borrow::Cow<'_, ProjectSchema> {
+  if project.subtitles.is_empty() || drawtext_available {
+    std::borrow::Cow::Borrowed(project)
+  } else {
+    let mut stripped = project.clone();
+    stripped.subtitles.clear();
+    std::borrow::Cow::Owned(stripped)
   }
 }
 
@@ -343,6 +384,29 @@ mod tests {
     // Проверяем что команда содержит основные элементы сегмента
     assert!(args.contains(&"-y".to_string()));
     assert!(args.contains(&"-hide_banner".to_string()));
+  }
+
+  #[test]
+  fn test_project_without_unsupported_subtitles() {
+    let mut project = create_minimal_project();
+    project.subtitles.push(crate::video_compiler::schema::Subtitle::new(
+      "hi".to_string(),
+      0.0,
+      2.0,
+    ));
+
+    // drawtext доступен → субтитры сохраняются, проект заимствуется без клона.
+    let kept = project_without_unsupported_subtitles(&project, true);
+    assert_eq!(kept.subtitles.len(), 1);
+    assert!(matches!(kept, std::borrow::Cow::Borrowed(_)));
+
+    // drawtext недоступен → субтитры убираем, чтобы рендер не падал целиком.
+    let stripped = project_without_unsupported_subtitles(&project, false);
+    assert!(stripped.subtitles.is_empty());
+    assert!(matches!(stripped, std::borrow::Cow::Owned(_)));
+
+    // исходный проект не мутируется
+    assert_eq!(project.subtitles.len(), 1);
   }
 
   #[test]

--- a/crates/ts-render/src/video_compiler/core/ffmpeg_builder/filters.rs
+++ b/crates/ts-render/src/video_compiler/core/ffmpeg_builder/filters.rs
@@ -3,7 +3,7 @@
 use tokio::process::Command;
 
 use crate::video_compiler::error::Result;
-use crate::video_compiler::schema::{Clip, ProjectSchema, Track, TrackType, Transition};
+use crate::video_compiler::schema::{Clip, ClipSource, ProjectSchema, Track, TrackType, Transition};
 
 use super::effects::EffectBuilder;
 use super::subtitles::SubtitleBuilder;
@@ -34,12 +34,10 @@ impl<'a> FilterBuilder<'a> {
 
       // Маппинг выходов
       let has_video = self.has_video_tracks();
-      // Аудио на выходе: отдельные audio-треки ИЛИ встроенное аудио видео-клипов.
-      let has_audio = self.has_audio_tracks()
-        || self
-          .get_video_tracks()
-          .iter()
-          .any(|t| t.enabled && !t.clips.is_empty());
+      // Аудио на выходе мапим ТОЛЬКО если граф реально его произведёт, иначе `-map [outa]`
+      // ссылается на несуществующий поток и FFmpeg падает (частый случай: фото без музыки —
+      // у изображения нет аудиодорожки).
+      let has_audio = self.audio_output_present();
       let has_subtitles = !self.project.subtitles.is_empty();
 
       if has_video {
@@ -241,69 +239,103 @@ impl<'a> FilterBuilder<'a> {
   }
 
   /// Аудио из встроенных дорожек видео-клипов (когда отдельных audio-треков нет).
-  /// Индексы входов совпадают с видео-клипами (0..N), т.к. этот путь работает только
-  /// при `!has_audio_tracks()`. Допущение: видео-клипы содержат аудиодорожку — клипы без
-  /// звука пока не отсеиваются (потребуют ffprobe); для видео-со-звуком покрывает типичный случай.
+  /// Индексы входов совпадают с порядком File-клипов (0..N) — ровно так их нумерует
+  /// `InputBuilder`. Клипы-изображения пропускаем: у фото нет аудиопотока, и ссылка
+  /// `[i:a]` на него уронила бы рендер. Не-File источники не становятся входами FFmpeg.
   fn build_video_clips_audio_chain(&self) -> String {
-    let count: usize = self
-      .get_video_tracks()
-      .iter()
-      .filter(|t| t.enabled)
-      .map(|t| t.clips.len())
-      .sum();
-    match count {
-      0 => String::new(),
-      1 => "[0:a]anull[outa]".to_string(),
-      n => {
-        let inputs: String = (0..n).map(|i| format!("[{i}:a]")).collect();
-        format!("{inputs}concat=n={n}:v=0:a=1[outa]")
+    let mut labels: Vec<String> = Vec::new();
+    let mut input_index = 0usize;
+
+    for track in self.get_video_tracks() {
+      if !track.enabled {
+        continue;
       }
+      for clip in &track.clips {
+        // Индекс входа выделяется только File-клипам (см. InputBuilder::collect_input_sources).
+        if matches!(&clip.source, ClipSource::File(_)) {
+          if Self::clip_provides_embedded_audio(&clip.source) {
+            labels.push(format!("[{input_index}:a]"));
+          }
+          input_index += 1;
+        }
+      }
+    }
+
+    match labels.len() {
+      0 => String::new(),
+      1 => format!("{}anull[outa]", labels[0]),
+      n => format!("{}concat=n={n}:v=0:a=1[outa]", labels.join("")),
     }
   }
 
-  /// Построить цепочку аудио фильтров
+  /// Построить цепочку аудио фильтров.
+  ///
+  /// Симметрично видео-цепочке: каждый аудиоклип даёт тело с меткой `[a{i}]`, затем клипы
+  /// трека склеиваются `concat` с ЯВНЫМ перечислением входных меток, а треки сводятся `amix`.
+  /// Метки обязательны — без них ffmpeg падает с «No such filter: ''» (ровно эта ошибка уже
+  /// была вычищена в видео-пути; в аудио-пути её пропустили: `;concat=` без входов и финальный
+  /// `[atrack0][outa]` без фильтра между метками).
   async fn build_audio_filter_chain(&self, input_index: &mut usize) -> Result<String> {
     let mut filters = Vec::new();
+    let mut track_labels: Vec<String> = Vec::new();
     let audio_tracks = self.get_audio_tracks();
 
-    for (track_idx, track) in audio_tracks.iter().enumerate() {
+    for track in audio_tracks.iter() {
       if !track.enabled {
         continue;
       }
 
-      let mut track_filters = Vec::new();
+      let mut clip_chains: Vec<String> = Vec::new();
+      let mut clip_labels: Vec<String> = Vec::new();
 
       for clip in &track.clips {
         let clip_filter = self.build_audio_clip_filter(clip, *input_index).await?;
-        track_filters.push(clip_filter);
+        clip_chains.push(clip_filter);
+        clip_labels.push(format!("[a{}]", *input_index));
         *input_index += 1;
       }
 
-      // Объединяем клипы трека
-      if !track_filters.is_empty() {
-        let track_filter = format!(
-          "{};concat=n={}:v=0:a=1[atrack{}]",
-          track_filters.join(";"),
-          track_filters.len(),
-          track_idx
-        );
-        filters.push(track_filter);
+      if clip_chains.is_empty() {
+        continue;
       }
+
+      let track_label = format!("atrack{}", track_labels.len());
+      let chain = if clip_labels.len() == 1 {
+        // один клип на треке — переименовываем его выход null-фильтром (без лишнего concat)
+        format!(
+          "{};{}anull[{}]",
+          clip_chains.join(";"),
+          clip_labels[0],
+          track_label
+        )
+      } else {
+        // несколько клипов — склейка concat с ВХОДНЫМИ метками
+        format!(
+          "{};{}concat=n={}:v=0:a=1[{}]",
+          clip_chains.join(";"),
+          clip_labels.join(""),
+          clip_labels.len(),
+          track_label
+        )
+      };
+      filters.push(chain);
+      track_labels.push(format!("[{track_label}]"));
     }
 
-    // Смешиваем аудио треки
-    if filters.len() > 1 {
-      let mix_filter = format!(
-        "{}amix=inputs={}[outa]",
-        (0..filters.len())
-          .map(|i| format!("[atrack{i}]"))
-          .collect::<Vec<_>>()
-          .join(""),
-        filters.len()
-      );
-      filters.push(mix_filter);
-    } else if filters.len() == 1 {
-      filters.push("[atrack0][outa]".to_string());
+    // Сводим аудио треки в [outa]
+    match track_labels.len() {
+      0 => {}
+      1 => {
+        // один трек — переименовываем его выход в [outa] null-фильтром
+        filters.push(format!("{}anull[outa]", track_labels[0]));
+      }
+      _ => {
+        filters.push(format!(
+          "{}amix=inputs={}[outa]",
+          track_labels.join(""),
+          track_labels.len()
+        ));
+      }
     }
 
     Ok(filters.join(";"))
@@ -515,6 +547,34 @@ impl<'a> FilterBuilder<'a> {
       .iter()
       .filter(|t| t.track_type == TrackType::Audio)
       .collect()
+  }
+
+  /// Содержит ли File-клип собственную аудиодорожку.
+  /// Только File-клипы становятся входами FFmpeg; фото беззвучны, поэтому исключаются.
+  fn clip_provides_embedded_audio(source: &ClipSource) -> bool {
+    matches!(source, ClipSource::File(p) if !super::is_image_path(p))
+  }
+
+  /// Будет ли в filtergraph реально получен аудиовыход `[outa]`.
+  ///
+  /// Должно точно совпадать с логикой `build_filter_complex`: при наличии аудио-треков
+  /// аудио берётся из них (нужен хотя бы один клип), иначе — из встроенного звука
+  /// неизображённых видео-клипов. Иначе `-map [outa]` сошлётся на несуществующий поток.
+  fn audio_output_present(&self) -> bool {
+    if self.has_audio_tracks() {
+      self
+        .get_audio_tracks()
+        .iter()
+        .any(|t| t.enabled && !t.clips.is_empty())
+    } else {
+      self.get_video_tracks().iter().any(|t| {
+        t.enabled
+          && t
+            .clips
+            .iter()
+            .any(|c| Self::clip_provides_embedded_audio(&c.source))
+      })
+    }
   }
 }
 
@@ -974,6 +1034,137 @@ mod tests {
     let filter = result.unwrap();
     // Должен содержать amix для смешивания треков
     assert!(filter.contains("amix"));
+  }
+
+  #[tokio::test]
+  async fn test_build_audio_filter_chain_single_track_is_valid() {
+    let mut project = create_minimal_project();
+
+    let mut audio_track = Track::new(TrackType::Audio, "Music".to_string());
+    audio_track
+      .clips
+      .push(Clip::new(std::path::PathBuf::from("/tmp/music.mp3"), 0.0, 5.0));
+    project.tracks.push(audio_track);
+
+    let builder = FilterBuilder::new(&project);
+    let mut input_index = 0;
+    let filter = builder
+      .build_audio_filter_chain(&mut input_index)
+      .await
+      .unwrap();
+
+    // Метка клипа существует и корректно сводится в [outa] через anull.
+    assert!(filter.contains("[a0]"), "filter was: {filter}");
+    assert!(filter.contains("anull[outa]"), "filter was: {filter}");
+    // Регрессия: ранее генерировались невалидные участки графа.
+    assert!(
+      !filter.contains("[atrack0][outa]"),
+      "label-only segment must not appear: {filter}"
+    );
+    assert!(
+      !filter.contains(";concat="),
+      "concat must list input labels: {filter}"
+    );
+  }
+
+  #[test]
+  fn test_build_video_clips_audio_chain_skips_images() {
+    let mut project = create_minimal_project();
+
+    let mut video_track = Track::new(TrackType::Video, "Video".to_string());
+    // index 0 — фото (без звука), index 1 — видео (со звуком)
+    video_track
+      .clips
+      .push(Clip::new(std::path::PathBuf::from("/tmp/photo.jpg"), 0.0, 5.0));
+    video_track
+      .clips
+      .push(Clip::new(std::path::PathBuf::from("/tmp/clip.mp4"), 5.0, 5.0));
+    project.tracks.push(video_track);
+
+    let builder = FilterBuilder::new(&project);
+    let chain = builder.build_video_clips_audio_chain();
+
+    // Фото пропущено: ссылаемся только на аудио видеоклипа (вход 1).
+    assert!(chain.contains("[1:a]"), "chain was: {chain}");
+    assert!(!chain.contains("[0:a]"), "image must be skipped: {chain}");
+    assert!(chain.contains("anull[outa]"), "chain was: {chain}");
+  }
+
+  #[test]
+  fn test_audio_output_present() {
+    // Только фото, без аудио-трека → аудиовыхода нет.
+    let mut photo_only = create_minimal_project();
+    let mut video_track = Track::new(TrackType::Video, "Video".to_string());
+    video_track
+      .clips
+      .push(Clip::new(std::path::PathBuf::from("/tmp/photo.jpg"), 0.0, 5.0));
+    photo_only.tracks.push(video_track);
+    assert!(!FilterBuilder::new(&photo_only).audio_output_present());
+
+    // Фото + музыка → аудиовыход есть.
+    let mut with_music = photo_only.clone();
+    let mut audio_track = Track::new(TrackType::Audio, "Music".to_string());
+    audio_track
+      .clips
+      .push(Clip::new(std::path::PathBuf::from("/tmp/music.mp3"), 0.0, 5.0));
+    with_music.tracks.push(audio_track);
+    assert!(FilterBuilder::new(&with_music).audio_output_present());
+  }
+
+  #[tokio::test]
+  async fn test_add_filter_complex_photo_music_subtitles() {
+    // Полный сценарий бота: фото (видео) + музыка (аудио) + субтитр.
+    let mut project = create_minimal_project();
+
+    let mut video = Track::new(TrackType::Video, "Video".to_string());
+    video
+      .clips
+      .push(Clip::new(std::path::PathBuf::from("/tmp/photo.jpg"), 0.0, 5.0));
+    let mut audio = Track::new(TrackType::Audio, "Music".to_string());
+    audio
+      .clips
+      .push(Clip::new(std::path::PathBuf::from("/tmp/music.mp3"), 0.0, 5.0));
+    project.tracks.push(video);
+    project.tracks.push(audio);
+    project.subtitles.push(crate::video_compiler::schema::Subtitle::new(
+      "Привет".to_string(),
+      0.0,
+      5.0,
+    ));
+
+    let builder = FilterBuilder::new(&project);
+    let mut cmd = Command::new("ffmpeg");
+    builder.add_filter_complex(&mut cmd).await.unwrap();
+
+    let args: Vec<String> = cmd
+      .as_std()
+      .get_args()
+      .map(|s| s.to_string_lossy().to_string())
+      .collect();
+
+    let fc_idx = args
+      .iter()
+      .position(|a| a == "-filter_complex")
+      .expect("filter_complex must be present");
+    let fc = &args[fc_idx + 1];
+
+    // Субтитр выжигается (drawtext) и даёт отдельный видеовыход.
+    assert!(fc.contains("drawtext"), "subtitle burn-in missing: {fc}");
+    assert!(fc.contains("[outv_with_subs]"), "subtitle output missing: {fc}");
+    // Аудио сведено в [outa].
+    assert!(fc.contains("[outa]"), "audio output missing: {fc}");
+    // Граф не содержит регрессионных «пустых» участков.
+    assert!(!fc.contains(";concat="), "concat without inputs: {fc}");
+
+    // Маппинг выходов: видео-с-субтитрами + аудио.
+    assert!(
+      args.windows(2).any(|w| w[0] == "-map" && w[1] == "[outv_with_subs]"),
+      "args: {args:?}"
+    );
+    assert!(
+      args.windows(2).any(|w| w[0] == "-map" && w[1] == "[outa]"),
+      "args: {args:?}"
+    );
   }
 
   #[tokio::test]

--- a/crates/ts-render/src/video_compiler/core/ffmpeg_builder/inputs.rs
+++ b/crates/ts-render/src/video_compiler/core/ffmpeg_builder/inputs.rs
@@ -6,6 +6,10 @@ use tokio::process::Command;
 use crate::video_compiler::error::Result;
 use crate::video_compiler::schema::{ClipSource, ProjectSchema, TrackType};
 
+/// Длительность показа фото по умолчанию, если у клипа не задана корректная длительность.
+/// Нужна как страховка от бесконечного `-loop 1` без `-t`.
+const DEFAULT_IMAGE_DURATION_SECONDS: f64 = 5.0;
+
 /// Информация о входном источнике
 #[derive(Debug, Clone)]
 pub struct InputSource {
@@ -61,25 +65,46 @@ impl<'a> InputBuilder<'a> {
   fn add_input_source(&self, cmd: &mut Command, source: &InputSource) -> Result<()> {
     // --- Опции ВХОДА: обязаны идти ДО -i ---
 
-    // Время начала чтения источника
-    if source.start_time > 0.0 {
-      cmd.args(["-ss", &source.start_time.to_string()]);
-    }
+    let path = source.path.to_string_lossy();
+    let is_image = matches!(source.track_type, TrackType::Video) && super::is_image_path(&path);
 
-    // Ограничение длительности чтения ВХОДА.
-    // ВАЖНО: -t обязан стоять ДО -i — иначе это ВЫХОДНАЯ опция и обрезает весь рендер
-    // до длины последнего клипа (был баг мультиклипа: 3×2с давали выход 2с).
-    if source.duration > 0.0 {
-      cmd.args(["-t", &source.duration.to_string()]);
-    }
+    if is_image {
+      // Статичное фото: зацикливаем единственный кадр и задаём частоту кадров входа.
+      // Без `-loop 1` FFmpeg декодирует ровно один кадр, `-t` ни на что не влияет,
+      // и на выходе получается ~1 кадр вместо клипа нужной длины.
+      cmd.args(["-loop", "1"]);
+      cmd.args(["-framerate", &self.project.settings.frame_rate.to_string()]);
 
-    // Аппаратное декодирование — тоже опция входа (до -i)
-    if matches!(source.track_type, TrackType::Video) && self.should_use_hardware_decoding() {
-      cmd.args(["-hwaccel", "auto"]);
+      // Длительность показа фото (опция ВХОДА, до -i — ограничивает бесконечный цикл).
+      let duration = if source.duration > 0.0 {
+        source.duration
+      } else {
+        DEFAULT_IMAGE_DURATION_SECONDS
+      };
+      cmd.args(["-t", &duration.to_string()]);
+
+      // У фото нет временно́й оси — `-ss`/`-hwaccel` не применяем.
+    } else {
+      // Время начала чтения источника
+      if source.start_time > 0.0 {
+        cmd.args(["-ss", &source.start_time.to_string()]);
+      }
+
+      // Ограничение длительности чтения ВХОДА.
+      // ВАЖНО: -t обязан стоять ДО -i — иначе это ВЫХОДНАЯ опция и обрезает весь рендер
+      // до длины последнего клипа (был баг мультиклипа: 3×2с давали выход 2с).
+      if source.duration > 0.0 {
+        cmd.args(["-t", &source.duration.to_string()]);
+      }
+
+      // Аппаратное декодирование — тоже опция входа (до -i)
+      if matches!(source.track_type, TrackType::Video) && self.should_use_hardware_decoding() {
+        cmd.args(["-hwaccel", "auto"]);
+      }
     }
 
     // Входной файл
-    cmd.args(["-i", &source.path.to_string_lossy()]);
+    cmd.args(["-i", &path]);
 
     Ok(())
   }
@@ -378,6 +403,88 @@ mod tests {
 
     assert!(args.contains(&"-i".to_string()));
     assert!(args.contains(&"/test/audio.mp3".to_string()));
+  }
+
+  #[test]
+  fn test_add_input_source_image_loops() {
+    let project = create_minimal_project();
+    let builder = InputBuilder::new(&project);
+    let mut cmd = Command::new("ffmpeg");
+
+    let source = InputSource {
+      path: PathBuf::from("/test/photo.jpg"),
+      start_time: 0.0,
+      duration: 5.0,
+      track_type: TrackType::Video,
+    };
+
+    builder.add_input_source(&mut cmd, &source).unwrap();
+
+    let args: Vec<String> = cmd
+      .as_std()
+      .get_args()
+      .map(|s| s.to_string_lossy().to_string())
+      .collect();
+
+    // Фото обязано зацикливаться и иметь частоту кадров + ограничение длительности.
+    assert!(args.contains(&"-loop".to_string()));
+    assert!(args.contains(&"1".to_string()));
+    assert!(args.contains(&"-framerate".to_string()));
+    assert!(args.contains(&"-t".to_string()));
+    assert!(args.contains(&"5".to_string()));
+    assert!(args.contains(&"/test/photo.jpg".to_string()));
+  }
+
+  #[test]
+  fn test_add_input_source_image_uses_default_duration() {
+    let project = create_minimal_project();
+    let builder = InputBuilder::new(&project);
+    let mut cmd = Command::new("ffmpeg");
+
+    // Длительность не задана (0.0) — фото всё равно не должно зацикливаться бесконечно.
+    let source = InputSource {
+      path: PathBuf::from("/test/photo.png"),
+      start_time: 0.0,
+      duration: 0.0,
+      track_type: TrackType::Video,
+    };
+
+    builder.add_input_source(&mut cmd, &source).unwrap();
+
+    let args: Vec<String> = cmd
+      .as_std()
+      .get_args()
+      .map(|s| s.to_string_lossy().to_string())
+      .collect();
+
+    assert!(args.contains(&"-loop".to_string()));
+    assert!(args.contains(&"-t".to_string()));
+    assert!(args.contains(&"5".to_string())); // DEFAULT_IMAGE_DURATION_SECONDS
+  }
+
+  #[test]
+  fn test_add_input_source_video_does_not_loop() {
+    let project = create_minimal_project();
+    let builder = InputBuilder::new(&project);
+    let mut cmd = Command::new("ffmpeg");
+
+    let source = InputSource {
+      path: PathBuf::from("/test/clip.mp4"),
+      start_time: 0.0,
+      duration: 5.0,
+      track_type: TrackType::Video,
+    };
+
+    builder.add_input_source(&mut cmd, &source).unwrap();
+
+    let args: Vec<String> = cmd
+      .as_std()
+      .get_args()
+      .map(|s| s.to_string_lossy().to_string())
+      .collect();
+
+    assert!(!args.contains(&"-loop".to_string()));
+    assert!(!args.contains(&"-framerate".to_string()));
   }
 
   #[tokio::test]

--- a/crates/ts-render/src/video_compiler/core/ffmpeg_builder/mod.rs
+++ b/crates/ts-render/src/video_compiler/core/ffmpeg_builder/mod.rs
@@ -21,3 +21,36 @@ pub mod templates;
 
 // Re-export main types
 pub use builder::FFmpegBuilder;
+
+/// Является ли путь статичным изображением (фото) по расширению.
+///
+/// Такие входы FFmpeg обязан зацикливать (`-loop 1` + `-t`), иначе из одного кадра
+/// получится клип длиной ~1 кадр вместо нужной длительности. `gif` намеренно исключён —
+/// анимированные gif декодируются как последовательность видео-кадров.
+pub(crate) fn is_image_path(path: &str) -> bool {
+  let ext = std::path::Path::new(path)
+    .extension()
+    .and_then(|e| e.to_str())
+    .map(|e| e.to_ascii_lowercase());
+  matches!(
+    ext.as_deref(),
+    Some("jpg" | "jpeg" | "png" | "bmp" | "webp" | "tif" | "tiff" | "heic" | "heif")
+  )
+}
+
+#[cfg(test)]
+mod mod_tests {
+  use super::is_image_path;
+
+  #[test]
+  fn test_is_image_path() {
+    assert!(is_image_path("/tmp/photo.jpg"));
+    assert!(is_image_path("/tmp/photo.JPEG"));
+    assert!(is_image_path("a.png"));
+    assert!(is_image_path("/x/y.webp"));
+    assert!(!is_image_path("/tmp/clip.mp4"));
+    assert!(!is_image_path("/tmp/music.mp3"));
+    assert!(!is_image_path("/tmp/anim.gif"));
+    assert!(!is_image_path("/tmp/noext"));
+  }
+}

--- a/packages/core/src/services/__tests__/bot-project-assembler.test.ts
+++ b/packages/core/src/services/__tests__/bot-project-assembler.test.ts
@@ -104,6 +104,38 @@ describe("bot project assembler", () => {
     })
   })
 
+  it("puts audio media on a separate Audio track (photo + music)", () => {
+    const request: BotRenderJobRequest = {
+      source: "bot",
+      media: [
+        { type: "file", value: "/tmp/photo.jpg", name: "photo.jpg", mimeType: "image/jpeg" },
+        { type: "file", value: "/tmp/music.mp3", name: "music.mp3", mimeType: "audio/mpeg" },
+        // без mimeType — определяется по расширению
+        { type: "file", value: "/tmp/track.flac" },
+      ],
+      output: { format: "mp4" },
+      params: { clipDurationSeconds: "5" },
+    }
+
+    const schema = createBotProjectSchemaFromRenderJob(request)
+    expect(schema).not.toBeNull()
+
+    const videoTrack = schema!.tracks.find((t) => t.track_type === "Video")
+    const audioTrack = schema!.tracks.find((t) => t.track_type === "Audio")
+
+    expect(videoTrack?.id).toBe("bot-video-track")
+    expect(videoTrack?.clips).toHaveLength(1)
+    expect(videoTrack?.clips[0]?.source).toEqual({ File: "/tmp/photo.jpg" })
+
+    expect(audioTrack?.id).toBe("bot-audio-track")
+    expect(audioTrack?.clips).toHaveLength(2)
+    expect(audioTrack?.clips[0]?.source).toEqual({ File: "/tmp/music.mp3" })
+    expect(audioTrack?.clips[1]?.source).toEqual({ File: "/tmp/track.flac" })
+    // аудио-клипы нумеруются независимо (последовательно внутри своего трека)
+    expect(audioTrack?.clips[0]?.start_time).toBe(0)
+    expect(audioTrack?.clips[1]?.start_time).toBe(5)
+  })
+
   it("hydrates render jobs without an explicit project", () => {
     const request: BotRenderJobRequest = {
       source: "bot",

--- a/packages/core/src/services/__tests__/bot-project-assembler.test.ts
+++ b/packages/core/src/services/__tests__/bot-project-assembler.test.ts
@@ -104,36 +104,85 @@ describe("bot project assembler", () => {
     })
   })
 
-  it("puts audio media on a separate Audio track (photo + music)", () => {
+  it("splits audio media onto a dedicated Audio track and keeps the image on the Video track", () => {
     const request: BotRenderJobRequest = {
       source: "bot",
       media: [
-        { type: "file", value: "/tmp/photo.jpg", name: "photo.jpg", mimeType: "image/jpeg" },
-        { type: "file", value: "/tmp/music.mp3", name: "music.mp3", mimeType: "audio/mpeg" },
-        // без mimeType — определяется по расширению
-        { type: "file", value: "/tmp/track.flac" },
+        {
+          type: "file",
+          value: "/tmp/photo.jpg",
+          name: "photo.jpg",
+          mimeType: "image/jpeg",
+        },
+        {
+          type: "file",
+          value: "/tmp/music.mp3",
+          name: "music.mp3",
+          mimeType: "audio/mpeg",
+          metadata: { duration: 30 },
+        },
+      ],
+      params: { clipDurationSeconds: "5" },
+      output: { format: "mp4" },
+    }
+
+    const schema = createBotProjectSchemaFromRenderJob(request, {
+      now: () => "2026-06-08T00:00:00.000Z",
+    })
+
+    expect(schema?.tracks).toHaveLength(2)
+
+    const videoTrack = schema?.tracks[0]
+    expect(videoTrack).toMatchObject({ id: "bot-video-track", track_type: "Video" })
+    expect(videoTrack?.clips).toHaveLength(1)
+    expect(videoTrack?.clips[0]).toMatchObject({
+      source: { File: "/tmp/photo.jpg" },
+      start_time: 0,
+      end_time: 5,
+      source_start: 0,
+      source_end: 5,
+      properties: { custom_metadata: { mediaType: "image" } },
+    })
+
+    const audioTrack = schema?.tracks[1]
+    expect(audioTrack).toMatchObject({ id: "bot-audio-track", track_type: "Audio" })
+    expect(audioTrack?.clips).toHaveLength(1)
+    expect(audioTrack?.clips[0]).toMatchObject({
+      source: { File: "/tmp/music.mp3" },
+      start_time: 0,
+      source_start: 0,
+      source_end: 30,
+      end_time: 30,
+      template_id: null,
+      template_position: null,
+      properties: { custom_metadata: { mediaType: "audio" } },
+    })
+
+    // Timeline spans the longer music clip so the looping image is fully scored.
+    expect(schema?.timeline.duration).toBe(30)
+  })
+
+  it("detects audio media by file extension when no mimeType is provided", () => {
+    const request: BotRenderJobRequest = {
+      source: "bot",
+      media: [
+        { type: "file", value: "/tmp/slide.png" },
+        { type: "url", value: "https://cdn.example.com/score.wav?token=abc" },
       ],
       output: { format: "mp4" },
-      params: { clipDurationSeconds: "5" },
     }
 
     const schema = createBotProjectSchemaFromRenderJob(request)
-    expect(schema).not.toBeNull()
 
-    const videoTrack = schema!.tracks.find((t) => t.track_type === "Video")
-    const audioTrack = schema!.tracks.find((t) => t.track_type === "Audio")
-
-    expect(videoTrack?.id).toBe("bot-video-track")
-    expect(videoTrack?.clips).toHaveLength(1)
-    expect(videoTrack?.clips[0]?.source).toEqual({ File: "/tmp/photo.jpg" })
-
-    expect(audioTrack?.id).toBe("bot-audio-track")
-    expect(audioTrack?.clips).toHaveLength(2)
-    expect(audioTrack?.clips[0]?.source).toEqual({ File: "/tmp/music.mp3" })
-    expect(audioTrack?.clips[1]?.source).toEqual({ File: "/tmp/track.flac" })
-    // аудио-клипы нумеруются независимо (последовательно внутри своего трека)
-    expect(audioTrack?.clips[0]?.start_time).toBe(0)
-    expect(audioTrack?.clips[1]?.start_time).toBe(5)
+    expect(schema?.tracks).toHaveLength(2)
+    expect(schema?.tracks[0].track_type).toBe("Video")
+    expect(schema?.tracks[0].clips).toHaveLength(1)
+    expect(schema?.tracks[1].track_type).toBe("Audio")
+    expect(schema?.tracks[1].clips).toHaveLength(1)
+    expect(schema?.tracks[1].clips[0]).toMatchObject({
+      source: { Stream: "https://cdn.example.com/score.wav?token=abc" },
+      start_time: 0,
+    })
   })
 
   it("hydrates render jobs without an explicit project", () => {

--- a/packages/core/src/services/bot-project-assembler.ts
+++ b/packages/core/src/services/bot-project-assembler.ts
@@ -12,6 +12,11 @@ const DEFAULT_CLIP_DURATION_SECONDS = 5
 const DEFAULT_FPS = 30
 const DEFAULT_SAMPLE_RATE = 48000
 
+type MediaKind = "video" | "image" | "audio"
+
+const AUDIO_EXTENSIONS = new Set(["mp3", "wav", "aac", "m4a", "flac", "ogg"])
+const IMAGE_EXTENSIONS = new Set(["jpg", "jpeg", "png", "bmp", "webp"])
+
 export function withBotProjectSchema(
   request: BotRenderJobRequest,
   options: BotProjectAssemblyOptions = {},
@@ -43,18 +48,24 @@ export function createBotProjectSchemaFromRenderJob(
   const aspectRatio = resolveAspectRatio(resolution)
   const fps = options.fps ?? DEFAULT_FPS
   const sampleRate = options.sampleRate ?? DEFAULT_SAMPLE_RATE
-  // Аудио (музыка) должно попадать на отдельную Audio-дорожку, а не на видео-трек:
-  // иначе Rust-рендер обрабатывает звук как видеовход (scale=... падает) и не миксует музыку.
-  const visualMedia = media.filter((item) => mediaKind(item) !== "audio")
-  const audioMedia = media.filter((item) => mediaKind(item) === "audio")
 
-  const visualClips = visualMedia.map((item, index) => createClip(item, index, request, clipDuration))
-  const audioClips = audioMedia.map((item, index) => createClip(item, index, request, clipDuration))
+  // Audio/music media must live on a dedicated Audio track, otherwise the Rust
+  // renderer treats it as a video input on the no-AI fallback path. Visual media
+  // (video + image) stays on the Video track and lays out sequentially.
+  const visualClips: Clip[] = []
+  const audioClips: Clip[] = []
+  media.forEach((item, index) => {
+    const kind = detectMediaKind(item)
+    if (kind === "audio") {
+      audioClips.push(createClip(item, index, audioClips.length, kind, request, clipDuration))
+    } else {
+      visualClips.push(createClip(item, index, visualClips.length, kind, request, clipDuration))
+    }
+  })
+
   const duration = Math.max(...[...visualClips, ...audioClips].map((clip) => clip.end_time), clipDuration)
-
-  const tracks: Track[] = []
-  if (visualClips.length > 0) {
-    tracks.push({
+  const tracks: Track[] = [
+    {
       id: "bot-video-track",
       track_type: "Video",
       name: "Bot Video",
@@ -64,8 +75,8 @@ export function createBotProjectSchemaFromRenderJob(
       clips: visualClips,
       effects: [],
       filters: [],
-    })
-  }
+    },
+  ]
   if (audioClips.length > 0) {
     tracks.push({
       id: "bot-audio-track",
@@ -146,12 +157,19 @@ export function createBotProjectSchemaFromRenderJob(
 function createClip(
   media: BotRenderJobMediaInput,
   index: number,
+  position: number,
+  kind: MediaKind,
   request: BotRenderJobRequest,
-  duration: number,
+  clipDuration: number,
 ): Clip {
-  const start = index * duration
+  const isAudio = kind === "audio"
+  // Audio clips span the whole track from 0 for the music length; visual clips
+  // lay out sequentially by their position on the Video track.
+  const duration = isAudio ? resolveMediaDuration(media, clipDuration) : clipDuration
+  const start = isAudio ? 0 : position * clipDuration
   const customMetadata: Record<string, unknown> = {
     source: "bot",
+    mediaType: kind,
   }
 
   if (media.name) customMetadata.name = media.name
@@ -169,8 +187,8 @@ function createClip(
     opacity: 1,
     effects: [],
     filters: [],
-    template_id: request.templateId ?? null,
-    template_position: request.templateId ? index : null,
+    template_id: isAudio ? null : (request.templateId ?? null),
+    template_position: !isAudio && request.templateId ? position : null,
     color_correction: null,
     crop: null,
     transform: null,
@@ -181,6 +199,32 @@ function createClip(
       custom_metadata: customMetadata,
     },
   }
+}
+
+function detectMediaKind(media: BotRenderJobMediaInput): MediaKind {
+  const mimeType = media.mimeType?.toLowerCase().trim()
+  if (mimeType) {
+    if (mimeType.startsWith("audio/")) return "audio"
+    if (mimeType.startsWith("image/")) return "image"
+    if (mimeType.startsWith("video/")) return "video"
+  }
+
+  const extension = fileExtension(media.name ?? media.value)
+  if (AUDIO_EXTENSIONS.has(extension)) return "audio"
+  if (IMAGE_EXTENSIONS.has(extension)) return "image"
+
+  return "video"
+}
+
+function fileExtension(pathOrName: string): string {
+  const withoutQuery = pathOrName.split(/[?#]/, 1)[0]
+  const base = withoutQuery.slice(Math.max(withoutQuery.lastIndexOf("/"), withoutQuery.lastIndexOf("\\")) + 1)
+  const dot = base.lastIndexOf(".")
+  return dot >= 0 ? base.slice(dot + 1).toLowerCase() : ""
+}
+
+function resolveMediaDuration(media: BotRenderJobMediaInput, fallback: number): number {
+  return positiveNumber(media.metadata?.duration) ?? fallback
 }
 
 function createClipSource(media: BotRenderJobMediaInput): Clip["source"] {
@@ -264,17 +308,6 @@ function positiveNumber(value: unknown): number | undefined {
 
 function isUrl(value: string): boolean {
   return value.startsWith("http://") || value.startsWith("https://")
-}
-
-/// Тип медиа: "audio" (музыка/звук) — на отдельную аудио-дорожку; "visual" (видео/фото) — на видео.
-function mediaKind(media: BotRenderJobMediaInput): "audio" | "visual" {
-  const mime = media.mimeType?.toLowerCase() ?? ""
-  if (mime.startsWith("audio/")) return "audio"
-  if (mime.startsWith("video/") || mime.startsWith("image/")) return "visual"
-
-  const ref = (media.name ?? media.value).toLowerCase()
-  if (/\.(mp3|wav|aac|m4a|flac|ogg|oga|opus|wma|aif|aiff|alac)$/.test(ref)) return "audio"
-  return "visual"
 }
 
 function isClose(actual: number, expected: number): boolean {

--- a/packages/core/src/services/bot-project-assembler.ts
+++ b/packages/core/src/services/bot-project-assembler.ts
@@ -43,18 +43,41 @@ export function createBotProjectSchemaFromRenderJob(
   const aspectRatio = resolveAspectRatio(resolution)
   const fps = options.fps ?? DEFAULT_FPS
   const sampleRate = options.sampleRate ?? DEFAULT_SAMPLE_RATE
-  const clips = media.map((item, index) => createClip(item, index, request, clipDuration))
-  const duration = Math.max(...clips.map((clip) => clip.end_time), clipDuration)
-  const track: Track = {
-    id: "bot-video-track",
-    track_type: "Video",
-    name: "Bot Video",
-    enabled: true,
-    volume: 1,
-    locked: false,
-    clips,
-    effects: [],
-    filters: [],
+  // Аудио (музыка) должно попадать на отдельную Audio-дорожку, а не на видео-трек:
+  // иначе Rust-рендер обрабатывает звук как видеовход (scale=... падает) и не миксует музыку.
+  const visualMedia = media.filter((item) => mediaKind(item) !== "audio")
+  const audioMedia = media.filter((item) => mediaKind(item) === "audio")
+
+  const visualClips = visualMedia.map((item, index) => createClip(item, index, request, clipDuration))
+  const audioClips = audioMedia.map((item, index) => createClip(item, index, request, clipDuration))
+  const duration = Math.max(...[...visualClips, ...audioClips].map((clip) => clip.end_time), clipDuration)
+
+  const tracks: Track[] = []
+  if (visualClips.length > 0) {
+    tracks.push({
+      id: "bot-video-track",
+      track_type: "Video",
+      name: "Bot Video",
+      enabled: true,
+      volume: 1,
+      locked: false,
+      clips: visualClips,
+      effects: [],
+      filters: [],
+    })
+  }
+  if (audioClips.length > 0) {
+    tracks.push({
+      id: "bot-audio-track",
+      track_type: "Audio",
+      name: "Bot Audio",
+      enabled: true,
+      volume: 1,
+      locked: false,
+      clips: audioClips,
+      effects: [],
+      filters: [],
+    })
   }
 
   return {
@@ -73,7 +96,7 @@ export function createBotProjectSchemaFromRenderJob(
       sample_rate: sampleRate,
       aspect_ratio: aspectRatio,
     },
-    tracks: [track],
+    tracks,
     effects: [],
     transitions: [],
     filters: [],
@@ -241,6 +264,17 @@ function positiveNumber(value: unknown): number | undefined {
 
 function isUrl(value: string): boolean {
   return value.startsWith("http://") || value.startsWith("https://")
+}
+
+/// Тип медиа: "audio" (музыка/звук) — на отдельную аудио-дорожку; "visual" (видео/фото) — на видео.
+function mediaKind(media: BotRenderJobMediaInput): "audio" | "visual" {
+  const mime = media.mimeType?.toLowerCase() ?? ""
+  if (mime.startsWith("audio/")) return "audio"
+  if (mime.startsWith("video/") || mime.startsWith("image/")) return "visual"
+
+  const ref = (media.name ?? media.value).toLowerCase()
+  if (/\.(mp3|wav|aac|m4a|flac|ogg|oga|opus|wma|aif|aiff|alac)$/.test(ref)) return "audio"
+  return "visual"
 }
 
 function isClose(actual: number, expected: number): boolean {


### PR DESCRIPTION
## What & why

The core Telegram-bot scenario — send a **photo + music + subtitles**, get a rendered video back — did not actually produce a usable video. The gaps were in the Rust render engine (`ts-render`) and the no-AI fallback project assembler:

- A still photo was fed to ffmpeg with no `-loop 1`/`-framerate`, so it rendered to **~1 frame** instead of a clip.
- Any music/audio track produced an **invalid `filter_complex`** (`concat` with no input labels + a single-track `[atrack0][outa]` with no filter between labels → ffmpeg `No such filter: ''`), so the whole render failed.
- Subtitles use the `drawtext` filter; on an ffmpeg built **without libfreetype** the entire job crashed.
- The deterministic fallback assembler put **all** media (including music) on one Video track.

Note: the "real" engine is `FFmpegBuilder::build_render_command` (`core/ffmpeg_builder/*`), not the `core/stages/*` files (which are vestigial).

## Changes

**Rust render engine (`crates/ts-render/.../ffmpeg_builder/`)**
- `inputs.rs` — loop still images (`-loop 1 -framerate <fps> -t <dur>`); image detection via new `ffmpeg_builder::is_image_path`.
- `filters.rs` — rewrite `build_audio_filter_chain` to prepend `concat` input labels and fix the single-track output (mirrors the already-fixed video path); make the embedded-audio chain image-aware; gate `-map [outa]` on real audio production (`audio_output_present`) so a silent photo doesn't map a missing stream.
- `builder.rs` — when ffmpeg lacks `drawtext` (no libfreetype), render **without** burned-in subtitles instead of failing the whole job (overridable via `TIMELINE_ASSUME_DRAWTEXT`).

**Bot fallback assembler (`packages/core/src/services/bot-project-assembler.ts`)**
- Detect media kind (mime → query-string-safe file extension) and split audio onto a dedicated `bot-audio-track`; music uses its real `metadata.duration` and starts at 0 (no longer truncated to `clipDuration`); visual media stays on the Video track and lays out sequentially.

## Verification

- `cargo test -p ts-render --lib`: **504 pass** (incl. new unit tests for image looping, audio filtergraph validity, subtitle-strip fallback, full photo+music+subtitle command).
- `vitest` bot assembler + first-cut: **13 pass**.
- Real ffmpeg renders:
  - photo → **5.0s** 1080p H.264 (was ~1 frame)
  - photo + music → 5.0s **H.264 + AAC**
  - photo + 8s music → **8.0s** (music spans full length)
  - photo + music + subtitles → succeeds with a warning on a drawtext-less ffmpeg; keeps `drawtext` when available.

## Reviewer notes

- **Deployment requirement:** the render host's ffmpeg must be built with **libfreetype** for burned-in subtitles. Without it, video+music still render; subtitles are skipped (logged).
- No schema/contract changes; ProjectSchema shape is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)