### PR TITLE
feat(gateway): owner-scoped session router over shared bot store (#329)

### DIFF
--- a/src-node/__tests__/api/session.test.ts
+++ b/src-node/__tests__/api/session.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Gateway session router (#329) — read-only, owner-scoped view over the bot's
+ * shared edit-session store.
+ */
+
+import { describe, test, expect } from "bun:test"
+import crypto from "node:crypto"
+import type { BotEditSession, BotEditSessionStore, BotEditSessionQuery } from "@timeline-studio/core"
+import { appRouter } from "../../src/api/root"
+import type { Context } from "../../src/api/context"
+import { createLogger } from "../../src/utils/logger"
+
+const BOT_TOKEN = "123456:test-bot-token"
+
+function signInitData(userId: number): string {
+  const fields = { auth_date: "1700000000", user: JSON.stringify({ id: userId, username: `u${userId}` }) }
+  const dataCheckString = Object.entries(fields)
+    .map(([k, v]) => `${k}=${v}`)
+    .sort()
+    .join("\n")
+  const secretKey = crypto.createHmac("sha256", "WebAppData").update(BOT_TOKEN).digest()
+  const hash = crypto.createHmac("sha256", secretKey).update(dataCheckString).digest("hex")
+  const params = new URLSearchParams(fields)
+  params.set("hash", hash)
+  return params.toString()
+}
+
+function makeSession(id: string, userId: string, overrides: Partial<BotEditSession> = {}): BotEditSession {
+  return {
+    id,
+    source: "telegram",
+    status: "preview_ready",
+    userId,
+    media: [],
+    revisionCounter: 1,
+    revisions: [],
+    createdAt: "2026-06-27T08:00:00.000Z",
+    updatedAt: "2026-06-27T08:00:00.000Z",
+    ...overrides,
+  }
+}
+
+function fakeStore(sessions: BotEditSession[]): BotEditSessionStore {
+  return {
+    readSession: async (id: string) => sessions.find((s) => s.id === id),
+    writeSession: async () => {},
+    deleteSession: async () => {},
+    listSessions: async (query: BotEditSessionQuery = {}) =>
+      sessions
+        .filter((s) => (!query.source || s.source === query.source) && (!query.userId || s.userId === query.userId))
+        .slice(0, query.limit ?? sessions.length),
+    readCurrentSession: async (query: BotEditSessionQuery) =>
+      sessions.find((s) => (!query.userId || s.userId === query.userId)),
+  }
+}
+
+function ctxFor(userId: number, store?: BotEditSessionStore): Context {
+  return {
+    logger: createLogger("test"),
+    botToken: BOT_TOKEN,
+    initDataMaxAge: 0,
+    initData: signInitData(userId),
+    editSessionStore: store,
+  } as Context
+}
+
+async function expectTrpcError(promise: Promise<unknown>, code: string): Promise<void> {
+  try {
+    await promise
+    throw new Error("expected the call to throw")
+  } catch (error) {
+    expect((error as { code?: string }).code).toBe(code)
+  }
+}
+
+describe("Gateway session router (#329)", () => {
+  const sessions = [
+    makeSession("edit:telegram:1:42", "42", { goal: "promo", revisionCounter: 2 }),
+    makeSession("edit:telegram:1:42:b", "42", { status: "approved", approvedAt: "2026-06-27T09:00:00.000Z" }),
+    makeSession("edit:telegram:2:99", "99", { goal: "other user" }),
+  ]
+
+  test("session.list returns only the caller's sessions as safe summaries", async () => {
+    const caller = appRouter.createCaller(ctxFor(42, fakeStore(sessions)))
+    const result = await caller.session.list()
+    expect(result.map((s) => s.id)).toEqual(["edit:telegram:1:42", "edit:telegram:1:42:b"])
+    expect(result[0]).toEqual({
+      id: "edit:telegram:1:42",
+      status: "preview_ready",
+      goal: "promo",
+      revisionCount: 2,
+      approvedRevisionId: null,
+      approvedAt: null,
+      publishedAt: null,
+      failure: null,
+      createdAt: "2026-06-27T08:00:00.000Z",
+      updatedAt: "2026-06-27T08:00:00.000Z",
+    })
+  })
+
+  test("session.get returns an owned session", async () => {
+    const caller = appRouter.createCaller(ctxFor(42, fakeStore(sessions)))
+    const result = await caller.session.get({ id: "edit:telegram:1:42:b" })
+    expect(result.status).toBe("approved")
+  })
+
+  test("session.get hides another user's session as NOT_FOUND", async () => {
+    const caller = appRouter.createCaller(ctxFor(42, fakeStore(sessions)))
+    await expectTrpcError(caller.session.get({ id: "edit:telegram:2:99" }), "NOT_FOUND")
+  })
+
+  test("fails when the edit-session store is not configured (500)", async () => {
+    const caller = appRouter.createCaller(ctxFor(42, undefined))
+    await expectTrpcError(caller.session.list(), "INTERNAL_SERVER_ERROR")
+  })
+
+  test("still requires authentication (401 without initData)", async () => {
+    const caller = appRouter.createCaller({
+      logger: createLogger("test"),
+      botToken: BOT_TOKEN,
+      editSessionStore: fakeStore(sessions),
+    } as Context)
+    await expectTrpcError(caller.session.list(), "UNAUTHORIZED")
+  })
+})

--- a/src-node/src/api/context.ts
+++ b/src-node/src/api/context.ts
@@ -1,3 +1,5 @@
+import type { BotEditSessionStore } from "@timeline-studio/core"
+import { NodeBotEditSessionFileStore } from "@timeline-studio/adapters/node"
 import type { EnhancedMediaService } from "../services/media-service"
 import type { CacheService } from "../services/cache-service"
 import type { QueueService } from "../services/queue-service"
@@ -19,6 +21,20 @@ export interface Context {
   botToken?: string
   /** Max `initData` age in seconds; 0 disables the freshness check. */
   initDataMaxAge?: number
+  /** Edit-session store shared read-only with the bot, when configured (#329). */
+  editSessionStore?: BotEditSessionStore
+}
+
+// Edit-session store is a process singleton over the bot's shared directory.
+let editSessionStore: BotEditSessionStore | undefined
+function getEditSessionStore(): BotEditSessionStore | undefined {
+  if (!config.TELEGRAM_BOT_EDIT_SESSION_DIR) return undefined
+  if (!editSessionStore) {
+    editSessionStore = new NodeBotEditSessionFileStore({
+      directory: config.TELEGRAM_BOT_EDIT_SESSION_DIR,
+    })
+  }
+  return editSessionStore
 }
 
 type ContextServices = Pick<Context, "mediaService" | "cacheService" | "queueService">
@@ -67,5 +83,6 @@ export async function createContext(opts: CreateContextOptions = {}): Promise<Co
     initData: extractInitData(opts.req),
     botToken: config.TELEGRAM_BOT_TOKEN,
     initDataMaxAge: config.TELEGRAM_INIT_DATA_MAX_AGE,
+    editSessionStore: getEditSessionStore(),
   }
 }

