### PR TITLE
feat(gateway): edit.approve mutation reusing the bot review logic (#329)

### DIFF
--- a/src-node/__tests__/api/edit.test.ts
+++ b/src-node/__tests__/api/edit.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Gateway edit-mutation router (#329) — approve reuses the bot's review logic
+ * over the shared edit-session store, scoped to the authenticated user.
+ */
+
+import { describe, test, expect } from "bun:test"
+import crypto from "node:crypto"
+import type {
+  BotEditSession,
+  BotEditSessionStore,
+  BotEditSessionQuery,
+  BotEditSessionStatus,
+} from "@timeline-studio/core"
+import { appRouter } from "../../src/api/root"
+import type { Context } from "../../src/api/context"
+import { createLogger } from "../../src/utils/logger"
+
+const BOT_TOKEN = "123456:test-bot-token"
+
+function signInitData(userId: number): string {
+  const fields = { auth_date: "1700000000", user: JSON.stringify({ id: userId }) }
+  const dataCheckString = Object.entries(fields)
+    .map(([k, v]) => `${k}=${v}`)
+    .sort()
+    .join("\n")
+  const secretKey = crypto.createHmac("sha256", "WebAppData").update(BOT_TOKEN).digest()
+  const hash = crypto.createHmac("sha256", secretKey).update(dataCheckString).digest("hex")
+  const params = new URLSearchParams(fields)
+  params.set("hash", hash)
+  return params.toString()
+}
+
+function makeSession(
+  id: string,
+  userId: string,
+  status: BotEditSessionStatus,
+): BotEditSession {
+  return {
+    id,
+    source: "telegram",
+    status,
+    chatId: userId,
+    userId,
+    goal: "promo",
+    media: [],
+    revisionCounter: 1,
+    revisions: [
+      {
+        id: `${id}:rev0`,
+        index: 0,
+        summary: "preview",
+        createdAt: "2026-06-27T08:00:00.000Z",
+        updatedAt: "2026-06-27T08:00:00.000Z",
+      },
+    ],
+    createdAt: "2026-06-27T08:00:00.000Z",
+    updatedAt: "2026-06-27T08:00:00.000Z",
+  }
+}
+
+function mutableStore(initial: BotEditSession[]): BotEditSessionStore {
+  const map = new Map(initial.map((s) => [s.id, s]))
+  const store: BotEditSessionStore = {
+    readSession: async (id) => map.get(id),
+    writeSession: async (s) => {
+      map.set(s.id, s)
+    },
+    deleteSession: async (id) => {
+      map.delete(id)
+    },
+    listSessions: async (q: BotEditSessionQuery = {}) =>
+      [...map.values()].filter(
+        (s) =>
+          (!q.source || s.source === q.source) &&
+          (!q.chatId || s.chatId === q.chatId) &&
+          (!q.userId || s.userId === q.userId) &&
+          (!q.activeOnly || !["cancelled", "done", "failed"].includes(s.status)),
+      ),
+    readCurrentSession: async (q) => (await store.listSessions({ ...q, activeOnly: q.activeOnly ?? true }))[0],
+  }
+  return store
+}
+
+function ctxFor(userId: number, store?: BotEditSessionStore): Context {
+  return {
+    logger: createLogger("test"),
+    botToken: BOT_TOKEN,
+    initDataMaxAge: 0,
+    initData: signInitData(userId),
+    editSessionStore: store,
+  } as Context
+}
+
+describe("Gateway edit router (#329)", () => {
+  test("edit.approve marks the caller's preview-ready session approved", async () => {
+    const store = mutableStore([makeSession("s1", "42", "preview_ready")])
+    const caller = appRouter.createCaller(ctxFor(42, store))
+
+    const result = await caller.edit.approve({ id: "s1" })
+
+    expect(result.status).toBe("approved")
+    const persisted = await store.readSession("s1")
+    expect(persisted?.status).toBe("approved")
+    expect(persisted?.approvedBy).toBe("42")
+  })
+
+  test("edit.approve hides another user's session as NOT_FOUND", async () => {
+    const store = mutableStore([makeSession("s9", "99", "preview_ready")])
+    const caller = appRouter.createCaller(ctxFor(42, store))
+    await expect(caller.edit.approve({ id: "s9" })).rejects.toMatchObject({ code: "NOT_FOUND" })
+  })
+
+  test("edit.approve conflicts when the session is not preview-ready", async () => {
+    const store = mutableStore([makeSession("s2", "42", "draft" as BotEditSessionStatus)])
+    const caller = appRouter.createCaller(ctxFor(42, store))
+    await expect(caller.edit.approve({ id: "s2" })).rejects.toMatchObject({ code: "CONFLICT" })
+  })
+
+  test("edit.approve is idempotent on an already-approved session", async () => {
+    const approved = { ...makeSession("s3", "42", "approved"), approvedRevisionId: "s3:rev0" }
+    const caller = appRouter.createCaller(ctxFor(42, mutableStore([approved])))
+    const result = await caller.edit.approve({ id: "s3" })
+    expect(result.status).toBe("approved")
+  })
+
+  test("edit.approve fails when the store is unconfigured (500)", async () => {
+    const caller = appRouter.createCaller(ctxFor(42, undefined))
+    await expect(caller.edit.approve({ id: "s1" })).rejects.toMatchObject({ code: "INTERNAL_SERVER_ERROR" })
+  })
+
+  test("edit.approve requires authentication (401)", async () => {
+    const caller = appRouter.createCaller({
+      logger: createLogger("test"),
+      botToken: BOT_TOKEN,
+      editSessionStore: mutableStore([makeSession("s1", "42", "preview_ready")]),
+    } as Context)
+    await expect(caller.edit.approve({ id: "s1" })).rejects.toMatchObject({ code: "UNAUTHORIZED" })
+  })
+})

--- a/src-node/src/api/root.ts
+++ b/src-node/src/api/root.ts
@@ -8,6 +8,7 @@ import { queueRouter } from "./routers/queue"
 import { authRouter } from "./routers/auth"
 import { sessionRouter } from "./routers/session"
 import { renderRouter } from "./routers/render"
+import { editRouter } from "./routers/edit"
 
 /**
  * Main tRPC app router
@@ -22,6 +23,7 @@ export const appRouter = router({
   auth: authRouter,
   session: sessionRouter,
   render: renderRouter,
+  edit: editRouter,
 })
 
 /**

--- a/src-node/src/api/routers/edit.ts
+++ b/src-node/src/api/routers/edit.ts
@@ -1,0 +1,77 @@
+import { z } from "zod"
+import { TRPCError } from "@trpc/server"
+import type { BotEditSessionStore } from "@timeline-studio/core"
+import { NodeTelegramBotWorker, type NodeBotWorkflowService } from "@timeline-studio/adapters/node"
+import { router, protectedProcedure } from "../trpc"
+import { toSessionSummary } from "./session"
+
+/**
+ * Gateway edit-mutation router (#329).
+ *
+ * Mutations reuse the bot's own review logic instead of re-implementing it: the
+ * gateway drives a NodeTelegramBotWorker (bound to the shared edit-session store)
+ * with a synthesized `/approve` update, scoped to the authenticated user. This
+ * keeps approval semantics identical to the bot and writes to the same store.
+ *
+ * `approve` records the operator decision (status -> approved, approvedBy). It
+ * intentionally does NOT publish: delivery needs a publish service and is a
+ * follow-up, so this endpoint has no external side effects.
+ */
+
+// The approve path never touches the workflow service; a stub satisfies the type.
+const stubWorkflow = {
+  runWorkflow: async () => {
+    throw new Error("workflow execution is not available via the gateway")
+  },
+  runTelegramLikePayload: async () => {
+    throw new Error("workflow execution is not available via the gateway")
+  },
+  cancelRenderJob: async () => false,
+} as unknown as NodeBotWorkflowService
+
+function requireStore(store: BotEditSessionStore | undefined): BotEditSessionStore {
+  if (!store) {
+    throw new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: "Edit-session store is not configured (TELEGRAM_BOT_EDIT_SESSION_DIR missing)",
+    })
+  }
+  return store
+}
+
+export const editRouter = router({
+  /**
+   * Approve the caller's review session (concierge approval from the Mini App),
+   * reusing the bot's approveEditSession via a synthesized `/approve`. Idempotent
+   * on an already-approved session; conflicts when not in a preview-ready state.
+   */
+  approve: protectedProcedure
+    .input(z.object({ id: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      const store = requireStore(ctx.editSessionStore)
+      const session = await store.readSession(input.id)
+      if (!session || session.userId !== ctx.auth.userId) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Session not found" })
+      }
+
+      const worker = new NodeTelegramBotWorker({ workflow: stubWorkflow, editSessionStore: store })
+      await worker.handleUpdate({
+        update_id: 0,
+        message: {
+          message_id: `gateway-approve-${input.id}`,
+          chat: { id: session.chatId ?? ctx.auth.userId },
+          from: { id: ctx.auth.userId },
+          text: "/approve",
+        },
+      })
+
+      const updated = await store.readSession(input.id)
+      if (!updated || updated.status !== "approved") {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: `Session cannot be approved in its current state (${updated?.status ?? "missing"})`,
+        })
+      }
+      return toSessionSummary(updated)
+    }),
+})

