### PR TITLE
fix(render): cross-platform font resolution for subtitle burn-in (#374)

### DIFF
--- a/crates/ts-render/src/video_compiler/core/ffmpeg_builder/fonts.rs
+++ b/crates/ts-render/src/video_compiler/core/ffmpeg_builder/fonts.rs
@@ -1,0 +1,214 @@
+//! Кросс-платформенное разрешение пути к шрифту для ffmpeg `drawtext` (`fontfile=`).
+//!
+//! Раньше путь к шрифту жёстко зашивался под macOS (`/System/Library/Fonts/*`),
+//! из-за чего прожиг субтитров падал на headless Linux/Docker (#374). Здесь логические
+//! семейства (Arial/Times New Roman/Courier New) сопоставляются с конкретными файлами,
+//! доступными на текущей ОС, с приоритетом:
+//!   1. каталог из env `TIMELINE_FONTS_DIR` (bundled-шрифты),
+//!   2. известные системные пути (Linux: Liberation/DejaVu, macOS, Windows),
+//!   3. безопасный дефолт для текущей ОС.
+//!
+//! На Linux основным подстановочным набором служат шрифты **Liberation**
+//! (метрически совместимы с Arial/Times/Courier) с откатом на **DejaVu** —
+//! оба ставятся в `docker/Dockerfile.headless`.
+
+use std::path::Path;
+
+/// Класс шрифта по начертанию — к нему сводятся логические имена семейств.
+#[derive(Clone, Copy)]
+enum FontKind {
+  Sans,
+  Serif,
+  Mono,
+}
+
+fn classify(font_family: &str) -> FontKind {
+  match font_family {
+    "Times New Roman" | "Times" | "Georgia" | "serif" => FontKind::Serif,
+    "Courier New" | "Courier" | "Consolas" | "Menlo" | "monospace" => FontKind::Mono,
+    // Arial/Helvetica/Verdana/sans-serif и всё неизвестное → sans
+    _ => FontKind::Sans,
+  }
+}
+
+impl FontKind {
+  /// Имена файлов, которые ищем в `TIMELINE_FONTS_DIR`.
+  fn env_filenames(self) -> &'static [&'static str] {
+    match self {
+      FontKind::Sans => &[
+        "LiberationSans-Regular.ttf",
+        "DejaVuSans.ttf",
+        "Arial.ttf",
+        "Helvetica.ttc",
+      ],
+      FontKind::Serif => &[
+        "LiberationSerif-Regular.ttf",
+        "DejaVuSerif.ttf",
+        "Times New Roman.ttf",
+        "Times.ttc",
+      ],
+      FontKind::Mono => &[
+        "LiberationMono-Regular.ttf",
+        "DejaVuSansMono.ttf",
+        "Courier New.ttf",
+        "Courier.ttc",
+      ],
+    }
+  }
+
+  /// Известные абсолютные пути по платформам (проверяются на существование по порядку).
+  fn candidates(self) -> &'static [&'static str] {
+    match self {
+      FontKind::Sans => &[
+        // Linux — Liberation (метрически совместим с Arial), затем DejaVu
+        "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+        "/usr/share/fonts/liberation/LiberationSans-Regular.ttf",
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+        "/usr/share/fonts/dejavu/DejaVuSans.ttf",
+        // macOS
+        "/System/Library/Fonts/Helvetica.ttc",
+        "/Library/Fonts/Arial.ttf",
+        // Windows
+        "C:\\Windows\\Fonts\\arial.ttf",
+      ],
+      FontKind::Serif => &[
+        "/usr/share/fonts/truetype/liberation/LiberationSerif-Regular.ttf",
+        "/usr/share/fonts/liberation/LiberationSerif-Regular.ttf",
+        "/usr/share/fonts/truetype/dejavu/DejaVuSerif.ttf",
+        "/usr/share/fonts/dejavu/DejaVuSerif.ttf",
+        "/System/Library/Fonts/Times.ttc",
+        "/System/Library/Fonts/Supplemental/Times New Roman.ttf",
+        "C:\\Windows\\Fonts\\times.ttf",
+      ],
+      FontKind::Mono => &[
+        "/usr/share/fonts/truetype/liberation/LiberationMono-Regular.ttf",
+        "/usr/share/fonts/liberation/LiberationMono-Regular.ttf",
+        "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf",
+        "/usr/share/fonts/dejavu/DejaVuSansMono.ttf",
+        "/System/Library/Fonts/Courier.ttc",
+        "/System/Library/Fonts/Supplemental/Courier New.ttf",
+        "C:\\Windows\\Fonts\\cour.ttf",
+      ],
+    }
+  }
+
+  /// Безопасный дефолт для текущей ОС, когда ни один файл не найден.
+  /// Возвращает правдоподобный путь (нужного начертания и расширения),
+  /// чтобы `fontfile=` оставался валидным выражением даже без установленных шрифтов.
+  fn default_path(self) -> &'static str {
+    if cfg!(target_os = "macos") {
+      match self {
+        FontKind::Sans => "/System/Library/Fonts/Helvetica.ttc",
+        FontKind::Serif => "/System/Library/Fonts/Times.ttc",
+        FontKind::Mono => "/System/Library/Fonts/Courier.ttc",
+      }
+    } else if cfg!(target_os = "windows") {
+      match self {
+        FontKind::Sans => "C:\\Windows\\Fonts\\arial.ttf",
+        FontKind::Serif => "C:\\Windows\\Fonts\\times.ttf",
+        FontKind::Mono => "C:\\Windows\\Fonts\\cour.ttf",
+      }
+    } else {
+      // Linux/прочее — Liberation (ставится в Dockerfile.headless)
+      match self {
+        FontKind::Sans => "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+        FontKind::Serif => "/usr/share/fonts/truetype/liberation/LiberationSerif-Regular.ttf",
+        FontKind::Mono => "/usr/share/fonts/truetype/liberation/LiberationMono-Regular.ttf",
+      }
+    }
+  }
+}
+
+/// Разрешить путь к файлу шрифта для логического семейства, пригодный для
+/// ffmpeg `drawtext=fontfile='<path>'`. Никогда не паникует и всегда возвращает
+/// непустой путь нужного начертания.
+pub fn resolve_font_path(font_family: &str) -> String {
+  let dir = std::env::var("TIMELINE_FONTS_DIR").ok();
+  resolve_font_path_in(font_family, dir.as_deref())
+}
+
+/// Ядро разрешения с явным каталогом bundled-шрифтов (вместо чтения env) —
+/// чтобы тесты не мутировали глобальное окружение (CI крейтов многопоточный).
+fn resolve_font_path_in(font_family: &str, fonts_dir: Option<&str>) -> String {
+  let kind = classify(font_family);
+
+  // 1. Bundled-каталог (postim.life / Docker могут смонтировать свои шрифты).
+  if let Some(dir) = fonts_dir {
+    if !dir.is_empty() {
+      for name in kind.env_filenames() {
+        let p = Path::new(dir).join(name);
+        if p.exists() {
+          return p.to_string_lossy().into_owned();
+        }
+      }
+    }
+  }
+
+  // 2. Известные системные пути — берём первый существующий.
+  for cand in kind.candidates() {
+    if Path::new(cand).exists() {
+      return (*cand).to_string();
+    }
+  }
+
+  // 3. Дефолт для текущей ОС (может не существовать, но валиден по форме).
+  kind.default_path().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn has_font_ext(p: &str) -> bool {
+    p.ends_with(".ttf") || p.ends_with(".ttc") || p.ends_with(".otf")
+  }
+
+  #[test]
+  fn resolves_known_families_to_valid_paths() {
+    for family in ["Arial", "Times New Roman", "Courier New", "Unknown Font"] {
+      let path = resolve_font_path(family);
+      assert!(!path.is_empty(), "empty path for {family}");
+      assert!(has_font_ext(&path), "bad extension for {family}: {path}");
+      assert!(
+        path.starts_with('/') || path.contains('\\'),
+        "not an absolute path for {family}: {path}"
+      );
+    }
+  }
+
+  #[test]
+  fn unknown_family_falls_back_to_sans() {
+    // Неизвестное семейство и явный sans дают один и тот же дефолт начертания.
+    assert_eq!(resolve_font_path("Unknown Font"), resolve_font_path("Arial"));
+  }
+
+  #[test]
+  fn distinct_kinds_resolve_distinctly_by_default() {
+    // Без установленных шрифтов sans/serif/mono дают разные дефолтные пути.
+    let sans = resolve_font_path("Arial");
+    let serif = resolve_font_path("Times New Roman");
+    let mono = resolve_font_path("Courier New");
+    // Хотя бы одно из начертаний должно отличаться от sans (на любой ОС дефолты различны).
+    assert!(serif != sans || mono != sans);
+  }
+
+  #[test]
+  fn bundled_dir_is_honored_when_file_present() {
+    // Каталог с реальным файлом нужного имени → берём его. Без мутации env:
+    // зовём ядро напрямую (CI крейтов многопоточный, глобальный env гонялся бы).
+    let dir = std::env::temp_dir().join("ts_fonts_test_374");
+    let _ = std::fs::create_dir_all(&dir);
+    let font = dir.join("LiberationSans-Regular.ttf");
+    std::fs::write(&font, b"stub").unwrap();
+    let resolved = resolve_font_path_in("Arial", Some(&dir.to_string_lossy()));
+    let _ = std::fs::remove_file(&font);
+    assert_eq!(resolved, font.to_string_lossy());
+  }
+
+  #[test]
+  fn empty_or_missing_bundled_dir_falls_through() {
+    // Пустой каталог-override не должен ломать разрешение — падаем на системные/дефолт.
+    let p = resolve_font_path_in("Arial", Some(""));
+    assert!(has_font_ext(&p));
+  }
+}

