### PR TITLE
feat(gateway): edit.cancel mutation reusing the bot review logic (#329)

### DIFF
--- a/src-node/__tests__/api/edit.test.ts
+++ b/src-node/__tests__/api/edit.test.ts
@@ -181,4 +181,30 @@ describe("Gateway edit router (#329)", () => {
     } as Context)
     await expect(caller.edit.approve({ id: "s1" })).rejects.toMatchObject({ code: "UNAUTHORIZED" })
   })
+
+  test("edit.cancel cancels an active session", async () => {
+    const store = mutableStore([makeSession("c1", "42", "preview_ready")])
+    const caller = appRouter.createCaller(ctxFor(42, store))
+    const result = await caller.edit.cancel({ id: "c1" })
+    expect(result.status).toBe("cancelled")
+    expect((await store.readSession("c1"))?.status).toBe("cancelled")
+  })
+
+  test("edit.cancel is idempotent on an already-cancelled session", async () => {
+    const store = mutableStore([makeSession("c2", "42", "cancelled")])
+    const caller = appRouter.createCaller(ctxFor(42, store))
+    expect((await caller.edit.cancel({ id: "c2" })).status).toBe("cancelled")
+  })
+
+  test("edit.cancel conflicts on a completed session", async () => {
+    const store = mutableStore([makeSession("c3", "42", "done")])
+    const caller = appRouter.createCaller(ctxFor(42, store))
+    await expect(caller.edit.cancel({ id: "c3" })).rejects.toMatchObject({ code: "CONFLICT" })
+  })
+
+  test("edit.cancel hides another user's session as NOT_FOUND", async () => {
+    const store = mutableStore([makeSession("c9", "99", "preview_ready")])
+    const caller = appRouter.createCaller(ctxFor(42, store))
+    await expect(caller.edit.cancel({ id: "c9" })).rejects.toMatchObject({ code: "NOT_FOUND" })
+  })
 })

--- a/src-node/src/api/routers/edit.ts
+++ b/src-node/src/api/routers/edit.ts
@@ -87,4 +87,48 @@ export const editRouter = router({
         message: `Session cannot be approved in its current state (${updated?.status ?? "missing"})`,
       })
     }),
+
+  /**
+   * Cancel (discard) the caller's review session, reusing the bot's
+   * cancelEditSession via a synthesized `/cancel`. Idempotent on an
+   * already-cancelled session; conflicts on a completed (done/failed) one.
+   */
+  cancel: protectedProcedure
+    .input(z.object({ id: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      const store = requireStore(ctx.editSessionStore)
+      const session = await store.readSession(input.id)
+      if (!session || session.userId !== ctx.auth.userId) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Session not found" })
+      }
+      if (session.status === "cancelled") {
+        return toSessionSummary(session) // idempotent
+      }
+      if (session.status === "done" || session.status === "failed") {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: `Session cannot be cancelled in its current state (${session.status})`,
+        })
+      }
+
+      const worker = new NodeTelegramBotWorker({ workflow: stubWorkflow, editSessionStore: store })
+      await worker.handleUpdate({
+        update_id: 0,
+        message: {
+          message_id: `gateway-cancel-${input.id}`,
+          chat: { id: session.chatId ?? ctx.auth.userId },
+          from: { id: ctx.auth.userId },
+          text: "/cancel",
+        },
+      })
+
+      const updated = await store.readSession(input.id)
+      if (updated?.status !== "cancelled") {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: `Session could not be cancelled (${updated?.status ?? "missing"})`,
+        })
+      }
+      return toSessionSummary(updated)
+    }),
 })


### PR DESCRIPTION
Дополняет surface мутаций шлюза (approve + **cancel**).

Как и approve, `edit.cancel` переиспользует логику бота через синтетический `/cancel` поверх общего edit-session store — без дублирования, без AI/publish, без внешних side-effects.

## Что сделано
- **routers/edit.ts** — `edit.cancel(id)` за `protectedProcedure`:
  - проверка владения (чужая → `NOT_FOUND`);
  - идемпотентно на уже-cancelled; `CONFLICT` на завершённой (done/failed); иначе гонит реальный `cancelEditSession` и возвращает summary со статусом `cancelled`.
- **тесты**: отмена активной, повторная отмена идемпотентна, завершённая → `CONFLICT`, чужая → `NOT_FOUND` (4 теста).

## Проверка
- собственные исходники `src-node` — `tsc` чисто; root `check:type` — **0**; `bun test __tests__/api/` — **58 passed**.

## Состояние шлюза #329 (backend)
- read: `auth.me`, `session.list/get`, `render.list/get` + `render.events` (SSE);
- mutate: `edit.approve` (+ opt-in publish), `edit.cancel`.

Осталось из тяжёлого: `edit.revise` (тянет AI-editor + re-render граф — большой config) и фронт Mini App (#330). Оба — отдельные крупные форки.

🤖 Generated with [Claude Code](https://claude.com/claude-code)