### PR TITLE
feat(bot): concierge manual-approval toggle + operator decision log (#325)

### DIFF
--- a/apps/cli/src/commands/bot-worker.ts
+++ b/apps/cli/src/commands/bot-worker.ts
@@ -81,6 +81,7 @@ export interface BotWorkerCommandOptions {
   feedbackTranscriberModel?: string
   feedbackTranscriberLanguage?: string
   transcribeVoiceIdeas?: boolean
+  conciergeApproval?: boolean
   firstCutPlanner?: boolean
   firstCutPlannerCommand?: string
   firstCutPlannerKind?: NodeRustFirstCutPlannerKind
@@ -162,6 +163,10 @@ export const botWorkerCommand = new Command("bot-worker")
   .option(
     "--transcribe-voice-ideas",
     "Transcribe a fresh voice idea into the goal before first-cut (reuses the feedback transcriber)",
+  )
+  .option(
+    "--no-concierge-approval",
+    "Disable the operator manual-approval gate and auto-deliver results (default: approval required)",
   )
   .option("--first-cut-planner", "Enable Rust timeline montage-plan/llm-plan first-cut planning")
   .option("--first-cut-planner-command <path>", "Path/name for the Rust timeline first-cut planner command")
@@ -283,6 +288,7 @@ export async function runBotWorker(options: BotWorkerCommandOptions = {}): Promi
     aiProjectEditMaxRepairAttempts: parseOptionalNonNegativeInteger(resolvedOptions.aiEditorRepairAttempts) ?? 1,
     feedbackTranscriber: services.botFeedbackTranscriber,
     transcribeVoiceIdeas: resolvedOptions.transcribeVoiceIdeas ?? false,
+    conciergeApproval: resolvedOptions.conciergeApproval ?? true,
     previewRenderer: createBotReviewPreviewRenderer(services.renderJob, resolvedOptions),
     publishService: services.publish,
     previewResponder: services.botStatus,
@@ -390,6 +396,10 @@ export function resolveBotWorkerCommandOptions(
       env.TIMELINE_BOT_FEEDBACK_TRANSCRIBER_LANGUAGE,
     ),
     transcribeVoiceIdeas: options.transcribeVoiceIdeas ?? parseBooleanEnv(env.TIMELINE_BOT_TRANSCRIBE_VOICE_IDEAS),
+    // Default ON (concierge). `--no-concierge-approval` sets options.conciergeApproval=false;
+    // otherwise the env can disable it, falling back to enabled.
+    conciergeApproval:
+      options.conciergeApproval === false ? false : (parseBooleanEnv(env.TIMELINE_BOT_CONCIERGE_APPROVAL) ?? true),
     firstCutPlanner: options.firstCutPlanner ?? parseBooleanEnv(env.TIMELINE_BOT_FIRST_CUT_PLANNER),
     firstCutPlannerCommand: firstConfigured(options.firstCutPlannerCommand, env.TIMELINE_BOT_FIRST_CUT_PLANNER_COMMAND),
     firstCutPlannerKind: firstConfigured(

--- a/config/bot-worker.production.env.example
+++ b/config/bot-worker.production.env.example
@@ -76,6 +76,11 @@ TIMELINE_BOT_FEEDBACK_TRANSCRIBER_LANGUAGE=
 # feedback transcriber above). Requires a transcriber provider to be set.
 TIMELINE_BOT_TRANSCRIBE_VOICE_IDEAS=true
 
+# Concierge manual-approval gate (#325): require an operator /approve before
+# delivery/publish. Default on; set false (or pass --no-concierge-approval) for
+# self-serve auto-delivery.
+TIMELINE_BOT_CONCIERGE_APPROVAL=true
+
 # First-cut planner.
 TIMELINE_BOT_FIRST_CUT_PLANNER=true
 TIMELINE_BOT_FIRST_CUT_PLANNER_COMMAND=/usr/local/bin/timeline

--- a/packages/adapters/src/node/__tests__/telegram-bot-worker.test.ts
+++ b/packages/adapters/src/node/__tests__/telegram-bot-worker.test.ts
@@ -388,6 +388,67 @@ describe("Telegram bot worker", () => {
     expect(payloadArg.text).toBeUndefined()
   })
 
+  const ideaTextUpdate = (id: number): TelegramBotUpdate => ({
+    update_id: id,
+    message: {
+      message_id: `idea-${id}`,
+      chat: { id: "chat-1" },
+      from: { id: "user-1" },
+      text: "make a promo",
+    },
+  })
+
+  it("gates delivery behind operator approval by default (#325)", async () => {
+    const { store } = createEditSessionStore()
+    const { service, runTelegramLikePayload } = createWorkflowService()
+    const worker = new NodeTelegramBotWorker({ workflow: service, editSessionStore: store })
+
+    await worker.handleUpdate(ideaTextUpdate(31))
+
+    expect(runTelegramLikePayload).toHaveBeenCalledOnce()
+    const [, workflowOptions] = runTelegramLikePayload.mock.calls[0]
+    expect(workflowOptions).toMatchObject({
+      approvalGate: { enabled: true, previewDestination: "telegram" },
+    })
+  })
+
+  it("bypasses the approval gate when concierge approval is disabled (#325)", async () => {
+    const { store } = createEditSessionStore()
+    const { service, runTelegramLikePayload } = createWorkflowService()
+    const worker = new NodeTelegramBotWorker({
+      workflow: service,
+      editSessionStore: store,
+      conciergeApproval: false,
+    })
+
+    await worker.handleUpdate(ideaTextUpdate(32))
+
+    expect(runTelegramLikePayload).toHaveBeenCalledOnce()
+    const [, workflowOptions] = runTelegramLikePayload.mock.calls[0]
+    expect(workflowOptions?.approvalGate).toBeUndefined()
+  })
+
+  it("records the approving operator in the edit session (#325)", async () => {
+    const session = createReviewSession({ status: "preview_ready" })
+    const { store, records } = createEditSessionStore([session])
+    const { service } = createWorkflowService()
+    const worker = new NodeTelegramBotWorker({ workflow: service, editSessionStore: store })
+
+    await worker.handleUpdate({
+      update_id: 33,
+      message: {
+        message_id: "approve-33",
+        chat: { id: "chat-1" },
+        from: { id: "user-1" },
+        text: "/approve",
+      },
+    })
+
+    const approved = records.get(session.id)
+    expect(approved?.status).toBe("approved")
+    expect(approved?.approvedBy).toBe("user-1")
+  })
+
   it("queues workflow runs without waiting for render completion", async () => {
     let resolveWorkflow!: () => void
     const runTelegramLikePayload = vi.fn(

--- a/packages/adapters/src/node/telegram-bot-worker.ts
+++ b/packages/adapters/src/node/telegram-bot-worker.ts
@@ -130,6 +130,14 @@ export interface NodeTelegramBotWorkerOptions {
    * Requires {@link feedbackTranscriber}; off by default to preserve behavior.
    */
   transcribeVoiceIdeas?: boolean
+  /**
+   * Concierge approval toggle (#325). When `true` (default whenever an
+   * {@link editSessionStore} is configured), every result is gated behind an
+   * operator `/approve` before delivery/publish — a human in the loop. Set to
+   * `false` to bypass the gate and auto-deliver (self-serve mode), while keeping
+   * the edit-session store for other features.
+   */
+  conciergeApproval?: boolean
   publishService?: IPublishService
   previewRenderer?: NodeTelegramBotReviewPreviewRenderer
   previewResponder?: NodeTelegramBotReviewPreviewResponder
@@ -779,6 +787,8 @@ export class NodeTelegramBotWorker {
     options: NodeBotWorkflowServiceOptions | undefined,
   ): NodeBotWorkflowServiceOptions | undefined {
     if (!this.options.editSessionStore) return options
+    // Concierge toggle (#325): bypass the gate for auto-delivery when disabled.
+    if (this.options.conciergeApproval === false) return options
     const gatedOptions = mergeWorkflowOptions(options, {
       approvalGate: {
         enabled: true,
@@ -1241,12 +1251,14 @@ export class NodeTelegramBotWorker {
     }
 
     const timestamp = this.now()
+    const approvedBy = payload.from?.id === undefined ? undefined : String(payload.from.id)
     const approvedSession: BotEditSession = {
       ...session,
       status: "approved",
       approvedRevisionId: revision.id,
       approvedAt: timestamp,
       ...(payload.message_id !== undefined ? { approvedMessageId: String(payload.message_id) } : {}),
+      ...(approvedBy ? { approvedBy } : {}),
       updatedAt: timestamp,
     }
     await this.options.editSessionStore?.writeSession(approvedSession)

--- a/packages/core/src/types/bot-workflow.ts
+++ b/packages/core/src/types/bot-workflow.ts
@@ -140,6 +140,8 @@ export interface BotEditSession {
   approvedRevisionId?: string
   approvedAt?: string
   approvedMessageId?: string
+  /** Operator (Telegram user id) who approved the result, for the concierge decision log (#325). */
+  approvedBy?: string
   cancelledAt?: string
   failedAt?: string
   failure?: string


### PR DESCRIPTION
Адресует #325.

## Контекст
Review-loop уже реализует человека-в-петле: оператор `/approve` гейтит доставку/публикацию (`approvalGate`, preview→approve, публикация после апрува). Но:
- gate был **жёстко включён** при наличии edit-session store — **тумблера не было**;
- апрув не фиксировал, **кто** его сделал.

## Что добавлено
- **Тумблер** `conciergeApproval` в `NodeTelegramBotWorker` (по умолчанию вкл). При `false` `withReviewApprovalGate` обходит гейт → результат доставляется автоматически (self-serve, задел под #334), при этом edit-session store остаётся для остальных фич.
- **Лог решения оператора**: при `/approve` в сессию пишется `approvedBy` (Telegram user id оператора) рядом с `approvedAt`/`approvedRevisionId`.
- **CLI**: `--no-concierge-approval` + env `TIMELINE_BOT_CONCIERGE_APPROVAL` (default on); задокументировано в `config/bot-worker.production.env.example`.
- **Тесты**: гейт включён по умолчанию, гейт обходится при выключении, `approvedBy` записывается.

## Чеклист #325
- [x] gate перед доставкой/публикацией — был, теперь **управляемый тумблером**
- [x] операторский апрув через бот-команды (`/approve`, `/revise`, `/versions`)
- [x] лог решений оператора — добавлен `approvedBy`

## Проверка
- `tsc --noEmit` (core + adapters + cli) — чисто.
- adapters node suite — **352 passed** (3 новых), cli bot-worker — **16 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)