--- a/crates/ts-render/src/video_compiler/core/ffmpeg_builder/mod.rs
+++ b/crates/ts-render/src/video_compiler/core/ffmpeg_builder/mod.rs
@@ -14,6 +14,7 @@ pub mod advanced;
 pub mod builder;
 pub mod effects;
 pub mod filters;
+pub mod fonts;
 pub mod inputs;
 pub mod outputs;
 pub mod subtitles;

--- a/crates/ts-render/src/video_compiler/core/ffmpeg_builder/subtitles.rs
+++ b/crates/ts-render/src/video_compiler/core/ffmpeg_builder/subtitles.rs
@@ -410,16 +410,9 @@ impl<'a> SubtitleBuilder<'a> {
       .replace("\n", "\\n")
   }
 
-  /// Получить путь к шрифту
+  /// Получить путь к шрифту (кросс-платформенно: Linux/macOS/Windows + env-override, #374).
   fn get_font_path(&self, font_family: &str) -> String {
-    // Здесь можно добавить логику поиска системных шрифтов
-    // Пока используем дефолтный путь
-    match font_family {
-      "Arial" => "/System/Library/Fonts/Helvetica.ttc".to_string(),
-      "Times New Roman" => "/System/Library/Fonts/Times.ttc".to_string(),
-      "Courier New" => "/System/Library/Fonts/Courier.ttc".to_string(),
-      _ => "/System/Library/Fonts/Helvetica.ttc".to_string(), // Default
-    }
+    super::fonts::resolve_font_path(font_family)
   }
 
   /// Вычислить позицию субтитра
