### PR TITLE
Duck bot background music and honor audio track volume

### DIFF
--- a/crates/ts-render/src/video_compiler/core/ffmpeg_builder/filters.rs
+++ b/crates/ts-render/src/video_compiler/core/ffmpeg_builder/filters.rs
@@ -274,7 +274,9 @@ impl<'a> FilterBuilder<'a> {
       let mut track_filters = Vec::new();
 
       for clip in &track.clips {
-        let clip_filter = self.build_audio_clip_filter(clip, *input_index).await?;
+        let clip_filter = self
+          .build_audio_clip_filter(clip, *input_index, track.volume)
+          .await?;
         track_filters.push(clip_filter);
         *input_index += 1;
       }
@@ -371,7 +373,9 @@ impl<'a> FilterBuilder<'a> {
         let clip_end = clip.start_time + clip_duration;
 
         if clip.start_time < end_time && clip_end > start_time {
-          let clip_filter = self.build_audio_clip_filter(clip, *input_index).await?;
+          let clip_filter = self
+            .build_audio_clip_filter(clip, *input_index, track.volume)
+            .await?;
           filters.push(clip_filter);
           *input_index += 1;
         }
@@ -420,14 +424,21 @@ impl<'a> FilterBuilder<'a> {
     Ok(parts.join(";"))
   }
 
-  /// Построить фильтр для аудио клипа
-  async fn build_audio_clip_filter(&self, clip: &Clip, input_index: usize) -> Result<String> {
+  /// Построить фильтр для аудио клипа.
+  /// `track_volume` — громкость родительского трека (0.0–2.0): фоновая музыка
+  /// уходит на отдельный аудио-трек с пониженной громкостью, чтобы не перекрывать речь.
+  async fn build_audio_clip_filter(
+    &self,
+    clip: &Clip,
+    input_index: usize,
+    track_volume: f32,
+  ) -> Result<String> {
     let mut filters = Vec::new();
 
-    // Базовая обработка аудио
+    // Базовая обработка аудио (громкость берём из трека, а не хардкодим 1.0)
     let base_filter = format!(
       "[{}:a]asetpts=PTS-STARTPTS,volume={}[a{}]",
-      input_index, 1.0, input_index
+      input_index, track_volume, input_index
     );
     filters.push(base_filter);
 
@@ -741,15 +752,15 @@ mod tests {
     let clip = &project.tracks[0].clips[0];
     let input_index = 0;
 
-    let result = builder.build_audio_clip_filter(clip, input_index).await;
+    let result = builder.build_audio_clip_filter(clip, input_index, 0.3).await;
     assert!(result.is_ok());
 
     let filter = result.unwrap();
     assert!(!filter.is_empty(), "Audio clip filter should not be empty");
 
-    // Проверяем что фильтр содержит аудио элементы
+    // Проверяем что фильтр содержит аудио элементы и громкость трека
     assert!(filter.contains("asetpts="));
-    assert!(filter.contains("volume="));
+    assert!(filter.contains("volume=0.3"));
   }
 
   #[test]

--- a/packages/core/src/services/__tests__/bot-project-assembler.test.ts
+++ b/packages/core/src/services/__tests__/bot-project-assembler.test.ts
@@ -146,6 +146,8 @@ describe("bot project assembler", () => {
 
     const audioTrack = schema?.tracks[1]
     expect(audioTrack).toMatchObject({ id: "bot-audio-track", track_type: "Audio" })
+    // Image-only slideshow has no speech to protect, so music plays at full volume.
+    expect(audioTrack?.volume).toBe(1)
     expect(audioTrack?.clips).toHaveLength(1)
     expect(audioTrack?.clips[0]).toMatchObject({
       source: { File: "/tmp/music.mp3" },
@@ -160,6 +162,40 @@ describe("bot project assembler", () => {
 
     // Timeline spans the longer music clip so the looping image is fully scored.
     expect(schema?.timeline.duration).toBe(30)
+  })
+
+  it("ducks background music when the project also contains video", () => {
+    const request: BotRenderJobRequest = {
+      source: "bot",
+      media: [
+        { type: "file", value: "/tmp/clip.mp4", mimeType: "video/mp4" },
+        { type: "file", value: "/tmp/music.mp3", mimeType: "audio/mpeg" },
+      ],
+      output: { format: "mp4" },
+    }
+
+    const schema = createBotProjectSchemaFromRenderJob(request)
+    const audioTrack = schema?.tracks.find((track) => track.track_type === "Audio")
+
+    expect(audioTrack?.volume).toBe(0.3)
+  })
+
+  it("honors an explicit musicVolume override", () => {
+    const request: BotRenderJobRequest = {
+      source: "bot",
+      media: [
+        { type: "file", value: "/tmp/clip.mp4", mimeType: "video/mp4" },
+        { type: "file", value: "/tmp/music.mp3", mimeType: "audio/mpeg" },
+      ],
+      params: { musicVolume: "0.8" },
+      output: { format: "mp4" },
+    }
+
+    const fromParams = createBotProjectSchemaFromRenderJob(request)
+    expect(fromParams?.tracks.find((track) => track.track_type === "Audio")?.volume).toBe(0.8)
+
+    const fromOptions = createBotProjectSchemaFromRenderJob(request, { musicVolume: 1.5 })
+    expect(fromOptions?.tracks.find((track) => track.track_type === "Audio")?.volume).toBe(1.5)
   })
 
   it("detects audio media by file extension when no mimeType is provided", () => {

--- a/packages/core/src/services/bot-project-assembler.ts
+++ b/packages/core/src/services/bot-project-assembler.ts
@@ -11,6 +11,9 @@ import type {
 const DEFAULT_CLIP_DURATION_SECONDS = 5
 const DEFAULT_FPS = 30
 const DEFAULT_SAMPLE_RATE = 48000
+const MAX_TRACK_VOLUME = 2
+const FULL_MUSIC_VOLUME = 1
+const DUCKED_MUSIC_VOLUME = 0.3
 
 type MediaKind = "video" | "image" | "audio"
 
@@ -54,11 +57,13 @@ export function createBotProjectSchemaFromRenderJob(
   // (video + image) stays on the Video track and lays out sequentially.
   const visualClips: Clip[] = []
   const audioClips: Clip[] = []
+  let hasVideo = false
   media.forEach((item, index) => {
     const kind = detectMediaKind(item)
     if (kind === "audio") {
       audioClips.push(createClip(item, index, audioClips.length, kind, request, clipDuration))
     } else {
+      if (kind === "video") hasVideo = true
       visualClips.push(createClip(item, index, visualClips.length, kind, request, clipDuration))
     }
   })
@@ -83,7 +88,7 @@ export function createBotProjectSchemaFromRenderJob(
       track_type: "Audio",
       name: "Bot Audio",
       enabled: true,
-      volume: 1,
+      volume: resolveMusicVolume(request, options, hasVideo),
       locked: false,
       clips: audioClips,
       effects: [],
@@ -225,6 +230,31 @@ function fileExtension(pathOrName: string): string {
 
 function resolveMediaDuration(media: BotRenderJobMediaInput, fallback: number): number {
   return positiveNumber(media.metadata?.duration) ?? fallback
+}
+
+function resolveMusicVolume(
+  request: BotRenderJobRequest,
+  options: BotProjectAssemblyOptions,
+  hasVideo: boolean,
+): number {
+  // Explicit overrides win; otherwise duck the music under video (which may carry
+  // speech) and keep full volume for an image-only slideshow.
+  return (
+    clampVolume(options.musicVolume) ??
+    clampVolume(request.params?.musicVolume) ??
+    (hasVideo ? DUCKED_MUSIC_VOLUME : FULL_MUSIC_VOLUME)
+  )
+}
+
+function clampVolume(value: unknown): number | undefined {
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim().length > 0
+        ? Number.parseFloat(value)
+        : Number.NaN
+  if (!Number.isFinite(parsed) || parsed < 0) return undefined
+  return Math.min(parsed, MAX_TRACK_VOLUME)
 }
 
 function createClipSource(media: BotRenderJobMediaInput): Clip["source"] {

--- a/packages/core/src/types/bot-workflow.ts
+++ b/packages/core/src/types/bot-workflow.ts
@@ -286,6 +286,12 @@ export interface BotProjectAssemblyOptions {
   fps?: number
   sampleRate?: number
   resolution?: BotProjectAssemblyResolution
+  /**
+   * Громкость аудио-трека с фоновой музыкой (0.0–2.0). По умолчанию музыка
+   * приглушается, если в проекте есть видео (чтобы не перекрывать речь), и
+   * звучит на полной громкости для слайдшоу из изображений.
+   */
+  musicVolume?: number
   now?: () => string
 }
 


### PR DESCRIPTION
> ⚠️ Стек поверх #337 (base — ветка `claude/awesome-mayer-423a3e`). Мержить после #337; затем сменю base на `main` или PR схлопнется автоматически.

## Проблема

Аудио-фильтр рендера хардкодил `volume=1.0` ([filters.rs](crates/ts-render/src/video_compiler/core/ffmpeg_builder/filters.rs)), поэтому громкость трека игнорировалась — фоновая музыка всегда звучала на полную, перекрывая звук видео/речь. На стороне TS у бот-ассемблера вообще не было ручки громкости музыки.

## Изменения

**Rust (рендер теперь уважает громкость трека):**
- `build_audio_clip_filter` принимает `track_volume` и подставляет его в `volume=` вместо жёсткой `1.0`. Оба пути (полная аудио-цепочка и сегментная) передают `track.volume`.

**TS (ассемблер задаёт громкость музыки):**
- `resolveMusicVolume`: приоритет у явных `options.musicVolume` / `params.musicVolume`; иначе музыка приглушается до **0.3**, если в проекте есть видео (возможна речь), и звучит на **полной** громкости для слайдшоу из изображений.
- Значение клампится в диапазон схемы `0.0–2.0`.
- Новая опция `BotProjectAssemblyOptions.musicVolume`.

## Тесты

- **Rust**: `test_build_audio_clip_filter` проверяет, что громкость трека доходит до filtergraph (`volume=0.3`). Все 28 тестов `filters::` зелёные.
- **TS**: дакинг при наличии видео (0.3), полная громкость для слайдшоу (1.0), переопределение через `params` и `options`. 7/7 ✅, `tsc` чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)