--- a/src-node/src/api/routers/session.ts
+++ b/src-node/src/api/routers/session.ts
@@ -12,7 +12,7 @@ import { router, protectedProcedure } from "../trpc"
  */
 
 /** Client-safe projection — internal ProjectSchema/artifacts are not exposed. */
-function toSessionSummary(session: BotEditSession) {
+export function toSessionSummary(session: BotEditSession) {
   return {
     id: session.id,
     status: session.status,


### PR DESCRIPTION
Пятый кусок #329 — **первая мутация**: concierge-апрув из Mini App.

Вместо переписывания логики апрува шлюз **переиспользует** её: конструирует `NodeTelegramBotWorker` (поверх общего edit-session store) и подаёт синтетический `/approve`-апдейт, заскоупленный на авторизованного юзера. Семантика идентична боту, тот же store, нулевое дублирование.

## Что сделано
- **routers/edit.ts** — `edit.approve(id)` за `protectedProcedure`:
  - проверка владения (чужая → `NOT_FOUND`);
  - помечает сессию approved через реальный `approveEditSession` бота (пишет `approvedBy=userId`);
  - идемпотентно на уже-approved; `CONFLICT`, если сессия не в preview-ready; `500`, если store не сконфигурирован;
  - **без publish → без внешних side-effects** (доставка — отдельный follow-up, нужен publish-сервис).
- экспорт `toSessionSummary` из session-роутера для переиспользования.
- тесты: happy-path + `approvedBy`, чужая → `NOT_FOUND`, не-preview-ready → `CONFLICT`, повторный апрув идемпотентен, без store → `500`, без auth → `401` (6 тестов).

## Проверка
- собственные исходники `src-node` — `tsc` чисто; root `check:type` — **0**; `bun test __tests__/api/` — **52 passed**.

## Дальше по #329
- **publish-on-approve** — доставка результата (нужен publish-сервис в шлюзе + его config);
- `edit.revise` — submit правки (тянет AI-editor + re-render граф);
- e2e SSE/мутации вместе с Mini App (#330).

Не закрывает #329. Влей — продолжу.

🤖 Generated with [Claude Code](https://claude.com/claude-code)