### PR TITLE
feat(gateway): render status read + SSE stream over shared job store (#329)

### DIFF
--- a/src-node/__tests__/api/render.test.ts
+++ b/src-node/__tests__/api/render.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Gateway render router (#329) — owner-scoped read + SSE stream over the bot's
+ * shared workflow job store.
+ */
+
+import { describe, test, expect } from "bun:test"
+import crypto from "node:crypto"
+import type {
+  NodeTelegramBotWorkflowJobRecord,
+  NodeTelegramBotWorkflowJobStatus,
+  NodeTelegramBotWorkflowJobStore,
+} from "@timeline-studio/adapters/node"
+import { appRouter } from "../../src/api/root"
+import type { Context } from "../../src/api/context"
+import { createLogger } from "../../src/utils/logger"
+
+const BOT_TOKEN = "123456:test-bot-token"
+
+function signInitData(userId: number): string {
+  const fields = { auth_date: "1700000000", user: JSON.stringify({ id: userId }) }
+  const dataCheckString = Object.entries(fields)
+    .map(([k, v]) => `${k}=${v}`)
+    .sort()
+    .join("\n")
+  const secretKey = crypto.createHmac("sha256", "WebAppData").update(BOT_TOKEN).digest()
+  const hash = crypto.createHmac("sha256", secretKey).update(dataCheckString).digest("hex")
+  const params = new URLSearchParams(fields)
+  params.set("hash", hash)
+  return params.toString()
+}
+
+function job(
+  id: string,
+  userId: string,
+  status: NodeTelegramBotWorkflowJobStatus,
+): NodeTelegramBotWorkflowJobRecord {
+  return {
+    id,
+    status,
+    updateId: 1,
+    userId,
+    createdAt: "2026-06-27T08:00:00.000Z",
+    updatedAt: "2026-06-27T08:00:00.000Z",
+  }
+}
+
+function staticStore(jobs: NodeTelegramBotWorkflowJobRecord[]): NodeTelegramBotWorkflowJobStore {
+  return {
+    readJob: async (id) => jobs.find((j) => j.id === id),
+    writeJob: async () => {},
+    listJobs: async () => jobs,
+  }
+}
+
+function ctxFor(userId: number, store?: NodeTelegramBotWorkflowJobStore): Context {
+  return {
+    logger: createLogger("test"),
+    botToken: BOT_TOKEN,
+    initDataMaxAge: 0,
+    initData: signInitData(userId),
+    workflowJobStore: store,
+    renderStreamIntervalMs: 50,
+  } as Context
+}
+
+async function take<T>(iterable: AsyncIterable<T>, n: number): Promise<T[]> {
+  const out: T[] = []
+  for await (const value of iterable) {
+    out.push(value)
+    if (out.length >= n) break
+  }
+  return out
+}
+
+describe("Gateway render router (#329)", () => {
+  const jobs = [job("j1", "42", "running"), job("j2", "42", "done"), job("j3", "99", "running")]
+
+  test("render.list returns only the caller's jobs as safe summaries", async () => {
+    const caller = appRouter.createCaller(ctxFor(42, staticStore(jobs)))
+    const result = await caller.render.list()
+    expect(result.map((j) => j.id)).toEqual(["j1", "j2"])
+    expect(result[0]).toEqual({
+      id: "j1",
+      status: "running",
+      renderStatus: null,
+      hasArtifact: false,
+      error: null,
+      createdAt: "2026-06-27T08:00:00.000Z",
+      updatedAt: "2026-06-27T08:00:00.000Z",
+    })
+  })
+
+  test("render.get hides another user's job as NOT_FOUND", async () => {
+    const caller = appRouter.createCaller(ctxFor(42, staticStore(jobs)))
+    await expect(caller.render.get({ id: "j3" })).rejects.toMatchObject({ code: "NOT_FOUND" })
+  })
+
+  test("render.list fails when the job store is unconfigured (500)", async () => {
+    const caller = appRouter.createCaller(ctxFor(42, undefined))
+    await expect(caller.render.list()).rejects.toMatchObject({ code: "INTERNAL_SERVER_ERROR" })
+  })
+
+  test("render.events streams an initial snapshot then emits on status change", async () => {
+    let calls = 0
+    const evolving: NodeTelegramBotWorkflowJobStore = {
+      readJob: async () => undefined,
+      writeJob: async () => {},
+      listJobs: async () => {
+        calls += 1
+        return calls === 1 ? [job("j1", "42", "running")] : [job("j1", "42", "done")]
+      },
+    }
+    const caller = appRouter.createCaller(ctxFor(42, evolving))
+    const snapshots = await take(await caller.render.events({ intervalMs: 50 }), 2)
+    expect(snapshots[0].jobs[0].status).toBe("running")
+    expect(snapshots[1].jobs[0].status).toBe("done")
+  })
+})

--- a/src-node/src/api/context.ts
+++ b/src-node/src/api/context.ts
@@ -1,5 +1,9 @@
 import type { BotEditSessionStore } from "@timeline-studio/core"
-import { NodeBotEditSessionFileStore } from "@timeline-studio/adapters/node"
+import {
+  NodeBotEditSessionFileStore,
+  NodeTelegramBotFileWorkflowJobStore,
+  type NodeTelegramBotWorkflowJobStore,
+} from "@timeline-studio/adapters/node"
 import type { EnhancedMediaService } from "../services/media-service"
 import type { CacheService } from "../services/cache-service"
 import type { QueueService } from "../services/queue-service"
@@ -23,6 +27,10 @@ export interface Context {
   initDataMaxAge?: number
   /** Edit-session store shared read-only with the bot, when configured (#329). */
   editSessionStore?: BotEditSessionStore
+  /** Workflow job store shared read-only with the bot, when configured (#329). */
+  workflowJobStore?: NodeTelegramBotWorkflowJobStore
+  /** Default poll interval (ms) for the render-status SSE stream. */
+  renderStreamIntervalMs?: number
 }
 
 // Edit-session store is a process singleton over the bot's shared directory.
@@ -35,6 +43,16 @@ function getEditSessionStore(): BotEditSessionStore | undefined {
     })
   }
   return editSessionStore
