### PR TITLE
feat(bot): transcribe a fresh voice idea into the goal before first-cut (#326)

### DIFF
--- a/apps/cli/src/commands/bot-worker.ts
+++ b/apps/cli/src/commands/bot-worker.ts
@@ -80,6 +80,7 @@ export interface BotWorkerCommandOptions {
   feedbackTranscriberProvider?: BotFeedbackTranscriptionProvider
   feedbackTranscriberModel?: string
   feedbackTranscriberLanguage?: string
+  transcribeVoiceIdeas?: boolean
   firstCutPlanner?: boolean
   firstCutPlannerCommand?: string
   firstCutPlannerKind?: NodeRustFirstCutPlannerKind
@@ -158,6 +159,10 @@ export const botWorkerCommand = new Command("bot-worker")
   )
   .option("--feedback-transcriber-model <model>", "Review voice transcription model")
   .option("--feedback-transcriber-language <language>", "Review voice transcription language hint")
+  .option(
+    "--transcribe-voice-ideas",
+    "Transcribe a fresh voice idea into the goal before first-cut (reuses the feedback transcriber)",
+  )
   .option("--first-cut-planner", "Enable Rust timeline montage-plan/llm-plan first-cut planning")
   .option("--first-cut-planner-command <path>", "Path/name for the Rust timeline first-cut planner command")
   .option("--first-cut-planner-kind <kind>", "Rust first-cut planner kind: auto, montage-plan, or llm-plan")
@@ -277,6 +282,7 @@ export async function runBotWorker(options: BotWorkerCommandOptions = {}): Promi
     aiProjectEditor: services.aiProjectEditor,
     aiProjectEditMaxRepairAttempts: parseOptionalNonNegativeInteger(resolvedOptions.aiEditorRepairAttempts) ?? 1,
     feedbackTranscriber: services.botFeedbackTranscriber,
+    transcribeVoiceIdeas: resolvedOptions.transcribeVoiceIdeas ?? false,
     previewRenderer: createBotReviewPreviewRenderer(services.renderJob, resolvedOptions),
     publishService: services.publish,
     previewResponder: services.botStatus,
@@ -383,6 +389,7 @@ export function resolveBotWorkerCommandOptions(
       options.feedbackTranscriberLanguage,
       env.TIMELINE_BOT_FEEDBACK_TRANSCRIBER_LANGUAGE,
     ),
+    transcribeVoiceIdeas: options.transcribeVoiceIdeas ?? parseBooleanEnv(env.TIMELINE_BOT_TRANSCRIBE_VOICE_IDEAS),
     firstCutPlanner: options.firstCutPlanner ?? parseBooleanEnv(env.TIMELINE_BOT_FIRST_CUT_PLANNER),
     firstCutPlannerCommand: firstConfigured(options.firstCutPlannerCommand, env.TIMELINE_BOT_FIRST_CUT_PLANNER_COMMAND),
     firstCutPlannerKind: firstConfigured(

--- a/config/bot-worker.production.env.example
+++ b/config/bot-worker.production.env.example
@@ -72,6 +72,10 @@ TIMELINE_BOT_FEEDBACK_TRANSCRIBER_PROVIDER=openai
 TIMELINE_BOT_FEEDBACK_TRANSCRIBER_MODEL=whisper-1
 TIMELINE_BOT_FEEDBACK_TRANSCRIBER_LANGUAGE=
 
+# Transcribe a fresh voice idea into the goal before first-cut (reuses the
+# feedback transcriber above). Requires a transcriber provider to be set.
+TIMELINE_BOT_TRANSCRIBE_VOICE_IDEAS=true
+
 # First-cut planner.
 TIMELINE_BOT_FIRST_CUT_PLANNER=true
 TIMELINE_BOT_FIRST_CUT_PLANNER_COMMAND=/usr/local/bin/timeline

--- a/packages/adapters/src/node/__tests__/telegram-bot-worker.test.ts
+++ b/packages/adapters/src/node/__tests__/telegram-bot-worker.test.ts
@@ -320,6 +320,74 @@ describe("Telegram bot worker", () => {
     expect(onResult).toHaveBeenCalledWith(result)
   })
 
+  const voiceIdeaUpdate = (): TelegramBotUpdate => ({
+    update_id: 21,
+    message: {
+      message_id: "voice-idea-1",
+      chat: { id: "chat-1" },
+      from: { id: "user-1" },
+      voice: {
+        file_id: "voice-file-id",
+        file_unique_id: "unique-voice-1",
+        mime_type: "audio/ogg",
+        file_size: 4096,
+        duration: 9,
+      },
+    },
+  })
+
+  it("transcribes a fresh voice idea into the workflow goal when enabled (#326)", async () => {
+    const { service, runTelegramLikePayload } = createWorkflowService()
+    const transcribeFeedback = vi.fn(async () => ({ text: "make a 30s promo about my cafe" }))
+    const worker = new NodeTelegramBotWorker({
+      workflow: service,
+      feedbackTranscriber: { transcribeFeedback } as unknown as IBotFeedbackTranscriber,
+      transcribeVoiceIdeas: true,
+    })
+
+    const result = await worker.handleUpdate(voiceIdeaUpdate())
+
+    expect(transcribeFeedback).toHaveBeenCalledOnce()
+    expect(result).toMatchObject({ skipped: false })
+    expect(runTelegramLikePayload).toHaveBeenCalledOnce()
+    const [payloadArg] = runTelegramLikePayload.mock.calls[0]
+    expect(payloadArg).toMatchObject({ text: "make a 30s promo about my cafe" })
+  })
+
+  it("does not transcribe voice ideas when the flag is off", async () => {
+    const { service, runTelegramLikePayload } = createWorkflowService()
+    const transcribeFeedback = vi.fn(async () => ({ text: "should not run" }))
+    const worker = new NodeTelegramBotWorker({
+      workflow: service,
+      feedbackTranscriber: { transcribeFeedback } as unknown as IBotFeedbackTranscriber,
+    })
+
+    await worker.handleUpdate(voiceIdeaUpdate())
+
+    expect(transcribeFeedback).not.toHaveBeenCalled()
+    const [payloadArg] = runTelegramLikePayload.mock.calls[0]
+    expect(payloadArg.text).toBeUndefined()
+  })
+
+  it("keeps the original message when voice-idea transcription fails", async () => {
+    const { service, runTelegramLikePayload } = createWorkflowService()
+    const transcribeFeedback = vi.fn(async () => {
+      throw new Error("whisper down")
+    })
+    const worker = new NodeTelegramBotWorker({
+      workflow: service,
+      feedbackTranscriber: { transcribeFeedback } as unknown as IBotFeedbackTranscriber,
+      transcribeVoiceIdeas: true,
+    })
+
+    const result = await worker.handleUpdate(voiceIdeaUpdate())
+
+    expect(transcribeFeedback).toHaveBeenCalledOnce()
+    expect(result).toMatchObject({ skipped: false })
+    const [payloadArg] = runTelegramLikePayload.mock.calls[0]
+    expect(payloadArg.text).toBeUndefined()
+  })
+
   it("queues workflow runs without waiting for render completion", async () => {
     let resolveWorkflow!: () => void
     const runTelegramLikePayload = vi.fn(

--- a/packages/adapters/src/node/telegram-bot-worker.ts
+++ b/packages/adapters/src/node/telegram-bot-worker.ts
@@ -122,6 +122,14 @@ export interface NodeTelegramBotWorkerOptions {
   aiProjectEditor?: IAIProjectEditor
   aiProjectEditMaxRepairAttempts?: number
   feedbackTranscriber?: IBotFeedbackTranscriber
+  /**
+   * Transcribe a fresh voice/video-note idea into the workflow goal via
+   * {@link feedbackTranscriber} before draft/first-cut assembly (#326). When a
+   * new (non-review) message has no usable text but carries a voice idea, its
+   * transcription becomes the idea text that feeds the script generator.
+   * Requires {@link feedbackTranscriber}; off by default to preserve behavior.
+   */
+  transcribeVoiceIdeas?: boolean
   publishService?: IPublishService
   previewRenderer?: NodeTelegramBotReviewPreviewRenderer
   previewResponder?: NodeTelegramBotReviewPreviewResponder
@@ -673,13 +681,17 @@ export class NodeTelegramBotWorker {
     const reviewFeedbackResult = await this.handleReviewFeedbackUpdate(update, payload)
     if (reviewFeedbackResult) return reviewFeedbackResult
 
-    const draftResult = await this.handleDraftUpdate(update, payload, options)
+    // A fresh voice idea (not review feedback) is transcribed into the goal text
+    // so it flows through the draft / first-cut / script generator (#326).
+    const ideaPayload = await this.applyVoiceIdeaTranscription(payload)
+
+    const draftResult = await this.handleDraftUpdate(update, ideaPayload, options)
     if (draftResult) return draftResult
 
-    return this.runOrQueueWorkflow(update, payload, {
+    return this.runOrQueueWorkflow(update, ideaPayload, {
       run: (workflowOptions) =>
         this.options.workflow.runTelegramLikePayload(
-          payload,
+          ideaPayload,
           this.withReviewApprovalGate(
             mergeWorkflowOptions(mergeWorkflowOptions(this.workflowOptions, options.workflowOptions), workflowOptions),
           ),
@@ -1644,6 +1656,57 @@ export class NodeTelegramBotWorker {
       ...(observabilityPatch ? { metadata: mergeMetadataObservability(session.metadata, observabilityPatch) } : {}),
       updatedAt: timestamp,
     }
+  }
+
+  /**
+   * Return a copy of {@link payload} with its `text` set to the transcription of
+   * a voice idea, when {@link NodeTelegramBotWorkerOptions.transcribeVoiceIdeas}
+   * is enabled and the message carries a voice/video-note idea without text.
+   * Best-effort: a transcription failure leaves the original payload untouched
+   * so the user's message is never dropped (#326).
+   */
+  private async applyVoiceIdeaTranscription(
+    payload: TelegramLikeBotPayload,
+  ): Promise<TelegramLikeBotPayload> {
+    try {
+      const ideaText = await this.resolveVoiceIdeaText(payload)
+      return ideaText ? { ...payload, text: ideaText } : payload
+    } catch {
+      return payload
+    }
+  }
+
+  private async resolveVoiceIdeaText(
+    payload: TelegramLikeBotPayload,
+  ): Promise<string | undefined> {
+    if (!this.options.transcribeVoiceIdeas || !this.options.feedbackTranscriber) {
+      return undefined
+    }
+
+    // Already has usable, non-command text — nothing to transcribe.
+    const text = normalizedTelegramText(payload.text ?? payload.caption)
+    if (text && !text.startsWith("/")) {
+      return undefined
+    }
+
+    const workflow = createTelegramLikeBotWorkflow(payload)
+    const media = workflow.media?.find((item) => getFeedbackMediaKind(item) !== undefined)
+    if (!media) return undefined
+
+    const kind = getFeedbackMediaKind(media)
+    if (!kind) return undefined
+
+    const transcription = await this.options.feedbackTranscriber.transcribeFeedback({
+      workflow,
+      media,
+      kind,
+      payload,
+      metadata: {
+        purpose: "idea",
+      },
+    })
+
+    return normalizedTelegramText(transcription.text)
   }
 
   private async resolveReviewFeedbackText(


### PR DESCRIPTION
Завершает голосовую часть intent'а #326.

## Контекст
Генератор сценария (idea → `ScriptDraft` → first-cut) уже был собран end-to-end (контракт + `NodeLlmScriptPlanner` + `DefaultScriptGenerator` + `enrichWithScript`). Но работал только текстовый путь: исходная **голосовая идея** не превращалась в текст, поэтому до раскадровки не доходила. Транскрибировался лишь review-фидбэк.

## Что добавлено
- **`NodeTelegramBotWorker`** — opt-in `transcribeVoiceIdeas`. Когда свежее (не review) сообщение содержит voice/video-note без полезного текста, его транскрипция (через **существующий** `feedbackTranscriber`/Whisper) становится текстом сообщения → `goal` → script generator → first cut. Вставка между review-feedback и draft-путём, так что подхватывают и multi-message draft, и прямой workflow. **Best-effort**: сбой транскрипции оставляет исходное сообщение нетронутым (не теряем медиа пользователя).
- **bot-worker CLI** — флаг `--transcribe-voice-ideas` + env `TIMELINE_BOT_TRANSCRIBE_VOICE_IDEAS`; задокументировано в `config/bot-worker.production.env.example`.
- **Тесты** — включено/выключено/сбой транскрипции.

## Проверка
- `tsc --noEmit` (adapters + cli) — чисто.
- adapters node suite — **333 passed** (3 новых теста), cli bot-worker — **16 passed**.

## Примечание
Контракт явно откладывает транскрипцию «upstream» — здесь она сделана опционально и переиспользует уже настроенный транскрайбер, без нового провайдера. Этим #326 закрывается полностью (чеклист + голосовой путь).

🤖 Generated with [Claude Code](https://claude.com/claude-code)