--- a/src-node/src/api/root.ts
+++ b/src-node/src/api/root.ts
@@ -6,6 +6,7 @@ import { cacheRouter } from "./routers/cache"
 import { healthRouter } from "./routers/health"
 import { queueRouter } from "./routers/queue"
 import { authRouter } from "./routers/auth"
+import { sessionRouter } from "./routers/session"
 
 /**
  * Main tRPC app router
@@ -18,6 +19,7 @@ export const appRouter = router({
   health: healthRouter,
   queue: queueRouter,
   auth: authRouter,
+  session: sessionRouter,
 })
 
 /**

--- a/src-node/src/api/routers/session.ts
+++ b/src-node/src/api/routers/session.ts
@@ -1,0 +1,70 @@
+import { z } from "zod"
+import { TRPCError } from "@trpc/server"
+import type { BotEditSession, BotEditSessionStore } from "@timeline-studio/core"
+import { router, protectedProcedure } from "../trpc"
+
+/**
+ * Gateway session router (#329).
+ *
+ * Read-only view over the bot's shared edit-session store: the Mini App lists and
+ * inspects the same review sessions the bot writes. Every endpoint is scoped to
+ * the authenticated `userId` — a caller can only see their own sessions.
+ */
+
+/** Client-safe projection — internal ProjectSchema/artifacts are not exposed. */
+function toSessionSummary(session: BotEditSession) {
+  return {
+    id: session.id,
+    status: session.status,
+    goal: session.goal ?? null,
+    revisionCount: session.revisionCounter,
+    approvedRevisionId: session.approvedRevisionId ?? null,
+    approvedAt: session.approvedAt ?? null,
+    publishedAt: session.publishedAt ?? null,
+    failure: session.failure ?? null,
+    createdAt: session.createdAt,
+    updatedAt: session.updatedAt,
+  }
+}
+
+function requireStore(store: BotEditSessionStore | undefined): BotEditSessionStore {
+  if (!store) {
+    throw new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: "Edit-session store is not configured (TELEGRAM_BOT_EDIT_SESSION_DIR missing)",
+    })
+  }
+  return store
+}
+
+export const sessionRouter = router({
+  /** List the caller's edit sessions, newest first. */
+  list: protectedProcedure
+    .input(
+      z
+        .object({ limit: z.number().int().positive().max(100).optional() })
+        .optional(),
+    )
+    .query(async ({ ctx, input }) => {
+      const store = requireStore(ctx.editSessionStore)
+      const sessions = await store.listSessions({
+        source: "telegram",
+        userId: ctx.auth.userId,
+        ...(input?.limit ? { limit: input.limit } : {}),
+      })
+      return sessions.map(toSessionSummary)
+    }),
+
+  /** Read a single session by id; only the owner may read it. */
+  get: protectedProcedure
+    .input(z.object({ id: z.string().min(1) }))
+    .query(async ({ ctx, input }) => {
+      const store = requireStore(ctx.editSessionStore)
+      const session = await store.readSession(input.id)
+      // Hide existence of sessions the caller does not own.
+      if (!session || session.userId !== ctx.auth.userId) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Session not found" })
+      }
+      return toSessionSummary(session)
+    }),
+})

