### PR TITLE
feat(mini-app): concierge actions (approve/revise/cancel) on sessions (#330)

### DIFF
--- a/apps/telegram-mini-app/src/App.tsx
+++ b/apps/telegram-mini-app/src/App.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 import { gateway } from "./gateway"
+import { type SessionSummary, SessionRow } from "./SessionRow"
 import { getInitData } from "./telegram"
 
 interface Me {
@@ -8,18 +9,23 @@ interface Me {
   username: string | null
 }
 
-type SessionSummary = Awaited<ReturnType<typeof gateway.session.list.query>>[number]
-
 /**
- * Home screen (#330): proves end-to-end auth + data over the gateway — shows the
- * verified identity and the caller's review sessions. Chat/preview screens and
- * the live render view follow.
+ * Home screen (#330): the verified identity and the caller's review sessions,
+ * each with concierge actions (approve/revise/cancel) over the gateway.
  */
 export function App() {
   const [me, setMe] = useState<Me | null>(null)
   const [sessions, setSessions] = useState<SessionSummary[]>([])
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
+
+  const refresh = useCallback(async () => {
+    try {
+      setSessions(await gateway.session.list.query())
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Failed to load sessions")
+    }
+  }, [])
 
   useEffect(() => {
     if (!getInitData()) {
@@ -30,10 +36,7 @@ export function App() {
     let cancelled = false
     ;(async () => {
       try {
-        const [identity, list] = await Promise.all([
-          gateway.auth.me.query(),
-          gateway.session.list.query(),
-        ])
+        const [identity, list] = await Promise.all([gateway.auth.me.query(), gateway.session.list.query()])
         if (cancelled) return
         setMe(identity)
         setSessions(list)
@@ -49,7 +52,7 @@ export function App() {
   }, [])
 
   if (loading) return <main className="screen">Loading…</main>
-  if (error) return <main className="screen error">{error}</main>
+  if (error && !me) return <main className="screen error">{error}</main>
 
   return (
     <main className="screen">
@@ -60,15 +63,13 @@ export function App() {
 
       <section>
         <h2>Your sessions</h2>
+        {error && <p className="error">{error}</p>}
         {sessions.length === 0 ? (
           <p className="muted">No review sessions yet. Send an idea to the bot to start.</p>
         ) : (
           <ul className="sessions">
             {sessions.map((session) => (
-              <li key={session.id}>
-                <span className={`status status-${session.status}`}>{session.status}</span>
-                <span className="goal">{session.goal ?? session.id}</span>
-              </li>
+              <SessionRow key={session.id} session={session} onChanged={() => void refresh()} />
             ))}
           </ul>
         )}

--- a/apps/telegram-mini-app/src/SessionRow.tsx
+++ b/apps/telegram-mini-app/src/SessionRow.tsx
@@ -1,0 +1,73 @@
+import { type FormEvent, useState } from "react"
+import { gateway } from "./gateway"
+
+export type SessionSummary = Awaited<ReturnType<typeof gateway.session.list.query>>[number]
+
+/**
+ * One review session with concierge actions (#330). Approve / Cancel / Revise
+ * are only offered while the session is preview-ready and call the gateway's
+ * owner-scoped `edit.*` mutations; the parent refreshes the list afterwards.
+ */
+export function SessionRow({ session, onChanged }: { session: SessionSummary; onChanged: () => void }) {
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [instruction, setInstruction] = useState("")
+
+  const canAct = session.status === "preview_ready"
+
+  async function run(action: () => Promise<unknown>): Promise<void> {
+    setBusy(true)
+    setError(null)
+    try {
+      await action()
+      onChanged()
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Action failed")
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  function onRevise(event: FormEvent): void {
+    event.preventDefault()
+    const trimmed = instruction.trim()
+    if (!trimmed) return
+    void run(async () => {
+      await gateway.edit.revise.mutate({ id: session.id, instruction: trimmed })
+      setInstruction("")
+    })
+  }
+
+  return (
+    <li>
+      <div className="row">
+        <span className={`status status-${session.status}`}>{session.status}</span>
+        <span className="goal">{session.goal ?? session.id}</span>
+      </div>
+
+      {canAct && (
+        <div className="actions">
+          <button type="button" disabled={busy} onClick={() => run(() => gateway.edit.approve.mutate({ id: session.id }))}>
+            Approve
+          </button>
+          <button type="button" disabled={busy} onClick={() => run(() => gateway.edit.cancel.mutate({ id: session.id }))}>
+            Cancel
+          </button>
+          <form className="revise" onSubmit={onRevise}>
+            <input
+              value={instruction}
+              onChange={(event) => setInstruction(event.target.value)}
+              placeholder="Revise…"
+              disabled={busy}
+            />
+            <button type="submit" disabled={busy || instruction.trim().length === 0}>
+              Revise
+            </button>
+          </form>
+        </div>
+      )}
+
+      {error && <p className="error">{error}</p>}
+    </li>
+  )
+}

--- a/apps/telegram-mini-app/src/styles.css
+++ b/apps/telegram-mini-app/src/styles.css
@@ -34,11 +34,54 @@ body {
 
 .sessions li {
   display: flex;
-  align-items: center;
+  flex-direction: column;
   gap: 8px;
   padding: 10px 12px;
   border-radius: 10px;
   background: var(--tg-theme-secondary-bg-color, #f4f4f5);
+}
+
+.sessions .row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.actions button {
+  padding: 6px 12px;
+  border: none;
+  border-radius: 8px;
+  background: var(--tg-theme-button-color, #2481cc);
+  color: var(--tg-theme-button-text-color, #ffffff);
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.actions button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.revise {
+  display: flex;
+  gap: 6px;
+  flex: 1;
+  min-width: 160px;
+}
+
+.revise input {
+  flex: 1;
+  padding: 6px 10px;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 8px;
+  font-size: 14px;
 }
 
 .status {


### PR DESCRIPTION
UI-срез Mini App: действия approve/revise/cancel прямо на сессиях, поверх `edit.*` мутаций шлюза.

## Что сделано
- **SessionRow**: на каждой preview-ready сессии — кнопки **Approve** / **Cancel** + поле **Revise**; каждое зовёт owner-scoped мутацию шлюза (`edit.approve`/`edit.cancel`/`edit.revise`), обновляет список и показывает ошибку инлайн.
- **App**: вынесен `refresh()`, рендер сессий через `SessionRow`.

## Проверка
- `apps/telegram-mini-app check:type` — **0** (типобезопасно против gateway-мутаций); root `check:type` — **0**. Только app-изменения (без lockfile/config).
- Рантайм — в Telegram WebApp (вне headless-CI).

## Дальше
- preview/render-статус (render.list/SSE), `@twa-dev/sdk` (тема/viewport), навигация.

🤖 Generated with [Claude Code](https://claude.com/claude-code)