+}
+
+// Workflow job store is a process singleton over the bot's shared job file.
+let workflowJobStore: NodeTelegramBotWorkflowJobStore | undefined
+function getWorkflowJobStore(): NodeTelegramBotWorkflowJobStore | undefined {
+  if (!config.TELEGRAM_BOT_JOB_STORE_FILE) return undefined
+  if (!workflowJobStore) {
+    workflowJobStore = new NodeTelegramBotFileWorkflowJobStore(config.TELEGRAM_BOT_JOB_STORE_FILE)
+  }
+  return workflowJobStore
 }
 
 type ContextServices = Pick<Context, "mediaService" | "cacheService" | "queueService">
@@ -84,5 +102,7 @@ export async function createContext(opts: CreateContextOptions = {}): Promise<Co
     botToken: config.TELEGRAM_BOT_TOKEN,
     initDataMaxAge: config.TELEGRAM_INIT_DATA_MAX_AGE,
     editSessionStore: getEditSessionStore(),
+    workflowJobStore: getWorkflowJobStore(),
+    renderStreamIntervalMs: config.TELEGRAM_RENDER_STREAM_INTERVAL_MS,
   }
 }

--- a/src-node/src/api/root.ts
+++ b/src-node/src/api/root.ts
@@ -7,6 +7,7 @@ import { healthRouter } from "./routers/health"
 import { queueRouter } from "./routers/queue"
 import { authRouter } from "./routers/auth"
 import { sessionRouter } from "./routers/session"
+import { renderRouter } from "./routers/render"
 
 /**
  * Main tRPC app router
@@ -20,6 +21,7 @@ export const appRouter = router({
   queue: queueRouter,
   auth: authRouter,
   session: sessionRouter,
+  render: renderRouter,
 })
 
 /**

--- a/src-node/src/api/routers/render.ts
+++ b/src-node/src/api/routers/render.ts
@@ -1,0 +1,109 @@
+import { z } from "zod"
+import { TRPCError } from "@trpc/server"
+import type {
+  NodeTelegramBotWorkflowJobRecord,
+  NodeTelegramBotWorkflowJobStore,
+} from "@timeline-studio/adapters/node"
+import { router, protectedProcedure } from "../trpc"
+
+/**
+ * Gateway render router (#329).
+ *
+ * Read + stream the caller's render jobs from the bot's shared workflow job
+ * store. `events` is an SSE subscription so the Mini App sees render progress
+ * live. All endpoints are scoped to the authenticated `userId`.
+ */
+
+/** Client-safe projection — artifact paths and source payloads are not exposed. */
+function toRenderJobSummary(job: NodeTelegramBotWorkflowJobRecord) {
+  return {
+    id: job.id,
+    status: job.status,
+    renderStatus: job.renderJobStatus ?? null,
+    hasArtifact: Boolean(job.artifact),
+    error: job.error ?? job.reason ?? null,
+    createdAt: job.createdAt,
+    updatedAt: job.updatedAt,
+  }
+}
+
+type RenderJobSummary = ReturnType<typeof toRenderJobSummary>
+
+function requireJobStore(
+  store: NodeTelegramBotWorkflowJobStore | undefined,
+): NodeTelegramBotWorkflowJobStore {
+  if (!store) {
+    throw new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: "Workflow job store is not configured (TELEGRAM_BOT_JOB_STORE_FILE missing)",
+    })
+  }
+  return store
+}
+
+async function listOwnedJobs(
+  store: NodeTelegramBotWorkflowJobStore,
+  userId: string,
+  limit?: number,
+): Promise<RenderJobSummary[]> {
+  const jobs = await store.listJobs()
+  const owned = jobs.filter((job) => job.userId === userId).map(toRenderJobSummary)
+  return limit ? owned.slice(0, limit) : owned
+}
+
+/** A stable signature of the owned jobs, to emit only on change. */
+function jobsSignature(jobs: RenderJobSummary[]): string {
+  return JSON.stringify(jobs.map((j) => [j.id, j.status, j.renderStatus]))
+}
+
+/** Abortable delay so the stream stops promptly when the client disconnects. */
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal?.aborted) return resolve()
+    const timer = setTimeout(resolve, ms)
+    signal?.addEventListener("abort", () => {
+      clearTimeout(timer)
+      resolve()
+    })
+  })
+}
+
+export const renderRouter = router({
+  /** List the caller's render jobs, newest first as stored. */
+  list: protectedProcedure
+    .input(z.object({ limit: z.number().int().positive().max(100).optional() }).optional())
+    .query(async ({ ctx, input }) => listOwnedJobs(requireJobStore(ctx.workflowJobStore), ctx.auth.userId, input?.limit)),
+
+  /** Read a single render job by id; only the owner may read it. */
+  get: protectedProcedure
+    .input(z.object({ id: z.string().min(1) }))
+    .query(async ({ ctx, input }) => {
+      const store = requireJobStore(ctx.workflowJobStore)
+      const job = await store.readJob(input.id)
+      if (!job || job.userId !== ctx.auth.userId) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Render job not found" })
+      }
+      return toRenderJobSummary(job)
+    }),
+
+  /**
+   * SSE stream of the caller's render jobs. Emits an initial snapshot, then a
+   * new snapshot whenever any owned job's status changes, until disconnect.
+   */
+  events: protectedProcedure
+    .input(z.object({ intervalMs: z.number().int().min(50).max(60000).optional() }).optional())
+    .subscription(async function* ({ ctx, input, signal }) {
+      const store = requireJobStore(ctx.workflowJobStore)
+      const interval = input?.intervalMs ?? ctx.renderStreamIntervalMs ?? 1000
+      let lastSignature: string | undefined
+      while (!signal?.aborted) {
+        const jobs = await listOwnedJobs(store, ctx.auth.userId)
+        const signature = jobsSignature(jobs)
+        if (signature !== lastSignature) {
+          lastSignature = signature
+          yield { jobs }
+        }
+        await delay(interval, signal)
+      }
+    }),
+})