--- a/src-node/src/config/index.ts
+++ b/src-node/src/config/index.ts
@@ -32,6 +32,9 @@ const ConfigSchema = z.object({
   // for verifying initData. Max-age (seconds) gates replay; 0 disables the check.
   TELEGRAM_BOT_TOKEN: z.string().optional(),
   TELEGRAM_INIT_DATA_MAX_AGE: z.coerce.number().min(0).default(0),
+  // Directory of the bot's edit-session store, shared read-only with the gateway
+  // so the Mini App can list/inspect the same sessions the bot writes (#329).
+  TELEGRAM_BOT_EDIT_SESSION_DIR: z.string().optional(),
 
   // Logging
   LOG_LEVEL: z


### PR DESCRIPTION
Третий кусок #329 — первый эндпоинт поверх **общего с ботом store**.

Read-only представление: Mini App видит/инспектирует те же review-сессии, что пишет бот, без выполнения workflow.

## Что сделано
- **config**: `TELEGRAM_BOT_EDIT_SESSION_DIR` — каталог edit-session store бота (общий).
- **context**: лениво создаётся singleton `NodeBotEditSessionFileStore` над этим каталогом, кладётся в контекст.
- **routers/session.ts**: `session.list` / `session.get` за `protectedProcedure`, скоупятся по `ctx.auth.userId`. Возвращают client-safe summary (без `ProjectSchema`/артефактов); `session.get` прячет чужие сессии как `NOT_FOUND`.
- **тесты**: только свои в списке, чтение своей, чужая → `NOT_FOUND`, несконфигурированный store → `500`, без auth → `401` (5 тестов).

## Проверка
- собственные исходники `src-node` — `tsc` чисто; `bun test` — **13 passed** (auth + session).

## Дальше по #329
- `edit.*` (revise/approve) и `publish.*` — это уже **мутации** через bot-порты (нужен `initNodeApp`-граф сервисов в шлюзе);
- `render.*` как **SSE** — главный нетривиальный кусок.

Не закрывает #329. Влей — продолжу мутациями/SSE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)