### PR TITLE
feat(mini-app): scaffold Telegram Mini App over the gateway (#330)

### DIFF
--- a/apps/telegram-mini-app/index.html
+++ b/apps/telegram-mini-app/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>Reels</title>
+    <script src="https://telegram.org/js/telegram-web-app.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/telegram-mini-app/package.json
+++ b/apps/telegram-mini-app/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@timeline-studio/telegram-mini-app",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Telegram Mini App front-end for the bot-first reels gateway (#330).",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "check:type": "tsc --noEmit",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@trpc/client": "11.17.0",
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.2.0",
+    "typescript": "~6.0.3",
+    "vite": "^6.0.0"
+  }
+}

--- a/apps/telegram-mini-app/package.json
+++ b/apps/telegram-mini-app/package.json
@@ -20,6 +20,6 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.2.0",
     "typescript": "~6.0.3",
-    "vite": "^6.0.0"
+    "vite": "^7.0.0"
   }
 }

--- a/apps/telegram-mini-app/src/App.tsx
+++ b/apps/telegram-mini-app/src/App.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from "react"
+import { gateway } from "./gateway"
+import { getInitData } from "./telegram"
+
+interface Me {
+  userId: string
+  chatId: string | null
+  username: string | null
+}
+
+type SessionSummary = Awaited<ReturnType<typeof gateway.session.list.query>>[number]
+
+/**
+ * Home screen (#330): proves end-to-end auth + data over the gateway — shows the
+ * verified identity and the caller's review sessions. Chat/preview screens and
+ * the live render view follow.
+ */
+export function App() {
+  const [me, setMe] = useState<Me | null>(null)
+  const [sessions, setSessions] = useState<SessionSummary[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (!getInitData()) {
+      setError("Open this app from Telegram — no initData available.")
+      setLoading(false)
+      return
+    }
+    let cancelled = false
+    ;(async () => {
+      try {
+        const [identity, list] = await Promise.all([
+          gateway.auth.me.query(),
+          gateway.session.list.query(),
+        ])
+        if (cancelled) return
+        setMe(identity)
+        setSessions(list)
+      } catch (cause) {
+        if (!cancelled) setError(cause instanceof Error ? cause.message : "Failed to load")
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  if (loading) return <main className="screen">Loading…</main>
+  if (error) return <main className="screen error">{error}</main>
+
+  return (
+    <main className="screen">
+      <header>
+        <h1>Reels</h1>
+        {me && <p className="muted">@{me.username ?? me.userId}</p>}
+      </header>
+
+      <section>
+        <h2>Your sessions</h2>
+        {sessions.length === 0 ? (
+          <p className="muted">No review sessions yet. Send an idea to the bot to start.</p>
+        ) : (
+          <ul className="sessions">
+            {sessions.map((session) => (
+              <li key={session.id}>
+                <span className={`status status-${session.status}`}>{session.status}</span>
+                <span className="goal">{session.goal ?? session.id}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
+  )
+}

--- a/apps/telegram-mini-app/src/bun-shims.d.ts
+++ b/apps/telegram-mini-app/src/bun-shims.d.ts
@@ -1,0 +1,30 @@
+/**
+ * Ambient shims for Bun APIs (#330).
+ *
+ * The Mini App consumes the gateway's `AppRouter` TYPE for end-to-end safety.
+ * That type transitively references gateway source that imports Bun runtime APIs
+ * (`bun:sqlite`, the `bun` module, the `Bun` global). The Mini App never runs
+ * that code — it only needs the types to resolve — so these loose declarations
+ * let the browser-targeted tsconfig type-check the router without pulling in
+ * `@types/bun` (which would wrongly imply a Bun runtime in the browser bundle).
+ */
+
+declare module "bun:sqlite" {
+  // biome-ignore lint/suspicious/noExplicitAny: type-only shim for an unused runtime API.
+  export class Database {
+    constructor(filename?: string, options?: unknown)
+    query(sql: string): any
+    run(sql: string, ...params: unknown[]): any
+    exec(sql: string): void
+    close(): void
+  }
+}
+
+declare module "bun" {
+  export const env: Record<string, string | undefined>
+  // biome-ignore lint/suspicious/noExplicitAny: type-only shim for an unused runtime API.
+  export const $: any
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: type-only shim for the Bun global.
+declare const Bun: any

--- a/apps/telegram-mini-app/src/gateway.ts
+++ b/apps/telegram-mini-app/src/gateway.ts
@@ -1,0 +1,28 @@
+/**
+ * Type-safe API client to the bot-first gateway (#330).
+ *
+ * Reuses the gateway's `AppRouter` type for end-to-end type safety, and sends
+ * the Telegram `initData` as `Authorization: tma <initData>` on every request —
+ * the header the gateway's protectedProcedure verifies.
+ *
+ * Queries/mutations only for this slice; the `render.events` SSE subscription is
+ * a follow-up (it needs EventSource-friendly auth).
+ */
+
+import { createTRPCClient, httpBatchLink } from "@trpc/client"
+import type { AppRouter } from "@gateway/api/root"
+import { getInitData } from "./telegram"
+
+const GATEWAY_URL = (import.meta.env.VITE_GATEWAY_URL as string | undefined) ?? "/trpc"
+
+export const gateway = createTRPCClient<AppRouter>({
+  links: [
+    httpBatchLink({
+      url: GATEWAY_URL,
+      headers() {
+        const initData = getInitData()
+        return initData ? { authorization: `tma ${initData}` } : {}
+      },
+    }),
+  ],
+})

--- a/apps/telegram-mini-app/src/main.tsx
+++ b/apps/telegram-mini-app/src/main.tsx
@@ -1,0 +1,19 @@
+import { StrictMode } from "react"
+import { createRoot } from "react-dom/client"
+import { App } from "./App"
+import { getWebApp } from "./telegram"
+import "./styles.css"
+
+// Tell Telegram the Mini App is ready and use the full viewport.
+const webApp = getWebApp()
+webApp?.ready()
+webApp?.expand()
+
+const container = document.getElementById("root")
+if (!container) throw new Error("Missing #root element")
+
+createRoot(container).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)

--- a/apps/telegram-mini-app/src/styles.css
+++ b/apps/telegram-mini-app/src/styles.css
@@ -1,0 +1,67 @@
+:root {
+  color-scheme: light dark;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}
+
+body {
+  margin: 0;
+  background: var(--tg-theme-bg-color, #ffffff);
+  color: var(--tg-theme-text-color, #111111);
+}
+
+.screen {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 16px;
+}
+
+.screen.error {
+  color: #c0392b;
+}
+
+.muted {
+  color: var(--tg-theme-hint-color, #888888);
+}
+
+.sessions {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sessions li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: var(--tg-theme-secondary-bg-color, #f4f4f5);
+}
+
+.status {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.08);
+}
+
+.status-approved,
+.status-done {
+  color: #1e7e34;
+}
+
+.status-failed {
+  color: #c0392b;
+}
+
+.goal {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/apps/telegram-mini-app/src/telegram.ts
+++ b/apps/telegram-mini-app/src/telegram.ts
@@ -1,0 +1,38 @@
+/**
+ * Minimal typed access to the Telegram WebApp runtime (#330).
+ *
+ * Reads `window.Telegram.WebApp.initData` directly — the same string the gateway
+ * verifies. Kept dependency-free for the first slice; the richer `@twa-dev/sdk`
+ * (theme/viewport helpers) can be layered on later without changing callers.
+ */
+
+export interface TelegramWebAppUser {
+  id: number
+  username?: string
+  first_name?: string
+  last_name?: string
+}
+
+export interface TelegramWebApp {
+  initData: string
+  initDataUnsafe?: { user?: TelegramWebAppUser }
+  colorScheme?: "light" | "dark"
+  ready: () => void
+  expand: () => void
+}
+
+declare global {
+  interface Window {
+    Telegram?: { WebApp?: TelegramWebApp }
+  }
+}
+
+export function getWebApp(): TelegramWebApp | undefined {
+  return typeof window === "undefined" ? undefined : window.Telegram?.WebApp
+}
+
+/** The raw `initData` to send to the gateway, or `undefined` outside Telegram. */
+export function getInitData(): string | undefined {
+  const data = getWebApp()?.initData
+  return data && data.length > 0 ? data : undefined
+}

--- a/apps/telegram-mini-app/src/vite-env.d.ts
+++ b/apps/telegram-mini-app/src/vite-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  /** Base URL of the gateway tRPC endpoint (defaults to `/trpc`). */
+  readonly VITE_GATEWAY_URL?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/apps/telegram-mini-app/tsconfig.json
+++ b/apps/telegram-mini-app/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "types": ["vite/client"],
+    "paths": {
+      "@gateway/*": ["../../src-node/src/*"],
+      "@/*": ["../../src/*"],
+      "@core/*": ["../../packages/core/src/*"],
+      "@adapters/*": ["../../packages/adapters/src/*"],
+      "@domains/*": ["../../packages/domains/src/*"]
+    }
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/apps/telegram-mini-app/vite.config.ts
+++ b/apps/telegram-mini-app/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vite"
+import react from "@vitejs/plugin-react"
+
+// During local dev, proxy `/trpc` to the gateway (src-node) so the Mini App and
+// API share an origin (matching production where they sit behind one host).
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      "/trpc": {
+        target: process.env.GATEWAY_ORIGIN ?? "http://localhost:3001",
+        changeOrigin: true,
+      },
+    },
+  },
+})

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "author": "Alexander Kireyev <ak.chatman.media@gmail.com>",
   "workspaces": [
     "packages/*",
-    "apps/*"
+    "apps/*",
+    "!apps/telegram-mini-app"
   ],
   "type": "module",
   "scripts": {
@@ -29,7 +30,7 @@
     "fix:rust": "npm run format:rust && npm run lint:rust:fix",
     "check:type": "tsc --noEmit",
     "check:packages": "bun run --cwd packages/core check:type && bun run --cwd packages/domains check:type && bun run --cwd packages/adapters check:type && bun run --cwd packages/ui check:type",
-    "check:apps": "bun run --cwd apps/desktop check:type && bun run --cwd apps/cli check:type && bun run --cwd apps/telegram-mini-app check:type",
+    "check:apps": "bun run --cwd apps/desktop check:type && bun run --cwd apps/cli check:type",
     "check:workspaces": "bun run check:packages && bun run check:apps",
     "check:boundaries": "node scripts/check-package-boundaries.mjs",
     "check:boundaries:external": "node scripts/check-package-boundaries.mjs --external-contracts",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "fix:rust": "npm run format:rust && npm run lint:rust:fix",
     "check:type": "tsc --noEmit",
     "check:packages": "bun run --cwd packages/core check:type && bun run --cwd packages/domains check:type && bun run --cwd packages/adapters check:type && bun run --cwd packages/ui check:type",
-    "check:apps": "bun run --cwd apps/desktop check:type && bun run --cwd apps/cli check:type",
+    "check:apps": "bun run --cwd apps/desktop check:type && bun run --cwd apps/cli check:type && bun run --cwd apps/telegram-mini-app check:type",
     "check:workspaces": "bun run check:packages && bun run check:apps",
     "check:boundaries": "node scripts/check-package-boundaries.mjs",
     "check:boundaries:external": "node scripts/check-package-boundaries.mjs --external-contracts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -102,6 +102,7 @@
     "node_modules",
     "src-tauri/target/**/*",
     "src-node",
+    "apps/telegram-mini-app",
     "promo"
   ]
 }


### PR DESCRIPTION
Первый срез фронта Mini App (#330) — Vite+React, общается со шлюзом с end-to-end типобезопасностью.

## Что сделано
- **`apps/telegram-mini-app`** — Vite + React 19 + `@trpc/client`.
- **типобезопасный клиент**: `createTRPCClient<AppRouter>` переиспользует тип роутера шлюза; шлёт Telegram `initData` как `Authorization: tma <initData>` в каждом запросе.
- **telegram.ts**: dependency-free доступ к `window.Telegram.WebApp.initData` (`@twa-dev/sdk` — позже).
- **home-экран**: `auth.me` + `session.list` — доказывает auth+данные end-to-end.
- **tsconfig**: алиасы к шлюзу/пакетам + ambient Bun-шим, чтобы браузерный конфиг типизировал тип роутера; исключён из корневого tsconfig (как `src-node`).

## Важно: app пока ВНЕ workspace
Делать app workspace-членом форсировало re-resolve lockfile, который бампал транзитивные deps и ломал корневой `vitest.config.ts` typecheck (латентная хрупкость репо). Поэтому app исключён из workspaces (`!apps/telegram-mini-app`): скаффолд ложится как **исходник без изменения lockfile** и без влияния на CI install. Его `check:type` проходит через root-hoisted react/typescript. Промоут до полноценного workspace-члена (свои deps в lockfile + CI `check:apps`) — отдельный follow-up.

## Проверка
- `apps/telegram-mini-app check:type` — **0** (полная типобезопасность против `AppRouter`); root `check:type` — **0** (чистая переустановка); **lockfile-ы не тронуты**; biome игнорирует app.

## Дальше (follow-ups)
- промоут в workspace (lockfile + CI-check); экраны chat/preview; **render.events SSE-вью**; кнопки approve/revise/cancel; `@twa-dev/sdk`.

## Верификация
Скаффолд проверен typecheck-ом; рантайм в Telegram WebApp — только в самом Telegram (вне headless-CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)