--- a/src-node/src/config/index.ts
+++ b/src-node/src/config/index.ts
@@ -35,6 +35,11 @@ const ConfigSchema = z.object({
   // Directory of the bot's edit-session store, shared read-only with the gateway
   // so the Mini App can list/inspect the same sessions the bot writes (#329).
   TELEGRAM_BOT_EDIT_SESSION_DIR: z.string().optional(),
+  // The bot's workflow job-store file (TIMELINE_BOT_JOB_STORE_FILE), shared
+  // read-only so the gateway can report/stream render status (#329).
+  TELEGRAM_BOT_JOB_STORE_FILE: z.string().optional(),
+  // Default poll interval (ms) for the render-status SSE stream.
+  TELEGRAM_RENDER_STREAM_INTERVAL_MS: z.coerce.number().int().min(50).default(1000),
 
   // Logging
   LOG_LEVEL: z


### PR DESCRIPTION
Четвёртый кусок #329 — **render-статус read + SSE-стрим** (главный нетривиальный кусок).

Owner-scoped представление render-джоб из **общего с ботом** workflow job store + живой SSE-стрим прогресса для Mini App.

## Что сделано
- **config**: `TELEGRAM_BOT_JOB_STORE_FILE` (файл job-store бота, общий) + `TELEGRAM_RENDER_STREAM_INTERVAL_MS`.
- **context**: lazy-singleton `NodeTelegramBotFileWorkflowJobStore` над этим файлом.
- **routers/render.ts** за `protectedProcedure`, скоуп по `ctx.auth.userId`:
  - `render.list` / `render.get` — чтение (client-safe summary: без artifact-путей/payload; чужие → `NOT_FOUND`);
  - `render.events` — **tRPC subscription / SSE**: начальный снапшот, затем новый при смене статуса любой своей джобы; abortable-поллинг останавливается при дисконнекте.
- **тесты**: только свои в списке, чужая → `NOT_FOUND`, несконфигурированный store → `500`, и SSE-стрим эмитит при смене статуса (4 теста; subscription прогоняется через `createCaller`).

## Проверка
- собственные исходники `src-node` — `tsc` чисто; `bun test __tests__/api/` — **46 passed** (auth+session+render+integration).
- Логика стрима проверена через `createCaller`. Транспорт — стандартный SSE `@trpc/server` v11 fetch-адаптера (server.ts пробрасывает поток); клиентский `httpSubscriptionLink` будет в Mini App (#330).

## Дальше по #329
- `edit.*` / `publish.*` — **мутации** через bot-порты (нужен `initNodeApp`-граф сервисов в шлюзе) — самый крупный оставшийся кусок;
- e2e-смоук SSE-транспорта вместе с фронтом Mini App (#330).

Не закрывает #329 (остаются мутации). Влей — продолжу.

🤖 Generated with [Claude Code](https://claude.com/claude-code)