### PR TITLE
fix(ci): type-safe mock.calls access in bot-worker tests

### DIFF
--- a/packages/adapters/src/node/__tests__/telegram-bot-worker.test.ts
+++ b/packages/adapters/src/node/__tests__/telegram-bot-worker.test.ts
@@ -350,7 +350,7 @@ describe("Telegram bot worker", () => {
     expect(transcribeFeedback).toHaveBeenCalledOnce()
     expect(result).toMatchObject({ skipped: false })
     expect(runTelegramLikePayload).toHaveBeenCalledOnce()
-    const [payloadArg] = runTelegramLikePayload.mock.calls[0]
+    const [payloadArg] = runTelegramLikePayload.mock.calls[0] as unknown as [{ text?: string }]
     expect(payloadArg).toMatchObject({ text: "make a 30s promo about my cafe" })
   })
 
@@ -365,7 +365,7 @@ describe("Telegram bot worker", () => {
     await worker.handleUpdate(voiceIdeaUpdate())
 
     expect(transcribeFeedback).not.toHaveBeenCalled()
-    const [payloadArg] = runTelegramLikePayload.mock.calls[0]
+    const [payloadArg] = runTelegramLikePayload.mock.calls[0] as unknown as [{ text?: string }]
     expect(payloadArg.text).toBeUndefined()
   })
 
@@ -384,7 +384,7 @@ describe("Telegram bot worker", () => {
 
     expect(transcribeFeedback).toHaveBeenCalledOnce()
     expect(result).toMatchObject({ skipped: false })
-    const [payloadArg] = runTelegramLikePayload.mock.calls[0]
+    const [payloadArg] = runTelegramLikePayload.mock.calls[0] as unknown as [{ text?: string }]
     expect(payloadArg.text).toBeUndefined()
   })
 
@@ -406,7 +406,10 @@ describe("Telegram bot worker", () => {
     await worker.handleUpdate(ideaTextUpdate(31))
 
     expect(runTelegramLikePayload).toHaveBeenCalledOnce()
-    const [, workflowOptions] = runTelegramLikePayload.mock.calls[0]
+    const [, workflowOptions] = runTelegramLikePayload.mock.calls[0] as unknown as [
+      unknown,
+      { approvalGate?: unknown } | undefined,
+    ]
     expect(workflowOptions).toMatchObject({
       approvalGate: { enabled: true, previewDestination: "telegram" },
     })
@@ -424,7 +427,10 @@ describe("Telegram bot worker", () => {
     await worker.handleUpdate(ideaTextUpdate(32))
 
     expect(runTelegramLikePayload).toHaveBeenCalledOnce()
-    const [, workflowOptions] = runTelegramLikePayload.mock.calls[0]
+    const [, workflowOptions] = runTelegramLikePayload.mock.calls[0] as unknown as [
+      unknown,
+      { approvalGate?: unknown } | undefined,
+    ]
     expect(workflowOptions?.approvalGate).toBeUndefined()
   })
 


### PR DESCRIPTION
Чинит красный CI на main — джоб **TypeScript Type Check** (`bun run check:type`).

## Причина
Корневой `tsc --noEmit` компилит тест-файлы adapters под **корневым** tsconfig, где `vi.fn(async () => result).mock.calls[0]` типизирован как пустой кортеж `[]`. Деструктуризация, добавленная в тестах #326/#325 (`const [payloadArg] = ...calls[0]`, `const [, workflowOptions] = ...calls[0]`), падала с `TS2493`/`TS18048`/`TS2339`. В tsconfig самого пакета adapters типизация мягче, поэтому ошибка всплыла только на корне.

## Фикс
Каст кортежа звонка через `unknown` к ожидаемой форме в 5 местах доступа. Поведение не меняется.

## Проверка
- root `bun run check:type` — **0 ошибок**; `packages/adapters` `check:type` — **0**.
- `vitest run telegram-bot-worker.test.ts` — **59 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)