### PR TITLE
feat(gateway+mini-app): live render status over SSE (#329/#330)

### DIFF
--- a/apps/telegram-mini-app/src/RenderJobs.tsx
+++ b/apps/telegram-mini-app/src/RenderJobs.tsx
@@ -3,13 +3,11 @@ import { gateway } from "./gateway"
 
 type RenderJob = Awaited<ReturnType<typeof gateway.render.list.query>>[number]
 
-const POLL_MS = 4000
-
 /**
- * The caller's render jobs (#330), polled for near-live status. A lightweight
- * stand-in for the `render.events` SSE stream — polling avoids the EventSource
- * auth nuance and is enough to show progress; the SSE view can replace it later.
- * Renders nothing until the first load and stays hidden when there are no jobs.
+ * The caller's render jobs (#330), streamed live over the gateway's
+ * `render.events` SSE subscription — an initial snapshot then a new one whenever
+ * a job changes status. Renders nothing until the first event and stays hidden
+ * when there are no jobs.
  */
 export function RenderJobs() {
   const [jobs, setJobs] = useState<RenderJob[]>([])
@@ -17,30 +15,18 @@ export function RenderJobs() {
   const [loaded, setLoaded] = useState(false)
 
   useEffect(() => {
-    let active = true
-    let timer: ReturnType<typeof setTimeout> | undefined
-
-    const poll = async () => {
-      try {
-        const list = await gateway.render.list.query()
-        if (!active) return
-        setJobs(list)
+    const subscription = gateway.render.events.subscribe(undefined, {
+      onData: (snapshot) => {
+        setJobs(snapshot.jobs)
         setError(null)
-      } catch (cause) {
-        if (active) setError(cause instanceof Error ? cause.message : "Failed to load renders")
-      } finally {
-        if (active) {
-          setLoaded(true)
-          timer = setTimeout(() => void poll(), POLL_MS)
-        }
-      }
-    }
-
-    void poll()
-    return () => {
-      active = false
-      if (timer) clearTimeout(timer)
-    }
+        setLoaded(true)
+      },
+      onError: (cause) => {
+        setError(cause.message)
+        setLoaded(true)
+      },
+    })
+    return () => subscription.unsubscribe()
   }, [])
 
   if (!loaded || (jobs.length === 0 && !error)) return null

--- a/apps/telegram-mini-app/src/gateway.ts
+++ b/apps/telegram-mini-app/src/gateway.ts
@@ -1,28 +1,39 @@
 /**
  * Type-safe API client to the bot-first gateway (#330).
  *
- * Reuses the gateway's `AppRouter` type for end-to-end type safety, and sends
- * the Telegram `initData` as `Authorization: tma <initData>` on every request —
- * the header the gateway's protectedProcedure verifies.
- *
- * Queries/mutations only for this slice; the `render.events` SSE subscription is
- * a follow-up (it needs EventSource-friendly auth).
+ * Reuses the gateway's `AppRouter` type for end-to-end type safety. Queries and
+ * mutations send the Telegram `initData` as `Authorization: tma <initData>`.
+ * Subscriptions (e.g. `render.events`) go over SSE via httpSubscriptionLink —
+ * EventSource can't set headers, so initData is passed as the `initData` query
+ * param, which the gateway also accepts.
  */
 
-import { createTRPCClient, httpBatchLink } from "@trpc/client"
+import { createTRPCClient, httpBatchLink, httpSubscriptionLink, splitLink } from "@trpc/client"
 import type { AppRouter } from "@gateway/api/root"
 import { getInitData } from "./telegram"
 
 const GATEWAY_URL = (import.meta.env.VITE_GATEWAY_URL as string | undefined) ?? "/trpc"
 
+/** SSE URL carrying initData in the query string (EventSource has no headers). */
+function subscriptionUrl(): string {
+  const initData = getInitData()
+  if (!initData) return GATEWAY_URL
+  const separator = GATEWAY_URL.includes("?") ? "&" : "?"
+  return `${GATEWAY_URL}${separator}initData=${encodeURIComponent(initData)}`
+}
+
 export const gateway = createTRPCClient<AppRouter>({
   links: [
-    httpBatchLink({
-      url: GATEWAY_URL,
-      headers() {
-        const initData = getInitData()
-        return initData ? { authorization: `tma ${initData}` } : {}
-      },
+    splitLink({
+      condition: (op) => op.type === "subscription",
+      true: httpSubscriptionLink({ url: subscriptionUrl }),
+      false: httpBatchLink({
+        url: GATEWAY_URL,
+        headers() {
+          const initData = getInitData()
+          return initData ? { authorization: `tma ${initData}` } : {}
+        },
+      }),
     }),
   ],
 })

--- a/src-node/__tests__/api/auth.test.ts
+++ b/src-node/__tests__/api/auth.test.ts
@@ -89,6 +89,18 @@ describe("extractInitData", () => {
     expect(extractInitData(req)).toBe("raw-init")
   })
 
+  test("reads the initData query param (for EventSource/SSE)", () => {
+    const req = new Request("http://x/trpc/render.events?initData=sse-init&batch=1")
+    expect(extractInitData(req)).toBe("sse-init")
+  })
+
+  test("prefers the Authorization header over the query param", () => {
+    const req = new Request("http://x/trpc?initData=from-query", {
+      headers: { authorization: "tma from-header" },
+    })
+    expect(extractInitData(req)).toBe("from-header")
+  })
+
   test("returns undefined when no init data header is present", () => {
     expect(extractInitData(new Request("http://x"))).toBeUndefined()
     expect(extractInitData(undefined)).toBeUndefined()

--- a/src-node/src/api/context.ts
+++ b/src-node/src/api/context.ts
@@ -117,7 +117,17 @@ export function extractInitData(req: Request | undefined): string | undefined {
     const match = /^tma\s+(.+)$/i.exec(auth.trim())
     if (match) return match[1]
   }
-  return req.headers.get("x-telegram-init-data") ?? undefined
+  const header = req.headers.get("x-telegram-init-data")
+  if (header) return header
+  // EventSource (SSE subscriptions) can't send custom headers, so also accept
+  // initData via the `initData` query param (#330).
+  try {
+    const fromQuery = new URL(req.url).searchParams.get("initData")
+    if (fromQuery) return fromQuery
+  } catch {
+    // req.url may be relative/unparseable in some adapters — ignore.
+  }
+  return undefined
 }
 
 /**


### PR DESCRIPTION
Заменяет поллинг render-статуса на `render.events` SSE-стрим и закрывает дыру с auth у EventSource.

## Что сделано
- **gateway**: `extractInitData` читает `initData` ещё и из query-параметра — EventSource (SSE) не может слать кастомные заголовки (заголовок по-прежнему в приоритете).
- **mini-app клиент**: `splitLink` направляет подписки через `httpSubscriptionLink` с initData в query SSE-URL; queries/mutations сохраняют auth-заголовок.
- **RenderJobs**: подписка на `render.events` (начальный снапшот + апдейты при смене статуса) вместо поллинга.

## Проверка
- src-node api suite — **63 passed** (+2 теста query-param `extractInitData`); app + root `check:type` — **0**. Новых deps нет.
- Клиентский SSE-путь верифицируется рантаймом только в Telegram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)