### PR TITLE
feat(gateway): verify Telegram Mini App initData → userId/chatId (#329)

### DIFF
--- a/packages/adapters/src/node/__tests__/telegram-init-data.test.ts
+++ b/packages/adapters/src/node/__tests__/telegram-init-data.test.ts
@@ -1,0 +1,95 @@
+import crypto from "node:crypto"
+import { describe, expect, it } from "vitest"
+import { verifyTelegramInitData } from "../telegram-init-data"
+
+const BOT_TOKEN = "123456:test-bot-token"
+
+/** Build a signed initData string the way Telegram does, for round-trip tests. */
+function signInitData(fields: Record<string, string>, botToken = BOT_TOKEN): string {
+  const dataCheckString = Object.entries(fields)
+    .map(([key, value]) => `${key}=${value}`)
+    .sort()
+    .join("\n")
+  const secretKey = crypto.createHmac("sha256", "WebAppData").update(botToken).digest()
+  const hash = crypto.createHmac("sha256", secretKey).update(dataCheckString).digest("hex")
+  const params = new URLSearchParams(fields)
+  params.set("hash", hash)
+  return params.toString()
+}
+
+const baseFields = (overrides: Record<string, string> = {}) => ({
+  auth_date: "1700000000",
+  query_id: "AAabcdef",
+  user: JSON.stringify({ id: 42, first_name: "Ada", username: "ada" }),
+  ...overrides,
+})
+
+describe("verifyTelegramInitData", () => {
+  it("accepts authentic initData and extracts userId/user/queryId", () => {
+    const result = verifyTelegramInitData(signInitData(baseFields()), BOT_TOKEN)
+    expect(result).toMatchObject({
+      valid: true,
+      data: {
+        userId: "42",
+        authDate: 1700000000,
+        queryId: "AAabcdef",
+        user: { id: 42, username: "ada" },
+      },
+    })
+  })
+
+  it("extracts chatId when a chat context is present", () => {
+    const initData = signInitData(baseFields({ chat: JSON.stringify({ id: -100123, type: "supergroup" }) }))
+    const result = verifyTelegramInitData(initData, BOT_TOKEN)
+    expect(result.valid).toBe(true)
+    if (result.valid) expect(result.data.chatId).toBe("-100123")
+  })
+
+  it("rejects a tampered field (hash mismatch)", () => {
+    const initData = signInitData(baseFields())
+    // Flip the user id after signing.
+    const tampered = initData.replace(/user=[^&]*/, encodeURI('user={"id":99,"first_name":"Mallory"}'))
+    const result = verifyTelegramInitData(tampered, BOT_TOKEN)
+    expect(result).toEqual({ valid: false, reason: "hash mismatch" })
+  })
+
+  it("rejects a wrong bot token", () => {
+    const result = verifyTelegramInitData(signInitData(baseFields()), "999999:other-token")
+    expect(result).toEqual({ valid: false, reason: "hash mismatch" })
+  })
+
+  it("rejects when hash is missing", () => {
+    const params = new URLSearchParams(baseFields())
+    const result = verifyTelegramInitData(params.toString(), BOT_TOKEN)
+    expect(result).toEqual({ valid: false, reason: "missing hash" })
+  })
+
+  it("rejects empty initData and missing token", () => {
+    expect(verifyTelegramInitData("", BOT_TOKEN)).toEqual({ valid: false, reason: "empty initData" })
+    expect(verifyTelegramInitData("x=1", "")).toEqual({ valid: false, reason: "missing bot token" })
+  })
+
+  it("rejects expired initData when maxAgeSeconds is set", () => {
+    const initData = signInitData(baseFields({ auth_date: "1700000000" }))
+    const result = verifyTelegramInitData(initData, BOT_TOKEN, {
+      maxAgeSeconds: 3600,
+      nowMs: () => 1700000000_000 + 7200_000, // 2h later
+    })
+    expect(result).toEqual({ valid: false, reason: "initData expired" })
+  })
+
+  it("accepts fresh initData within maxAgeSeconds", () => {
+    const initData = signInitData(baseFields({ auth_date: "1700000000" }))
+    const result = verifyTelegramInitData(initData, BOT_TOKEN, {
+      maxAgeSeconds: 3600,
+      nowMs: () => 1700000000_000 + 600_000, // 10 min later
+    })
+    expect(result.valid).toBe(true)
+  })
+
+  it("rejects when the user field is absent (no user id)", () => {
+    const fields = { auth_date: "1700000000" }
+    const result = verifyTelegramInitData(signInitData(fields), BOT_TOKEN)
+    expect(result).toEqual({ valid: false, reason: "missing user id" })
+  })
+})

--- a/packages/adapters/src/node/index.ts
+++ b/packages/adapters/src/node/index.ts
@@ -189,6 +189,13 @@ export {
   type TelegramBotUpdate,
 } from "./telegram-bot-worker"
 export {
+  type TelegramInitDataUser,
+  type TelegramInitDataVerification,
+  verifyTelegramInitData,
+  type VerifiedTelegramInitData,
+  type VerifyTelegramInitDataOptions,
+} from "./telegram-init-data"
+export {
   NodeTelegramRenderJobReviewPreviewRenderer,
   type NodeTelegramRenderJobReviewPreviewRendererOptions,
 } from "./telegram-review-preview-renderer"

--- a/packages/adapters/src/node/telegram-init-data.ts
+++ b/packages/adapters/src/node/telegram-init-data.ts
@@ -1,0 +1,145 @@
+/**
+ * Telegram Mini App `initData` verification (#329, Phase 2 gateway auth).
+ *
+ * The Mini App front-end sends `window.Telegram.WebApp.initData` (a URL-encoded
+ * query string) with every gateway request. This module verifies its authenticity
+ * against the bot token per the Telegram WebApp spec and extracts the caller's
+ * `userId` / `chatId`, so the HTTP/SSE gateway can authenticate the same identities
+ * the bot uses — without trusting client-supplied ids.
+ *
+ * Algorithm (https://core.telegram.org/bots/webapps#validating-data-received-via-the-mini-app):
+ *   secret_key   = HMAC_SHA256(key="WebAppData", message=bot_token)
+ *   data_check   = sorted "key=value" lines (excluding `hash`), joined by "\n"
+ *   computed_hash = HMAC_SHA256(key=secret_key, message=data_check) as hex
+ * The request is authentic iff `computed_hash === hash` (timing-safe).
+ */
+
+import crypto from "node:crypto"
+
+export interface TelegramInitDataUser {
+  id: number
+  is_bot?: boolean
+  first_name?: string
+  last_name?: string
+  username?: string
+  language_code?: string
+  is_premium?: boolean
+  photo_url?: string
+}
+
+export interface VerifiedTelegramInitData {
+  /** Telegram user id as a string (matches the bot's `from.id` handling). */
+  userId: string
+  /** Chat id, when the Mini App was opened from a chat context. */
+  chatId?: string
+  user?: TelegramInitDataUser
+  /** `auth_date` as unix seconds. */
+  authDate: number
+  /** Opaque `query_id`, when present (needed for `answerWebAppQuery`). */
+  queryId?: string
+  /** All verified fields (excluding `hash`) for downstream use. */
+  raw: Record<string, string>
+}
+
+export type TelegramInitDataVerification =
+  | { valid: true; data: VerifiedTelegramInitData }
+  | { valid: false; reason: string }
+
+export interface VerifyTelegramInitDataOptions {
+  /**
+   * Reject when `auth_date` is older than this many seconds (replay protection).
+   * Omit or set `0` to disable the freshness check.
+   */
+  maxAgeSeconds?: number
+  /** Injectable clock (ms since epoch) for deterministic tests. */
+  nowMs?: () => number
+}
+
+/**
+ * Verify a Telegram Mini App `initData` string against the bot token.
+ * Never throws: returns a discriminated result so the gateway can map a failure
+ * to `401` without try/catch.
+ */
+export function verifyTelegramInitData(
+  initData: string,
+  botToken: string,
+  options: VerifyTelegramInitDataOptions = {},
+): TelegramInitDataVerification {
+  if (!initData) return { valid: false, reason: "empty initData" }
+  if (!botToken) return { valid: false, reason: "missing bot token" }
+
+  let params: URLSearchParams
+  try {
+    params = new URLSearchParams(initData)
+  } catch {
+    return { valid: false, reason: "malformed initData" }
+  }
+
+  const hash = params.get("hash")
+  if (!hash) return { valid: false, reason: "missing hash" }
+  if (!/^[0-9a-f]+$/i.test(hash)) return { valid: false, reason: "malformed hash" }
+
+  const raw: Record<string, string> = {}
+  const pairs: string[] = []
+  for (const [key, value] of params.entries()) {
+    if (key === "hash") continue
+    raw[key] = value
+    pairs.push(`${key}=${value}`)
+  }
+  pairs.sort()
+  const dataCheckString = pairs.join("\n")
+
+  const secretKey = crypto.createHmac("sha256", "WebAppData").update(botToken).digest()
+  const computed = crypto.createHmac("sha256", secretKey).update(dataCheckString).digest("hex")
+
+  const provided = Buffer.from(hash, "hex")
+  const expected = Buffer.from(computed, "hex")
+  if (provided.length !== expected.length || !crypto.timingSafeEqual(provided, expected)) {
+    return { valid: false, reason: "hash mismatch" }
+  }
+
+  const authDate = Number(raw.auth_date)
+  if (!Number.isFinite(authDate)) {
+    return { valid: false, reason: "missing or invalid auth_date" }
+  }
+  if (options.maxAgeSeconds && options.maxAgeSeconds > 0) {
+    const nowSeconds = Math.floor((options.nowMs?.() ?? Date.now()) / 1000)
+    if (nowSeconds - authDate > options.maxAgeSeconds) {
+      return { valid: false, reason: "initData expired" }
+    }
+  }
+
+  let user: TelegramInitDataUser | undefined
+  if (raw.user) {
+    try {
+      user = JSON.parse(raw.user) as TelegramInitDataUser
+    } catch {
+      return { valid: false, reason: "malformed user field" }
+    }
+  }
+
+  const userId = user?.id === undefined ? undefined : String(user.id)
+  if (!userId) return { valid: false, reason: "missing user id" }
+
+  let chatId: string | undefined
+  if (raw.chat) {
+    try {
+      const chat = JSON.parse(raw.chat) as { id?: number | string }
+      if (chat?.id !== undefined) chatId = String(chat.id)
+    } catch {
+      // A malformed optional chat field does not invalidate an otherwise-authentic request.
+    }
+  }
+
+  return {
+    valid: true,
+    data: {
+      userId,
+      ...(chatId ? { chatId } : {}),
+      ...(user ? { user } : {}),
+      authDate,
+      ...(raw.query_id ? { queryId: raw.query_id } : {}),
+      raw,
+    },
+  }
+}


### PR DESCRIPTION
Первый кусок #329 (Phase 2 API/SSE-шлюз) — **примитив авторизации**.

Mini App шлёт `window.Telegram.WebApp.initData` с каждым запросом; шлюз обязан проверить его подлинность по bot-токену (а не доверять id с клиента) и получить тот же `userId`/`chatId`, что использует бот.

## Что сделано
- `verifyTelegramInitData(initData, botToken, { maxAgeSeconds?, nowMs? })`:
  - spec-корректная проверка по [Telegram WebApp](https://core.telegram.org/bots/webapps#validating-data-received-via-the-mini-app): `secret = HMAC_SHA256("WebAppData", token)`, `hash = HMAC_SHA256(secret, data_check_string)`, **timing-safe** сравнение;
  - опциональная свежесть `auth_date` (`maxAgeSeconds`, инъекция часов для тестов);
  - извлечение `userId` / `chatId` / `user` / `queryId`;
  - возвращает дискриминированный `{ valid: true, data } | { valid: false, reason }` — **не бросает**, чтобы шлюз чисто мапил в `401`.
- Экспорт из `@timeline-studio/adapters/node`.
- Тесты (9): подлинный round-trip, chat-контекст, подмена поля, чужой токен, нет hash, пустой/без токена, окно протухания, нет user id.

## Проверка
- adapters `tsc --noEmit` — чисто; тесты — **9 passed**.

## Дальше по #329 (нужно твоё направление по архитектуре)
Оставшиеся пункты — это уже сам HTTP/SSE-слой, и тут есть развилка:
- [ ] **транспорт**: расширять существующий tRPC в `src-node`, или поднять отдельный raw HTTP/SSE-шлюз? `src-node` сейчас tRPC (media/queue/cache), бот-порты там не экспонированы.
- [ ] эндпоинты `session.* / edit.* / render.* (SSE) / publish.*` поверх тех же core-портов;
- [ ] общий session/edit store с ботом без гонок (бот использует файловые сторы).

Этот PR не закрывает #329 — это фундамент. Скажешь транспорт (tRPC vs raw HTTP) — продолжу слоем эндпоинтов.

🤖 Generated with [Claude Code](https://claude.com/claude-code)