### PR TITLE
feat(gateway): tRPC auth layer over Telegram initData (#329)

### DIFF
--- a/src-node/__tests__/api/auth.test.ts
+++ b/src-node/__tests__/api/auth.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Gateway auth (#329) — initData-protected tRPC procedures.
+ */
+
+import { describe, test, expect } from "bun:test"
+import crypto from "node:crypto"
+import { appRouter } from "../../src/api/root"
+import { extractInitData } from "../../src/api/context"
+import type { Context } from "../../src/api/context"
+import { createLogger } from "../../src/utils/logger"
+
+const BOT_TOKEN = "123456:test-bot-token"
+
+function signInitData(fields: Record<string, string>, botToken = BOT_TOKEN): string {
+  const dataCheckString = Object.entries(fields)
+    .map(([key, value]) => `${key}=${value}`)
+    .sort()
+    .join("\n")
+  const secretKey = crypto.createHmac("sha256", "WebAppData").update(botToken).digest()
+  const hash = crypto.createHmac("sha256", secretKey).update(dataCheckString).digest("hex")
+  const params = new URLSearchParams(fields)
+  params.set("hash", hash)
+  return params.toString()
+}
+
+const signedInitData = () =>
+  signInitData({
+    auth_date: "1700000000",
+    user: JSON.stringify({ id: 42, first_name: "Ada", username: "ada" }),
+  })
+
+function makeContext(overrides: Partial<Context> = {}): Context {
+  return {
+    logger: createLogger("test"),
+    botToken: BOT_TOKEN,
+    initDataMaxAge: 0,
+    ...overrides,
+  } as Context
+}
+
+async function expectTrpcError(promise: Promise<unknown>, code: string): Promise<void> {
+  try {
+    await promise
+    throw new Error("expected the call to throw")
+  } catch (error) {
+    expect((error as { code?: string }).code).toBe(code)
+  }
+}
+
+describe("Gateway auth router (#329)", () => {
+  test("auth.me returns the verified identity for valid initData", async () => {
+    const caller = appRouter.createCaller(makeContext({ initData: signedInitData() }))
+    const me = await caller.auth.me()
+    expect(me).toEqual({ userId: "42", chatId: null, username: "ada" })
+  })
+
+  test("rejects a request without initData (401)", async () => {
+    const caller = appRouter.createCaller(makeContext())
+    await expectTrpcError(caller.auth.me(), "UNAUTHORIZED")
+  })
+
+  test("rejects initData signed with a different token (401)", async () => {
+    const caller = appRouter.createCaller(
+      makeContext({ initData: signInitData({ auth_date: "1700000000", user: '{"id":1}' }, "999:other") }),
+    )
+    await expectTrpcError(caller.auth.me(), "UNAUTHORIZED")
+  })
+
+  test("fails when the gateway has no bot token configured (500)", async () => {
+    const caller = appRouter.createCaller(makeContext({ initData: signedInitData(), botToken: undefined }))
+    await expectTrpcError(caller.auth.me(), "INTERNAL_SERVER_ERROR")
+  })
+
+  test("enforces initData freshness when initDataMaxAge is set", async () => {
+    const caller = appRouter.createCaller(makeContext({ initData: signedInitData(), initDataMaxAge: 1 }))
+    // auth_date 1700000000 is far in the past relative to the real clock.
+    await expectTrpcError(caller.auth.me(), "UNAUTHORIZED")
+  })
+})
+
+describe("extractInitData", () => {
+  test("reads the Authorization: tma <data> header", () => {
+    const req = new Request("http://x", { headers: { authorization: "tma abc.def" } })
+    expect(extractInitData(req)).toBe("abc.def")
+  })
+
+  test("reads the X-Telegram-Init-Data header", () => {
+    const req = new Request("http://x", { headers: { "x-telegram-init-data": "raw-init" } })
+    expect(extractInitData(req)).toBe("raw-init")
+  })
+
+  test("returns undefined when no init data header is present", () => {
+    expect(extractInitData(new Request("http://x"))).toBeUndefined()
+    expect(extractInitData(undefined)).toBeUndefined()
+  })
+})

--- a/src-node/src/api/context.ts
+++ b/src-node/src/api/context.ts
@@ -3,6 +3,7 @@ import type { CacheService } from "../services/cache-service"
 import type { QueueService } from "../services/queue-service"
 import type { Logger } from "../utils/logger"
 import { createLogger } from "../utils/logger"
+import { config } from "../config"
 
 /**
  * tRPC request context
@@ -12,22 +13,50 @@ export interface Context {
   cacheService: CacheService
   queueService: QueueService
   logger: Logger
+  /** Raw Telegram Mini App `initData` from the request, if present (#329). */
+  initData?: string
+  /** Bot token used to verify `initData` (from config). */
+  botToken?: string
+  /** Max `initData` age in seconds; 0 disables the freshness check. */
+  initDataMaxAge?: number
+}
+
+type ContextServices = Pick<Context, "mediaService" | "cacheService" | "queueService">
+
+/** Options passed by the tRPC fetch adapter for each request. */
+export interface CreateContextOptions {
+  req?: Request
 }
 
 // Global services (initialized in main.ts)
-let globalServices: Omit<Context, "logger"> | null = null
+let globalServices: ContextServices | null = null
 
 /**
  * Initialize global services
  */
-export function initializeServices(services: Omit<Context, "logger">): void {
+export function initializeServices(services: ContextServices): void {
   globalServices = services
+}
+
+/**
+ * Extract the Telegram Mini App `initData` from a request.
+ * Accepts `Authorization: tma <initData>` (Telegram convention) or the
+ * `X-Telegram-Init-Data` header.
+ */
+export function extractInitData(req: Request | undefined): string | undefined {
+  if (!req) return undefined
+  const auth = req.headers.get("authorization")
+  if (auth) {
+    const match = /^tma\s+(.+)$/i.exec(auth.trim())
+    if (match) return match[1]
+  }
+  return req.headers.get("x-telegram-init-data") ?? undefined
 }
 
 /**
  * Create context for each tRPC request
  */
-export async function createContext(): Promise<Context> {
+export async function createContext(opts: CreateContextOptions = {}): Promise<Context> {
   if (!globalServices) {
     throw new Error("Services not initialized. Call initializeServices first.")
   }
@@ -35,5 +64,8 @@ export async function createContext(): Promise<Context> {
   return {
     ...globalServices,
     logger: createLogger("tRPC"),
+    initData: extractInitData(opts.req),
+    botToken: config.TELEGRAM_BOT_TOKEN,
+    initDataMaxAge: config.TELEGRAM_INIT_DATA_MAX_AGE,
   }
 }

--- a/src-node/src/api/root.ts
+++ b/src-node/src/api/root.ts
@@ -5,6 +5,7 @@ import { waveformRouter } from "./routers/waveform"
 import { cacheRouter } from "./routers/cache"
 import { healthRouter } from "./routers/health"
 import { queueRouter } from "./routers/queue"
+import { authRouter } from "./routers/auth"
 
 /**
  * Main tRPC app router
@@ -16,6 +17,7 @@ export const appRouter = router({
   cache: cacheRouter,
   health: healthRouter,
   queue: queueRouter,
+  auth: authRouter,
 })
 
 /**

--- a/src-node/src/api/routers/auth.ts
+++ b/src-node/src/api/routers/auth.ts
@@ -1,0 +1,16 @@
+import { router, protectedProcedure } from "../trpc"
+
+/**
+ * Gateway auth router (#329).
+ *
+ * Endpoints behind {@link protectedProcedure} require a valid Telegram Mini App
+ * `initData`. `me` echoes the verified identity — the smallest proof that the
+ * gateway authenticates the same userId/chatId the bot uses.
+ */
+export const authRouter = router({
+  me: protectedProcedure.query(({ ctx }) => ({
+    userId: ctx.auth.userId,
+    chatId: ctx.auth.chatId ?? null,
+    username: ctx.auth.user?.username ?? null,
+  })),
+})

--- a/src-node/src/api/trpc.ts
+++ b/src-node/src/api/trpc.ts
@@ -1,4 +1,5 @@
-import { initTRPC } from "@trpc/server"
+import { initTRPC, TRPCError } from "@trpc/server"
+import { verifyTelegramInitData } from "@timeline-studio/adapters/node"
 import type { Context } from "./context"
 
 /**
@@ -14,4 +15,41 @@ const t = initTRPC.context<Context>().create({
  * Export reusable router and procedure helpers
  */
 export const router = t.router
+export const createCallerFactory = t.createCallerFactory
 export const publicProcedure = t.procedure
+
+/**
+ * Telegram Mini App gateway auth (#329). Verifies the request's `initData`
+ * against the bot token and augments the context with the resolved
+ * `auth.userId` / `auth.chatId`. Rejects unauthenticated requests with `401`.
+ */
+export const protectedProcedure = t.procedure.use(async ({ ctx, next }) => {
+  if (!ctx.botToken) {
+    throw new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: "Gateway auth is not configured (TELEGRAM_BOT_TOKEN missing)",
+    })
+  }
+  if (!ctx.initData) {
+    throw new TRPCError({ code: "UNAUTHORIZED", message: "Missing Telegram initData" })
+  }
+
+  const verification = verifyTelegramInitData(
+    ctx.initData,
+    ctx.botToken,
+    ctx.initDataMaxAge ? { maxAgeSeconds: ctx.initDataMaxAge } : {},
+  )
+  if (!verification.valid) {
+    throw new TRPCError({ code: "UNAUTHORIZED", message: `Invalid initData: ${verification.reason}` })
+  }
+
+  return next({
+    ctx: {
+      auth: {
+        userId: verification.data.userId,
+        chatId: verification.data.chatId,
+        user: verification.data.user,
+      },
+    },
+  })
+})

--- a/src-node/src/config/index.ts
+++ b/src-node/src/config/index.ts
@@ -28,6 +28,11 @@ const ConfigSchema = z.object({
   // CORS
   CORS_ORIGIN: z.string().default("http://localhost:3000"),
 
+  // Telegram Mini App gateway auth (#329). Token of the same bot the worker uses,
+  // for verifying initData. Max-age (seconds) gates replay; 0 disables the check.
+  TELEGRAM_BOT_TOKEN: z.string().optional(),
+  TELEGRAM_INIT_DATA_MAX_AGE: z.coerce.number().min(0).default(0),
+
   // Logging
   LOG_LEVEL: z
     .enum(["trace", "debug", "info", "warn", "error"])

--- a/src-node/src/server.ts
+++ b/src-node/src/server.ts
@@ -21,7 +21,7 @@ export function createServer(port?: number) {
           headers: {
             "Access-Control-Allow-Origin": config.CORS_ORIGIN,
             "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-            "Access-Control-Allow-Headers": "Content-Type",
+            "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Telegram-Init-Data",
           },
         })
       }
@@ -50,7 +50,7 @@ export function createServer(port?: number) {
             endpoint: "/trpc",
             req: request,
             router: appRouter,
-            createContext,
+            createContext: ({ req }) => createContext({ req }),
           })
 
           // Add CORS headers


### PR DESCRIPTION
Второй кусок #329 — **authenticated tRPC**, поверх верификатора из #381.

Расширяет tRPC-сервер `src-node` защищёнными процедурами: Mini App дёргает те же личности, что бот, с серверной проверкой `initData`.

## Что сделано
- **config**: `TELEGRAM_BOT_TOKEN` + `TELEGRAM_INIT_DATA_MAX_AGE` (0 = без проверки свежести).
- **context**: проброс `request` в контекст; извлечение `initData` из `Authorization: tma <data>` или `X-Telegram-Init-Data`; `botToken`/`maxAge` из config.
- **trpc**: `protectedProcedure` — middleware проверяет `initData` (`verifyTelegramInitData`) и кладёт в ctx `auth.{userId,chatId,user}`. `401` при отсутствии/невалидности, `500` если токен не сконфигурирован.
- **routers/auth.ts**: `auth.me` — возвращает проверенную личность (минимальное доказательство сквозной авторизации).
- **server**: передаёт request в `createContext`; CORS-preflight пропускает auth-заголовки.
- **тесты (bun)**: happy-path `auth.me`, без/невалидный/протухший `initData`, несконфигурированный токен, парсинг заголовков `extractInitData` — **8 тестов**.

## Проверка
- `tsc --noEmit` по собственным исходникам `src-node` — чисто (предсуществующие ошибки `.at()`/bun-fetch в `packages/adapters/*`, втягиваемых через `include`, к этому PR не относятся).
- `bun test __tests__/api/auth.test.ts` — **8 passed**.

## Дальше по #329 (отдельными PR)
- `session.* / edit.* / publish.*` поверх bot-портов (через `initNodeApp`-сервисы);
- `render.*` как **SSE** (прогресс рендера) — основной нетривиальный кусок;
- общий session/edit store с ботом без гонок.

Не закрывает #329 — это слой авторизации. Скажешь «дальше» — продолжу эндпоинтами.

🤖 Generated with [Claude Code](https://claude.com/claude-code)