### PR TITLE
feat(gateway): opt-in delivery on edit.approve via reused publish (#329)

### DIFF
--- a/src-node/__tests__/api/edit.test.ts
+++ b/src-node/__tests__/api/edit.test.ts
@@ -81,14 +81,24 @@ function mutableStore(initial: BotEditSession[]): BotEditSessionStore {
   return store
 }
 
-function ctxFor(userId: number, store?: BotEditSessionStore): Context {
+function ctxFor(userId: number, store?: BotEditSessionStore, publishService?: unknown): Context {
   return {
     logger: createLogger("test"),
     botToken: BOT_TOKEN,
     initDataMaxAge: 0,
     initData: signInitData(userId),
     editSessionStore: store,
+    publishService,
   } as Context
+}
+
+/** A preview-ready session with a deliverable artifact, for publish-on-approve. */
+function publishableSession(id: string, userId: string): BotEditSession {
+  return {
+    ...makeSession(id, userId, "preview_ready"),
+    publishTarget: "telegram",
+    currentArtifact: { type: "file", path: "/tmp/out.mp4", destination: "telegram" },
+  }
 }
 
 describe("Gateway edit router (#329)", () => {
@@ -114,6 +124,41 @@ describe("Gateway edit router (#329)", () => {
     const store = mutableStore([makeSession("s2", "42", "draft" as BotEditSessionStatus)])
     const caller = appRouter.createCaller(ctxFor(42, store))
     await expect(caller.edit.approve({ id: "s2" })).rejects.toMatchObject({ code: "CONFLICT" })
+  })
+
+  test("edit.approve delivers via the publish service when opted in", async () => {
+    const store = mutableStore([publishableSession("p1", "42")])
+    const publish = {
+      canPublish: () => true,
+      publish: async (req: { destination: string }) => ({ destination: req.destination, status: "done" }),
+    }
+    const publishSpy = publish.publish
+    let published = false
+    publish.publish = async (req) => {
+      published = true
+      return publishSpy(req)
+    }
+    const caller = appRouter.createCaller(ctxFor(42, store, publish))
+
+    const result = await caller.edit.approve({ id: "p1" })
+
+    expect(published).toBe(true)
+    expect(result.status).toBe("done")
+    expect((await store.readSession("p1"))?.publishedAt).toBeTruthy()
+  })
+
+  test("edit.approve surfaces a delivery failure as BAD_GATEWAY", async () => {
+    const store = mutableStore([publishableSession("p2", "42")])
+    const publish = {
+      canPublish: () => true,
+      publish: async (req: { destination: string }) => ({
+        destination: req.destination,
+        status: "failed",
+        error: "telegram rejected",
+      }),
+    }
+    const caller = appRouter.createCaller(ctxFor(42, store, publish))
+    await expect(caller.edit.approve({ id: "p2" })).rejects.toMatchObject({ code: "BAD_GATEWAY" })
   })
 
   test("edit.approve is idempotent on an already-approved session", async () => {

--- a/src-node/src/api/context.ts
+++ b/src-node/src/api/context.ts
@@ -1,6 +1,7 @@
-import type { BotEditSessionStore } from "@timeline-studio/core"
+import type { BotEditSessionStore, IPublishService } from "@timeline-studio/core"
 import {
   NodeBotEditSessionFileStore,
+  NodePublishService,
   NodeTelegramBotFileWorkflowJobStore,
   type NodeTelegramBotWorkflowJobStore,
 } from "@timeline-studio/adapters/node"
@@ -31,6 +32,8 @@ export interface Context {
   workflowJobStore?: NodeTelegramBotWorkflowJobStore
   /** Default poll interval (ms) for the render-status SSE stream. */
   renderStreamIntervalMs?: number
+  /** Publish service for delivery on approve, when opted in (#329). */
+  publishService?: IPublishService
 }
 
 // Edit-session store is a process singleton over the bot's shared directory.
@@ -53,6 +56,17 @@ function getWorkflowJobStore(): NodeTelegramBotWorkflowJobStore | undefined {
     workflowJobStore = new NodeTelegramBotFileWorkflowJobStore(config.TELEGRAM_BOT_JOB_STORE_FILE)
   }
   return workflowJobStore
+}
+
+// Publish service is built only when delivery-on-approve is opted in (#329),
+// reusing the bot token. Off → the gateway never publishes (no side effects).
+let publishService: IPublishService | undefined
+function getPublishService(): IPublishService | undefined {
+  if (!config.TELEGRAM_GATEWAY_PUBLISH_ON_APPROVE || !config.TELEGRAM_BOT_TOKEN) return undefined
+  if (!publishService) {
+    publishService = new NodePublishService({ telegram: { botToken: config.TELEGRAM_BOT_TOKEN } })
+  }
+  return publishService
 }
 
 type ContextServices = Pick<Context, "mediaService" | "cacheService" | "queueService">
@@ -104,5 +118,6 @@ export async function createContext(opts: CreateContextOptions = {}): Promise<Co
     editSessionStore: getEditSessionStore(),
     workflowJobStore: getWorkflowJobStore(),
     renderStreamIntervalMs: config.TELEGRAM_RENDER_STREAM_INTERVAL_MS,
+    publishService: getPublishService(),
   }
 }

--- a/src-node/src/api/routers/edit.ts
+++ b/src-node/src/api/routers/edit.ts
@@ -13,9 +13,10 @@ import { toSessionSummary } from "./session"
  * with a synthesized `/approve` update, scoped to the authenticated user. This
  * keeps approval semantics identical to the bot and writes to the same store.
  *
- * `approve` records the operator decision (status -> approved, approvedBy). It
- * intentionally does NOT publish: delivery needs a publish service and is a
- * follow-up, so this endpoint has no external side effects.
+ * `approve` records the operator decision (status -> approved, approvedBy). When
+ * delivery-on-approve is opted in (a publish service in context), the reused bot
+ * logic also publishes the result (status -> done/failed). Off by default, so the
+ * gateway has no external side effects unless explicitly configured.
  */
 
 // The approve path never touches the workflow service; a stub satisfies the type.
@@ -54,7 +55,11 @@ export const editRouter = router({
         throw new TRPCError({ code: "NOT_FOUND", message: "Session not found" })
       }
 
-      const worker = new NodeTelegramBotWorker({ workflow: stubWorkflow, editSessionStore: store })
+      const worker = new NodeTelegramBotWorker({
+        workflow: stubWorkflow,
+        editSessionStore: store,
+        ...(ctx.publishService ? { publishService: ctx.publishService } : {}),
+      })
       await worker.handleUpdate({
         update_id: 0,
         message: {
@@ -66,12 +71,20 @@ export const editRouter = router({
       })
 
       const updated = await store.readSession(input.id)
-      if (!updated || updated.status !== "approved") {
+      // "approved": recorded (no delivery). "done": approved + published.
+      if (updated && (updated.status === "approved" || updated.status === "done")) {
+        return toSessionSummary(updated)
+      }
+      // "failed" after our approve means delivery failed — surface it.
+      if (updated?.status === "failed") {
         throw new TRPCError({
-          code: "CONFLICT",
-          message: `Session cannot be approved in its current state (${updated?.status ?? "missing"})`,
+          code: "BAD_GATEWAY",
+          message: `Delivery failed: ${updated.failure ?? "unknown error"}`,
         })
       }
-      return toSessionSummary(updated)
+      throw new TRPCError({
+        code: "CONFLICT",
+        message: `Session cannot be approved in its current state (${updated?.status ?? "missing"})`,
+      })
     }),
 })

--- a/src-node/src/config/index.ts
+++ b/src-node/src/config/index.ts
@@ -40,6 +40,12 @@ const ConfigSchema = z.object({
   TELEGRAM_BOT_JOB_STORE_FILE: z.string().optional(),
   // Default poll interval (ms) for the render-status SSE stream.
   TELEGRAM_RENDER_STREAM_INTERVAL_MS: z.coerce.number().int().min(50).default(1000),
+  // Opt-in: deliver the result on edit.approve by publishing via the same bot
+  // token. Off by default so the gateway has no external side effects (#329).
+  TELEGRAM_GATEWAY_PUBLISH_ON_APPROVE: z
+    .string()
+    .optional()
+    .transform((v) => v === "true" || v === "1"),
 
   // Logging
   LOG_LEVEL: z


### PR DESCRIPTION
Шестой кусок #329 — замыкает поток **approve → выдача**.

При явном opt-in `edit.approve` ещё и **публикует** результат через ту же переиспользуемую логику бота (`publishApprovedEditSession`), на том же bot-токене — без нового config-surface.

## Что сделано
- **config**: `TELEGRAM_GATEWAY_PUBLISH_ON_APPROVE` (по умолчанию **off** → у шлюза нет внешних side-effects; публикует только когда явно включено).
- **context**: при включённом флаге собирается singleton `NodePublishService` из `TELEGRAM_BOT_TOKEN`, кладётся в контекст.
- **edit.approve**: передаёт publish-сервис воркеру; маппинг статуса — `approved` (записано) / `done` (доставлено) → успех, `failed` → `BAD_GATEWAY`, иначе `CONFLICT`.
- **тесты**: доставка happy-path (`done`, `publishedAt`, publisher вызван), сбой доставки → `BAD_GATEWAY`, плюс прежние approve-кейсы (8 тестов).

## Проверка
- собственные исходники `src-node` — `tsc` чисто; root `check:type` — **0**; `bun test __tests__/api/` — **54 passed**.

## Безопасность side-effects
Реальная публикация в Telegram происходит ТОЛЬКО когда оператор явно ставит `TELEGRAM_GATEWAY_PUBLISH_ON_APPROVE=true` + есть `TELEGRAM_BOT_TOKEN`. По умолчанию — approve лишь помечает сессию (как было). В тестах — фейковый publisher.

## Дальше по #329
- `edit.revise` — submit правок (тянет AI-editor + re-render граф) — последний крупный кусок мутаций;
- e2e с Mini App (#330).

Влей — продолжу.

🤖 Generated with [Claude Code](https://claude.com/claude-code)