### PR TITLE
chore(mini-app): allow tunnel hosts in vite dev for Telegram (#330)

### DIFF
--- a/apps/telegram-mini-app/vite.config.ts
+++ b/apps/telegram-mini-app/vite.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
   // root's Next.js postcss.config.mjs, whose plugins aren't vite-compatible.
   css: { postcss: {} },
   server: {
+    // Allow any host so an HTTPS tunnel (cloudflared/ngrok) to Telegram works —
+    // the tunnel subdomain is dynamic. Dev-only server.
+    allowedHosts: true,
     proxy: {
       "/trpc": {
         target: process.env.GATEWAY_ORIGIN ?? "http://localhost:3001",


### PR DESCRIPTION
Vite dev блокирует неизвестные хосты; HTTPS-туннель (cloudflared/ngrok) для открытия Mini App в Telegram имеет динамический сабдомен. `server.allowedHosts: true` (dev-only сервер) пропускает туннельный хост.

Найдено во время рантайм-чекпоинта в Telegram. app check:type — 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)