@@ -777,20 +770,28 @@ mod tests {
 
   #[test]
   fn test_get_font_path() {
+    // Кросс-платформенно (#374): не привязываемся к macOS-путям — проверяем форму.
     let project = create_minimal_project();
     let builder = SubtitleBuilder::new(&project);
 
-    let arial_path = builder.get_font_path("Arial");
-    assert!(arial_path.contains("Helvetica"));
+    for family in ["Arial", "Times New Roman", "Courier New", "Unknown Font"] {
+      let path = builder.get_font_path(family);
+      assert!(!path.is_empty(), "empty font path for {family}");
+      assert!(
+        path.ends_with(".ttf") || path.ends_with(".ttc") || path.ends_with(".otf"),
+        "unexpected font file for {family}: {path}"
+      );
+      assert!(
+        path.starts_with('/') || path.contains('\\'),
+        "font path not absolute for {family}: {path}"
+      );
+    }
 
-    let times_path = builder.get_font_path("Times New Roman");
-    assert!(times_path.contains("Times"));
-
-    let courier_path = builder.get_font_path("Courier New");
-    assert!(courier_path.contains("Courier"));
-
-    let unknown_path = builder.get_font_path("Unknown Font");
-    assert!(unknown_path.contains("Helvetica")); // Should fallback to default
+    // Неизвестное семейство откатывается на тот же дефолт, что и sans-serif.
+    assert_eq!(
+      builder.get_font_path("Unknown Font"),
+      builder.get_font_path("Arial")
+    );
   }
 
   #[test]

--- a/crates/ts-render/src/video_compiler/core/ffmpeg_builder/templates.rs
+++ b/crates/ts-render/src/video_compiler/core/ffmpeg_builder/templates.rs
@@ -624,16 +624,9 @@ impl<'a> TemplateBuilder<'a> {
     Ok(String::new())
   }
 
-  /// Получить системный шрифт
+  /// Получить системный шрифт (кросс-платформенно: Linux/macOS/Windows + env-override, #374).
   fn get_system_font(&self, font_name: &str) -> String {
-    // Здесь должна быть логика поиска системных шрифтов
-    // Пока используем захардкоженные пути для macOS
-    match font_name {
-      "Arial" => "/System/Library/Fonts/Helvetica.ttc".to_string(),
-      "Times New Roman" => "/System/Library/Fonts/Times.ttc".to_string(),
-      "Courier New" => "/System/Library/Fonts/Courier.ttc".to_string(),
-      _ => "/System/Library/Fonts/Helvetica.ttc".to_string(),
-    }
+    super::fonts::resolve_font_path(font_name)
   }
 
   /// Найти шаблон по ID
@@ -703,22 +696,24 @@ mod tests {
 
   #[test]
   fn test_get_system_font() {
+    // Кросс-платформенно (#374): проверяем форму пути, не привязку к macOS.
     let project = create_minimal_project();
     let builder = TemplateBuilder::new(&project);
 
-    // Тестируем получение системных шрифтов
-    let arial_path = builder.get_system_font("Arial");
-    assert!(arial_path.contains("Helvetica") || arial_path.contains("Arial"));
+    for family in ["Arial", "Times New Roman", "Courier New", "Unknown Font"] {
+      let path = builder.get_system_font(family);
+      assert!(!path.is_empty(), "empty font path for {family}");
+      assert!(
+        path.ends_with(".ttf") || path.ends_with(".ttc") || path.ends_with(".otf"),
+        "unexpected font file for {family}: {path}"
+      );
+    }
 
-    let times_path = builder.get_system_font("Times New Roman");
-    assert!(times_path.contains("Times") || times_path.contains("Helvetica"));
-
-    let courier_path = builder.get_system_font("Courier New");
-    assert!(courier_path.contains("Courier") || courier_path.contains("Helvetica"));
-
-    // Неизвестный шрифт должен вернуть дефолтный
-    let unknown_path = builder.get_system_font("Unknown Font");
-    assert!(unknown_path.contains("Helvetica"));
+    // Неизвестный шрифт откатывается на дефолтный sans-serif.
+    assert_eq!(
+      builder.get_system_font("Unknown Font"),
+      builder.get_system_font("Arial")
+    );
   }
 
   #[tokio::test]

--- a/docker/Dockerfile.headless
+++ b/docker/Dockerfile.headless
@@ -59,9 +59,15 @@ RUN cd crates && cargo build --release -p ts-cli
 FROM debian:bookworm-slim AS runtime
 
 # ffmpeg runtime + сертификаты для HTTPS (Telegram API + model download)
+# Шрифты (#374): нужны для прожига субтитров через drawtext на headless Linux.
+#   - fonts-liberation — метрически совместимы с Arial/Times/Courier (наши логические семейства)
+#   - fonts-dejavu-core — широкий fallback (юникод/кириллица)
+# Резолвер ts-render находит их в /usr/share/fonts/truetype/{liberation,dejavu}.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg \
     ca-certificates \
+    fonts-liberation \
+    fonts-dejavu-core \
     && rm -rf /var/lib/apt/lists/*
 
 # ONNX Runtime shared lib


### PR DESCRIPTION
Fixes #374.

## Проблема
Прожиг субтитров (`drawtext`) разрешал шрифты через жёстко зашитые macOS-пути (`/System/Library/Fonts/*`) в двух местах ts-render. На headless Linux/Docker этих путей нет → любой рендер с субтитрами падал/деградировал. Блокировало интеграцию postim.life (фаза t2, subtitle burn-in).

## Решение
- **Новый резолвер** `crates/ts-render/src/video_compiler/core/ffmpeg_builder/fonts.rs` — `resolve_font_path(font_family)` с приоритетом:
  1. каталог `TIMELINE_FONTS_DIR` (bundled/смонтированные шрифты),
  2. известные системные пути: **Linux** — Liberation (метрически совместимы с Arial/Times/Courier) → DejaVu; **macOS**; **Windows**,
  3. безопасный дефолт под текущую ОС (валиден по форме даже без установленных шрифтов).
- `subtitles.rs::get_font_path` и `templates.rs::get_system_font` теперь делегируют в общий резолвер (убран дублированный macOS-хардкод).
- `docker/Dockerfile.headless` ставит `fonts-liberation` + `fonts-dejavu-core` (резолвер находит их в `/usr/share/fonts/truetype/{liberation,dejavu}`).
- Логические семейства Arial/Times New Roman/Courier New маппятся на кросс-платформенные подстановки.

## Тесты
- Существующие тесты переписаны кросс-платформенно (проверяют форму пути, а не macOS-специфичный контент) — иначе падали бы на Linux CI.
- Добавлены тесты резолвера (env-override без мутации глобального окружения — CI крейтов многопоточный).
- `cargo test -p ts-render ffmpeg_builder` → **272 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)