### PR TITLE
feat(schema): semver versioning + backward-compat policy for ProjectSchema (#375)

### DIFF
--- a/crates/ts-schema/src/lib.rs
+++ b/crates/ts-schema/src/lib.rs
@@ -19,9 +19,11 @@ pub mod subtitles;
 pub mod templates;
 pub mod timeline;
 pub mod constants;
+pub mod versioning;
 
 // Re-export всех основных типов для удобства использования
 pub use common::*;
+pub use versioning::{check_compatibility, is_compatible, parse_semver, SCHEMA_VERSION};
 pub use effects::*;
 pub use export::*;
 pub use project::*;

--- a/crates/ts-schema/src/project.rs
+++ b/crates/ts-schema/src/project.rs
@@ -40,7 +40,7 @@ impl ProjectSchema {
   /// Создать новый пустой проект
   pub fn new(name: String) -> Self {
     Self {
-      version: "1.0.0".to_string(),
+      version: crate::versioning::SCHEMA_VERSION.to_string(),
       metadata: ProjectMetadata {
         name,
         description: None,
@@ -62,10 +62,8 @@ impl ProjectSchema {
 
   /// Валидация схемы проекта
   pub fn validate(&self) -> Result<(), String> {
-    // Проверка версии
-    if self.version.is_empty() {
-      return Err("Версия проекта не может быть пустой".to_string());
-    }
+    // Проверка версии: непустая, валидный semver и совместимый MAJOR (#375).
+    crate::versioning::check_compatibility(&self.version)?;
 
     // Проверка timeline
     if self.timeline.fps == 0 {
@@ -243,9 +241,26 @@ mod tests {
 
     let result = project.validate();
     assert!(result.is_err());
-    assert!(result
-      .unwrap_err()
-      .contains("Версия проекта не может быть пустой"));
+    assert!(result.unwrap_err().contains("не может быть пустой"));
+  }
+
+  #[test]
+  fn test_validate_incompatible_major_version() {
+    // Чужой MAJOR отвергается на валидации (#375).
+    let mut project = create_test_project();
+    let next_major = crate::versioning::current_major() + 1;
+    project.version = format!("{next_major}.0.0");
+
+    let result = project.validate();
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("Несовместимая версия"));
+  }
+
+  #[test]
+  fn test_validate_non_semver_version() {
+    let mut project = create_test_project();
+    project.version = "not-a-version".to_string();
+    assert!(project.validate().is_err());
   }
 
   #[test]

--- a/crates/ts-schema/src/versioning.rs
+++ b/crates/ts-schema/src/versioning.rs
@@ -1,0 +1,133 @@
+//! Версионирование и политика обратной совместимости `ProjectSchema` (#375).
+//!
+//! Раньше `ProjectSchema.version` был свободной строкой, захардкоженной в `"1.0.0"`,
+//! без semver-схемы, без проверки на загрузке и без задокументированных гарантий —
+//! совместимость держалась неявно на serde-дефолтах для отсутствующих полей.
+//! Внешние интеграции (postim.life) кодогенерят типы из `timeline emit-schema` и
+//! строят продукт против этого контракта, поэтому им нужен явный версионный контракт.
+//!
+//! # Политика (источник истины — [`SCHEMA_VERSION`])
+//!
+//! Версия схемы — **semver** `MAJOR.MINOR.PATCH`:
+//! - **PATCH** — правки, не меняющие форму (доки, дефолты). Полностью совместимо.
+//! - **MINOR** — **только аддитивные** изменения: новые опциональные поля / варианты
+//!   enum, которые старые загрузчики игнорируют, а новые читают через serde-дефолты.
+//!   Проект с тем же MAJOR всегда читается, даже если MINOR новее/старее.
+//! - **MAJOR** — ломающие изменения: удаление/переименование полей, смена типа,
+//!   несовместимая семантика. Поднимается ЯВНО и сигнализирует о необходимости миграции.
+//!
+//! Правило загрузки: проект совместим ⇔ его MAJOR равен MAJOR текущей [`SCHEMA_VERSION`].
+//! Чужой MAJOR (и новее, и старее) отвергается до появления явных миграций —
+//! см. [`is_compatible`] / [`check_compatibility`].
+
+/// Текущая версия схемы `ProjectSchema` (semver). Единственный источник истины:
+/// дефолт новых проектов и база для проверки совместимости на загрузке.
+///
+/// Поднимать MAJOR только при ломающих изменениях формы (см. политику модуля).
+pub const SCHEMA_VERSION: &str = "1.0.0";
+
+/// Разобрать строку semver в `(major, minor, patch)`.
+///
+/// Терпимо к pre-release/build-суффиксам (`1.2.0-rc.1`, `1.2.0+meta`): берётся
+/// числовая часть каждого компонента. Возвращает `None`, если major/minor/patch
+/// не парсятся как числа или компонентов меньше трёх.
+pub fn parse_semver(version: &str) -> Option<(u64, u64, u64)> {
+  // Отрезаем build-метаданные (`+...`) и pre-release (`-...`) от patch-хвоста.
+  let core = version.split('+').next().unwrap_or(version);
+  let core = core.split('-').next().unwrap_or(core);
+  let mut parts = core.split('.');
+  let major = parts.next()?.trim().parse().ok()?;
+  let minor = parts.next()?.trim().parse().ok()?;
+  let patch = parts.next()?.trim().parse().ok()?;
+  if parts.next().is_some() {
+    return None; // больше трёх компонентов — не валидный semver
+  }
+  Some((major, minor, patch))
+}
+
+/// MAJOR-компонент текущей [`SCHEMA_VERSION`].
+pub fn current_major() -> u64 {
+  parse_semver(SCHEMA_VERSION)
+    .expect("SCHEMA_VERSION must be valid semver")
+    .0
+}
+
+/// Совместим ли проект данной версии с текущей схемой.
+///
+/// `true` ⇔ версия — валидный semver и её MAJOR равен текущему. MINOR/PATCH
+/// игнорируются (аддитивные изменения безопасны внутри одного MAJOR).
+pub fn is_compatible(version: &str) -> bool {
+  matches!(parse_semver(version), Some((major, _, _)) if major == current_major())
+}
+
+/// Проверить совместимость версии проекта, вернув человекочитаемую ошибку.
+///
+/// Используется на загрузке/валидации. Различает три случая: пустая версия,
+/// невалидный semver и несовместимый MAJOR (с подсказкой о миграции).
+pub fn check_compatibility(version: &str) -> Result<(), String> {
+  if version.trim().is_empty() {
+    return Err("Версия схемы проекта не может быть пустой".to_string());
+  }
+  match parse_semver(version) {
+    None => Err(format!(
+      "Невалидная версия схемы '{version}': ожидается semver MAJOR.MINOR.PATCH (например, {SCHEMA_VERSION})"
+    )),
+    Some((major, _, _)) => {
+      let cur = current_major();
+      if major == cur {
+        Ok(())
+      } else {
+        Err(format!(
+          "Несовместимая версия схемы проекта: '{version}' (major {major}) против текущей {SCHEMA_VERSION} (major {cur}). \
+           Требуется миграция проекта."
+        ))
+      }
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn schema_version_is_valid_semver() {
+    assert!(parse_semver(SCHEMA_VERSION).is_some());
+  }
+
+  #[test]
+  fn parses_plain_and_suffixed_semver() {
+    assert_eq!(parse_semver("1.2.3"), Some((1, 2, 3)));
+    assert_eq!(parse_semver("2.0.0-rc.1"), Some((2, 0, 0)));
+    assert_eq!(parse_semver("1.4.0+build.7"), Some((1, 4, 0)));
+  }
+
+  #[test]
+  fn rejects_malformed_semver() {
+    for bad in ["", "1", "1.0", "1.0.0.0", "v1.0.0", "abc", "1.x.0"] {
+      assert_eq!(parse_semver(bad), None, "should reject {bad:?}");
+    }
+  }
+
+  #[test]
+  fn same_major_is_compatible_regardless_of_minor_patch() {
+    let major = current_major();
+    assert!(is_compatible(&format!("{major}.0.0")));
+    assert!(is_compatible(&format!("{major}.9.5")));
+    assert!(is_compatible(SCHEMA_VERSION));
+  }
+
+  #[test]
+  fn different_major_is_incompatible() {
+    let next = current_major() + 1;
+    assert!(!is_compatible(&format!("{next}.0.0")));
+    assert!(check_compatibility(&format!("{next}.0.0")).is_err());
+  }
+
+  #[test]
+  fn check_compatibility_distinguishes_cases() {
+    assert!(check_compatibility("").is_err()); // пустая
+    assert!(check_compatibility("not-semver").is_err()); // невалидная
+    assert!(check_compatibility(SCHEMA_VERSION).is_ok()); // текущая
+  }
+}


### PR DESCRIPTION
Адресует #375 (code-ядро).

## Проблема
`ProjectSchema.version` — свободная строка, захардкоженная в `"1.0.0"`: нет semver-схемы, нет проверки на загрузке, нет задокументированной гарантии совместимости. postim.life кодогенерят типы из `timeline emit-schema` и строят продукт против этого контракта — им нужен явный версионный контракт.

## Решение
- **Новый модуль** `crates/ts-schema/src/versioning.rs`:
  - `SCHEMA_VERSION` — единственный источник истины (дефолт новых проектов + база проверки).
  - Задокументированная политика прямо в коде: **PATCH/MINOR — только аддитивно** и совместимо внутри одного MAJOR; **MAJOR — ломающее**, поднимается явно.
  - Хелперы `parse_semver` / `is_compatible` / `check_compatibility` (терпимы к `-rc`/`+build` суффиксам).
- `ProjectSchema::new()` берёт версию из `SCHEMA_VERSION` (убран строковый литерал).
- `ProjectSchema::validate()` теперь отвергает пустую / невалидную / несовместимую по MAJOR версию через `check_compatibility` — load-time guard. Вызывающие в `ts-render` (`renderer`) и `ts-render-services` (`project_service`/`render_service`) получают проверку бесплатно.
- Ре-экспорт на корне крейта + тесты (парсинг, совместимость, валидация).

## Тесты
- `cargo test -p ts-schema` → **152 passed, 0 failed**.
- Downstream project-тесты (`ts-render`, `ts-render-services`) + `cargo check --workspace` зелёные.

## Вне scope (процессная часть #375 — за мейнтейнером)
- Публикация `emit-schema` как release-артефакта, тегированного по версии (источник истины для downstream-кодогена).
- Решение, поднимать ли сейчас MAJOR/политику депрекаций формально.

Не закрываю #375 автоматически — остаётся процессная часть; линкуется для трекинга.

🤖 Generated with [Claude Code](https://claude.com/claude-code)