### PR TITLE
Default polish for bot renders: 9:16 + subtitles + hook title

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -108,6 +108,7 @@ export {
   createBotWorkflowStatusMessage,
   createDeterministicFirstCutProject,
   createDeterministicScriptDraft,
+  generateScriptSubtitles,
   createNoopBotMediaResolver,
   createTelegramLikeBotWorkflow,
   DefaultBotFirstCutGenerator,

--- a/packages/core/src/services/__tests__/bot-project-assembler.test.ts
+++ b/packages/core/src/services/__tests__/bot-project-assembler.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
+import type { ScriptDraft } from "../../ports/script-generator.port"
 import type { BotRenderJobRequest } from "../../types"
-import { createBotProjectSchemaFromRenderJob, withBotProjectSchema } from "../bot-project-assembler"
+import { createBotProjectSchemaFromRenderJob, generateScriptSubtitles, withBotProjectSchema } from "../bot-project-assembler"
 
 describe("bot project assembler", () => {
   it("creates a ProjectSchema from bot media and template hints", () => {
@@ -208,6 +209,33 @@ describe("bot project assembler", () => {
     })
   })
 
+  it("defaults to portrait 9:16 resolution when no resolution is specified", () => {
+    const request: BotRenderJobRequest = {
+      source: "bot",
+      media: [{ type: "file", value: "/tmp/clip.mp4" }],
+      output: { format: "mp4" },
+    }
+
+    const schema = createBotProjectSchemaFromRenderJob(request)
+
+    expect(schema?.timeline.resolution).toEqual([1080, 1920])
+    expect(schema?.timeline.aspect_ratio).toBe("Ratio9x16")
+    expect(schema?.settings.resolution).toEqual({ width: 1080, height: 1920 })
+  })
+
+  it("respects explicit landscape resolution override", () => {
+    const request: BotRenderJobRequest = {
+      source: "bot",
+      media: [{ type: "file", value: "/tmp/clip.mp4" }],
+      output: { format: "mp4", resolution: "1080p" },
+    }
+
+    const schema = createBotProjectSchemaFromRenderJob(request)
+
+    expect(schema?.timeline.resolution).toEqual([1920, 1080])
+    expect(schema?.timeline.aspect_ratio).toBe("Ratio16x9")
+  })
+
   it("preserves explicit project inputs and ignores empty media", () => {
     const explicit: BotRenderJobRequest = {
       source: "bot",
@@ -223,5 +251,89 @@ describe("bot project assembler", () => {
     expect(withBotProjectSchema(explicit)).toBe(explicit)
     expect(createBotProjectSchemaFromRenderJob(empty)).toBeNull()
     expect(withBotProjectSchema(empty)).toBe(empty)
+  })
+})
+
+describe("generateScriptSubtitles", () => {
+  const SCRIPT: ScriptDraft = {
+    hook: "Watch this!",
+    scenes: [
+      { index: 0, shot: "product close-up", voiceover: "Meet our product." },
+      { index: 1, shot: "happy user", voiceover: "You will love it." },
+    ],
+  }
+
+  it("returns empty array when no script provided", () => {
+    expect(generateScriptSubtitles(undefined, 5, 10)).toEqual([])
+  })
+
+  it("generates a hook subtitle at top-center for first 3 seconds", () => {
+    const subs = generateScriptSubtitles(SCRIPT, 5, 30)
+    const hook = subs.find((s) => s.id === "sub-hook")
+    expect(hook).toBeDefined()
+    expect(hook?.text).toBe("Watch this!")
+    expect(hook?.start_time).toBe(0)
+    expect(hook?.end_time).toBe(3)
+    expect(hook?.position.align_y).toBe("Top")
+    expect(hook?.font_weight).toBe("Bold")
+  })
+
+  it("generates voiceover subtitles at bottom-center per scene", () => {
+    const subs = generateScriptSubtitles(SCRIPT, 5, 30)
+    const scene0 = subs.find((s) => s.id === "sub-scene-0")
+    const scene1 = subs.find((s) => s.id === "sub-scene-1")
+    expect(scene0?.text).toBe("Meet our product.")
+    expect(scene0?.position.align_y).toBe("Bottom")
+    expect(scene0?.start_time).toBe(0)
+    expect(scene0?.end_time).toBe(5)
+    expect(scene1?.start_time).toBe(5)
+    expect(scene1?.end_time).toBe(10)
+  })
+
+  it("clamps hook end_time to totalDuration", () => {
+    const subs = generateScriptSubtitles({ hook: "Quick!", scenes: [] }, 5, 1)
+    const hook = subs.find((s) => s.id === "sub-hook")
+    expect(hook?.end_time).toBe(1)
+  })
+
+  it("omits voiceover subtitle when voiceover is empty", () => {
+    const script: ScriptDraft = {
+      scenes: [{ index: 0, shot: "shot", voiceover: "  " }],
+    }
+    const subs = generateScriptSubtitles(script, 5, 10)
+    expect(subs).toHaveLength(0)
+  })
+
+  it("respects scene-level durationSeconds when set", () => {
+    const script: ScriptDraft = {
+      scenes: [
+        { index: 0, shot: "shot", voiceover: "Hello", durationSeconds: 8 },
+        { index: 1, shot: "shot2", voiceover: "World", durationSeconds: 4 },
+      ],
+    }
+    const subs = generateScriptSubtitles(script, 5, 30)
+    expect(subs[0].end_time).toBe(8)
+    expect(subs[1].start_time).toBe(8)
+    expect(subs[1].end_time).toBe(12)
+  })
+
+  it("script passed to assembler produces subtitles in project schema", () => {
+    const request: BotRenderJobRequest = {
+      source: "bot",
+      media: [
+        { type: "file", value: "/tmp/a.mp4" },
+        { type: "file", value: "/tmp/b.mp4" },
+      ],
+      params: { clipDurationSeconds: "5" },
+      output: { format: "mp4" },
+    }
+
+    const schema = createBotProjectSchemaFromRenderJob(request, { script: SCRIPT })
+
+    expect(schema?.subtitles).not.toHaveLength(0)
+    const hookSub = (schema?.subtitles as { id: string }[]).find((s) => s.id === "sub-hook")
+    const voiceSub = (schema?.subtitles as { id: string }[]).find((s) => s.id === "sub-scene-0")
+    expect(hookSub).toBeDefined()
+    expect(voiceSub).toBeDefined()
   })
 })

--- a/packages/core/src/services/bot-first-cut-generator.ts
+++ b/packages/core/src/services/bot-first-cut-generator.ts
@@ -122,7 +122,9 @@ export function createDeterministicFirstCutProject(request: BotFirstCutGenerator
       ...(script ? { script: serializeScriptForParams(script) } : {}),
     },
   }
-  const project = createBotProjectSchemaFromRenderJob(renderRequest)
+  const project = createBotProjectSchemaFromRenderJob(renderRequest, {
+    ...(script ? { script } : {}),
+  })
   if (!project) {
     throw new Error("Cannot generate first cut without source media")
   }

--- a/packages/core/src/services/bot-project-assembler.ts
+++ b/packages/core/src/services/bot-project-assembler.ts
@@ -1,5 +1,6 @@
 import type { AspectRatio, Clip, ProjectSchema, Track } from "@/types/contracts/project-schema"
 
+import type { ScriptDraft, ScriptScene } from "../ports/script-generator.port"
 import type {
   BotProjectAssemblyOptions,
   BotProjectAssemblyResolution,
@@ -7,6 +8,8 @@ import type {
   BotRenderJobOutput,
   BotRenderJobRequest,
 } from "../types"
+
+const HOOK_DURATION_SECONDS = 3
 
 const DEFAULT_CLIP_DURATION_SECONDS = 5
 const DEFAULT_FPS = 30
@@ -113,7 +116,7 @@ export function createBotProjectSchemaFromRenderJob(
     filters: [],
     templates: [],
     style_templates: [],
-    subtitles: [],
+    subtitles: generateScriptSubtitles(options.script, clipDuration, duration),
     settings: {
       export: {
         format: "Mp4",
@@ -262,10 +265,15 @@ function resolveResolution(
   switch (optionResolution ?? outputResolution) {
     case "720p":
       return [1280, 720]
+    case "1080p":
+      return [1920, 1080]
     case "4k":
       return [3840, 2160]
+    case "portrait-1080p":
+      return [1080, 1920]
     default:
-      return [1920, 1080]
+      // Bot renders default to vertical 9:16 for Reels/Shorts
+      return [1080, 1920]
   }
 }
 
@@ -282,9 +290,11 @@ function resolveAspectRatio([width, height]: [number, number]): AspectRatio {
 }
 
 function previewResolution([width, height]: [number, number]): [number, number] {
-  if (width <= 1280 && height <= 720) return [width, height]
+  const maxW = width >= height ? 1280 : 720
+  const maxH = width >= height ? 720 : 1280
+  if (width <= maxW && height <= maxH) return [width, height]
 
-  const scale = Math.min(1280 / width, 720 / height)
+  const scale = Math.min(maxW / width, maxH / height)
   return [Math.round(width * scale), Math.round(height * scale)]
 }
 
@@ -312,4 +322,143 @@ function isUrl(value: string): boolean {
 
 function isClose(actual: number, expected: number): boolean {
   return Math.abs(actual - expected) < 0.01
+}
+
+// ---------------------------------------------------------------------------
+// Subtitle generation from ScriptDraft
+// ---------------------------------------------------------------------------
+
+interface BotSubtitle {
+  id: string
+  text: string
+  start_time: number
+  end_time: number
+  duration: number
+  position: { type: "Relative"; align_x: "Center"; align_y: "Top" | "Bottom" }
+  style: {
+    font_family: string
+    font_size: number
+    font_weight: "Normal" | "Bold"
+    color: string
+    stroke_color: string
+    stroke_width: number
+    shadow_color: string
+    shadow_x: number
+    shadow_y: number
+    shadow_blur: number
+    background_color: null
+    background_opacity: number
+    padding: { top: number; right: number; bottom: number; left: number }
+    border_radius: number
+    line_height: number
+    letter_spacing: number
+    max_width: number
+  }
+  enabled: boolean
+  animations: []
+  // compat fields mirroring Rust Subtitle struct
+  font_family: string
+  font_size: number
+  color: string
+  opacity: number
+  font_weight: "Normal" | "Bold"
+  shadow: boolean
+  outline: boolean
+}
+
+const VOICEOVER_STYLE: BotSubtitle["style"] = {
+  font_family: "Arial",
+  font_size: 24,
+  font_weight: "Normal",
+  color: "#FFFFFF",
+  stroke_color: "#000000",
+  stroke_width: 2,
+  shadow_color: "#000000",
+  shadow_x: 2,
+  shadow_y: 2,
+  shadow_blur: 4,
+  background_color: null,
+  background_opacity: 0.8,
+  padding: { top: 8, right: 12, bottom: 8, left: 12 },
+  border_radius: 4,
+  line_height: 1.2,
+  letter_spacing: 0,
+  max_width: 80,
+}
+
+const HOOK_STYLE: BotSubtitle["style"] = {
+  ...VOICEOVER_STYLE,
+  font_size: 36,
+  font_weight: "Bold",
+  stroke_width: 3,
+  max_width: 85,
+}
+
+function makeSubtitle(
+  id: string,
+  text: string,
+  startTime: number,
+  endTime: number,
+  alignY: "Top" | "Bottom",
+  style: BotSubtitle["style"],
+): BotSubtitle {
+  const dur = endTime - startTime
+  return {
+    id,
+    text,
+    start_time: startTime,
+    end_time: endTime,
+    duration: dur,
+    position: { type: "Relative", align_x: "Center", align_y: alignY },
+    style,
+    enabled: true,
+    animations: [],
+    font_family: style.font_family,
+    font_size: style.font_size,
+    color: style.color,
+    opacity: 1,
+    font_weight: style.font_weight,
+    shadow: true,
+    outline: true,
+  }
+}
+
+function sceneClipDuration(scene: ScriptScene, defaultClipDuration: number): number {
+  return typeof scene.durationSeconds === "number" && scene.durationSeconds > 0
+    ? scene.durationSeconds
+    : defaultClipDuration
+}
+
+export function generateScriptSubtitles(
+  script: ScriptDraft | undefined,
+  clipDurationSeconds: number,
+  totalDuration: number,
+): BotSubtitle[] {
+  if (!script) return []
+
+  const subtitles: BotSubtitle[] = []
+
+  if (script.hook?.trim()) {
+    const hookEnd = Math.min(HOOK_DURATION_SECONDS, totalDuration)
+    subtitles.push(makeSubtitle("sub-hook", script.hook.trim(), 0, hookEnd, "Top", HOOK_STYLE))
+  }
+
+  let cursor = 0
+  for (const scene of script.scenes) {
+    const dur = sceneClipDuration(scene, clipDurationSeconds)
+    const sceneStart = cursor
+    const sceneEnd = Math.min(cursor + dur, totalDuration)
+    cursor = sceneEnd
+
+    const voiceover = scene.voiceover?.trim()
+    if (voiceover) {
+      subtitles.push(
+        makeSubtitle(`sub-scene-${scene.index}`, voiceover, sceneStart, sceneEnd, "Bottom", VOICEOVER_STYLE),
+      )
+    }
+
+    if (cursor >= totalDuration) break
+  }
+
+  return subtitles
 }

--- a/packages/core/src/types/bot-workflow.ts
+++ b/packages/core/src/types/bot-workflow.ts
@@ -6,6 +6,7 @@
  */
 
 import type { IBotFirstCutGenerator } from "../ports/bot-first-cut-generator.port"
+import type { ScriptDraft } from "../ports/script-generator.port"
 import type {
   BotPublishResult,
   BotRenderJobArtifact,
@@ -287,6 +288,8 @@ export interface BotProjectAssemblyOptions {
   sampleRate?: number
   resolution?: BotProjectAssemblyResolution
   now?: () => string
+  /** When provided, voiceover subtitles and hook title are auto-generated from the script. */
+  script?: ScriptDraft
 }
 
 export interface BotWorkflowIntakeOptions {

--- a/packages/core/src/types/render-job.ts
+++ b/packages/core/src/types/render-job.ts
@@ -34,7 +34,7 @@ export type BotRenderJobProjectInput =
 export interface BotRenderJobOutput {
   format: "mp4"
   path?: string
-  resolution?: "720p" | "1080p" | "4k"
+  resolution?: "720p" | "1080p" | "portrait-1080p" | "4k"
   destination?: BotRenderJobDestination
 }
 


### PR DESCRIPTION
## Summary

- **9:16 vertical by default** — `resolveResolution` now returns `[1080, 1920]` (portrait) when no explicit resolution is set, since bot renders target Telegram Reels/Shorts. Explicit `resolution: "1080p"` still gives `[1920, 1080]`; new `"portrait-1080p"` is also accepted.
- **Voiceover subtitles** — `generateScriptSubtitles()` builds `Subtitle[]` from `ScriptDraft.scenes[].voiceover`, with each entry timed to its scene clip. Respects per-scene `durationSeconds` when set.
- **Hook title card** — when `ScriptDraft.hook` is present, a bold 36px subtitle is placed at the top-center for the first 3 seconds of the video.
- `BotProjectAssemblyOptions` gains `script?: ScriptDraft`; `createDeterministicFirstCutProject` passes `request.script` through to the assembler so subtitles are auto-generated.

## Test plan

- [x] 9 new tests: portrait default, explicit landscape override, hook subtitle, voiceover timing, empty-voiceover skipped, scene-level durationSeconds, end-to-end via assembler
- [x] All 15 492 tests passing (780 test files)
- [x] `tsc --noEmit` clean on core / adapters / cli
- [x] `biome check` clean (1663 files)

Closes #327. Part of Epic #323.

🤖 Generated with [Claude Code](https://claude.com/claude-code)