### PR TITLE
feat(mini-app): live render-status list on the home screen (#330)

### DIFF
--- a/apps/telegram-mini-app/src/App.tsx
+++ b/apps/telegram-mini-app/src/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react"
 import { gateway } from "./gateway"
+import { RenderJobs } from "./RenderJobs"
 import { type SessionSummary, SessionRow } from "./SessionRow"
 import { getInitData } from "./telegram"
 
@@ -74,6 +75,8 @@ export function App() {
           </ul>
         )}
       </section>
+
+      <RenderJobs />
     </main>
   )
 }

--- a/apps/telegram-mini-app/src/RenderJobs.tsx
+++ b/apps/telegram-mini-app/src/RenderJobs.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from "react"
+import { gateway } from "./gateway"
+
+type RenderJob = Awaited<ReturnType<typeof gateway.render.list.query>>[number]
+
+const POLL_MS = 4000
+
+/**
+ * The caller's render jobs (#330), polled for near-live status. A lightweight
+ * stand-in for the `render.events` SSE stream — polling avoids the EventSource
+ * auth nuance and is enough to show progress; the SSE view can replace it later.
+ * Renders nothing until the first load and stays hidden when there are no jobs.
+ */
+export function RenderJobs() {
+  const [jobs, setJobs] = useState<RenderJob[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const [loaded, setLoaded] = useState(false)
+
+  useEffect(() => {
+    let active = true
+    let timer: ReturnType<typeof setTimeout> | undefined
+
+    const poll = async () => {
+      try {
+        const list = await gateway.render.list.query()
+        if (!active) return
+        setJobs(list)
+        setError(null)
+      } catch (cause) {
+        if (active) setError(cause instanceof Error ? cause.message : "Failed to load renders")
+      } finally {
+        if (active) {
+          setLoaded(true)
+          timer = setTimeout(() => void poll(), POLL_MS)
+        }
+      }
+    }
+
+    void poll()
+    return () => {
+      active = false
+      if (timer) clearTimeout(timer)
+    }
+  }, [])
+
+  if (!loaded || (jobs.length === 0 && !error)) return null
+
+  return (
+    <section>
+      <h2>Renders</h2>
+      {error && <p className="error">{error}</p>}
+      <ul className="sessions">
+        {jobs.map((job) => {
+          const state = job.renderStatus ?? job.status
+          return (
+            <li key={job.id}>
+              <div className="row">
+                <span className={`status status-${state}`}>{state}</span>
+                <span className="goal">{job.hasArtifact ? "ready to deliver" : job.id}</span>
+              </div>
+            </li>
+          )
+        })}
+      </ul>
+    </section>
+  )
+}


### PR DESCRIPTION
Секция **Renders** на home-экране: поллит `render.list` (каждые 4с) и показывает статус render-джоб юзера — лёгкая замена `render.events` SSE (поллинг обходит EventSource-auth нюанс; SSE-вью заменит позже). Скрыта до первой загрузки и при отсутствии джоб.

## Проверка
- `apps/telegram-mini-app check:type` — **0**; root `check:type` — **0**. Только app-изменения.

🤖 Generated with [Claude Code](https://claude.com/claude-code)