### PR TITLE
ci(crates): fix ffmpeg-sys-next build (install dev libs + disable x86asm)

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1,6 +1,6 @@
 name: Crates (workspace)
 
-# Сборка и тесты вынесенных крейтов (crates/*) — эпик декомпозиции #91.
+# Сборка и тесты вынесенных крейтов (crates/*) — эпик декомпозиции #91/#354.
 # Монолит src-tauri тестируется отдельными пайплайнами; этот защищает крейты.
 on:
   push:
@@ -20,10 +20,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install ffmpeg
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg
+      - name: Install ffmpeg + dev libs and pkg-config
+        # ffmpeg-sys-next (через ts-render/ffmpeg-next) требует dev-заголовки и .pc-файлы
+        # (pkg-config libavutil). Только runtime `ffmpeg` ломал сборку при cache-miss.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            ffmpeg libavcodec-dev libavformat-dev libavutil-dev libavfilter-dev \
+            libavdevice-dev libswscale-dev libswresample-dev pkg-config
+          echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig" >> "$GITHUB_ENV"
 
-      - name: Install Tauri system deps (для ts-render-tauri — несёт #[tauri::command], тянет gdk/webkit, #91)
+      - name: Install Tauri system deps (для *-tauri крейтов — gdk/webkit)
         run: |
           sudo apt-get install -y --no-install-recommends \
             libwebkit2gtk-4.1-dev libgtk-3-dev libsoup-3.0-dev \
@@ -48,4 +55,8 @@ jobs:
 
       - name: cargo test workspace
         working-directory: crates
+        # ffmpeg-sys-next 8.1.0 против apt-ffmpeg 4.4.2: отключаем x86asm (как в ci.yml/build).
+        env:
+          FFMPEG_SYS_DISABLE_X86ASM: "1"
+          CARGO_FEATURE_FFMPEG_SYS_DISABLE_X86ASM: "1"
         run: cargo test --workspace --no-fail-fast -- --test-threads=2


### PR DESCRIPTION
Джоба **Crates (workspace)** падала на сборке `ffmpeg-sys-next 8.1.0` (`pkg-config libavutil не найден`) — crates.yml ставил только runtime ffmpeg без dev-заголовков (проходило на кэше; Фаза 2 #354 инвалидировала кэш). Чиним по образцу ci.yml: ffmpeg + libav*-dev + pkg-config + PKG_CONFIG_PATH + FFMPEG_SYS_DISABLE_X86ASM.