### PR TITLE
feat(mini-app): session detail screen with BackButton + haptics (#330)

### DIFF
--- a/apps/telegram-mini-app/src/App.tsx
+++ b/apps/telegram-mini-app/src/App.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useState } from "react"
 import { gateway } from "./gateway"
 import { RenderJobs } from "./RenderJobs"
+import { SessionDetail } from "./SessionDetail"
 import { type SessionSummary, SessionRow } from "./SessionRow"
-import { getInitData } from "./telegram"
+import { getInitData, showBackButton } from "./telegram"
 
 interface Me {
   userId: string
@@ -11,12 +12,14 @@ interface Me {
 }
 
 /**
- * Home screen (#330): the verified identity and the caller's review sessions,
- * each with concierge actions (approve/revise/cancel) over the gateway.
+ * Mini App root (#330): home lists the caller's review sessions; tapping one
+ * opens a detail screen with concierge actions, navigable via the Telegram
+ * BackButton. A live Renders section streams render status over SSE.
  */
 export function App() {
   const [me, setMe] = useState<Me | null>(null)
   const [sessions, setSessions] = useState<SessionSummary[]>([])
+  const [selectedId, setSelectedId] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
 
@@ -52,8 +55,30 @@ export function App() {
     }
   }, [])
 
+  // Telegram BackButton returns from the detail screen to the list.
+  useEffect(() => {
+    if (!selectedId) return
+    return showBackButton(() => setSelectedId(null))
+  }, [selectedId])
+
   if (loading) return <main className="screen">Loading…</main>
   if (error && !me) return <main className="screen error">{error}</main>
+
+  const selected = selectedId ? sessions.find((s) => s.id === selectedId) : undefined
+
+  if (selected) {
+    return (
+      <main className="screen">
+        <SessionDetail
+          session={selected}
+          onChanged={() => {
+            void refresh()
+            setSelectedId(null)
+          }}
+        />
+      </main>
+    )
+  }
 
   return (
     <main className="screen">
@@ -70,7 +95,7 @@ export function App() {
         ) : (
           <ul className="sessions">
             {sessions.map((session) => (
-              <SessionRow key={session.id} session={session} onChanged={() => void refresh()} />
+              <SessionRow key={session.id} session={session} onOpen={setSelectedId} />
             ))}
           </ul>
         )}

--- a/apps/telegram-mini-app/src/SessionDetail.tsx
+++ b/apps/telegram-mini-app/src/SessionDetail.tsx
@@ -1,0 +1,104 @@
+import { type FormEvent, useState } from "react"
+import { gateway } from "./gateway"
+import type { SessionSummary } from "./SessionRow"
+import { haptics } from "./telegram"
+
+/**
+ * Session detail screen (#330): the full review session plus concierge actions
+ * (approve / revise / cancel) over the gateway's owner-scoped `edit.*` mutations,
+ * with haptic feedback. Actions are offered only while preview-ready.
+ */
+export function SessionDetail({ session, onChanged }: { session: SessionSummary; onChanged: () => void }) {
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [instruction, setInstruction] = useState("")
+
+  const canAct = session.status === "preview_ready"
+
+  async function run(action: () => Promise<unknown>): Promise<void> {
+    setBusy(true)
+    setError(null)
+    try {
+      await action()
+      haptics.notify("success")
+      onChanged()
+    } catch (cause) {
+      haptics.notify("error")
+      setError(cause instanceof Error ? cause.message : "Action failed")
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  function onRevise(event: FormEvent): void {
+    event.preventDefault()
+    const trimmed = instruction.trim()
+    if (!trimmed) return
+    void run(async () => {
+      await gateway.edit.revise.mutate({ id: session.id, instruction: trimmed })
+      setInstruction("")
+    })
+  }
+
+  return (
+    <section className="detail">
+      <span className={`status status-${session.status}`}>{session.status}</span>
+      <h2>{session.goal ?? "Review session"}</h2>
+
+      <dl className="meta">
+        <div>
+          <dt>Revisions</dt>
+          <dd>{session.revisionCount}</dd>
+        </div>
+        {session.approvedAt && (
+          <div>
+            <dt>Approved</dt>
+            <dd>{new Date(session.approvedAt).toLocaleString()}</dd>
+          </div>
+        )}
+        {session.publishedAt && (
+          <div>
+            <dt>Published</dt>
+            <dd>{new Date(session.publishedAt).toLocaleString()}</dd>
+          </div>
+        )}
+        {session.failure && (
+          <div>
+            <dt>Failure</dt>
+            <dd className="error">{session.failure}</dd>
+          </div>
+        )}
+        <div>
+          <dt>Updated</dt>
+          <dd>{new Date(session.updatedAt).toLocaleString()}</dd>
+        </div>
+      </dl>
+
+      {canAct ? (
+        <div className="actions">
+          <button type="button" disabled={busy} onClick={() => run(() => gateway.edit.approve.mutate({ id: session.id }))}>
+            Approve
+          </button>
+          <button type="button" disabled={busy} onClick={() => run(() => gateway.edit.cancel.mutate({ id: session.id }))}>
+            Cancel
+          </button>
+          <form className="revise" onSubmit={onRevise}>
+            <input
+              value={instruction}
+              onChange={(event) => setInstruction(event.target.value)}
+              placeholder="Revise…"
+              disabled={busy}
+            />
+            <button type="submit" disabled={busy || instruction.trim().length === 0}>
+              Revise
+            </button>
+          </form>
+        </div>
+      ) : (
+        <p className="muted">No actions available in “{session.status}”.</p>
+      )}
+
+      {error && <p className="error">{error}</p>}
+    </section>
+  )
+}

--- a/apps/telegram-mini-app/src/SessionRow.tsx
+++ b/apps/telegram-mini-app/src/SessionRow.tsx
@@ -1,73 +1,29 @@
-import { type FormEvent, useState } from "react"
 import { gateway } from "./gateway"
+import { haptics } from "./telegram"
 
 export type SessionSummary = Awaited<ReturnType<typeof gateway.session.list.query>>[number]
 
 /**
- * One review session with concierge actions (#330). Approve / Cancel / Revise
- * are only offered while the session is preview-ready and call the gateway's
- * owner-scoped `edit.*` mutations; the parent refreshes the list afterwards.
+ * A tappable session summary row (#330) — status + goal. Tapping opens the
+ * detail screen where the concierge actions live.
  */
-export function SessionRow({ session, onChanged }: { session: SessionSummary; onChanged: () => void }) {
-  const [busy, setBusy] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const [instruction, setInstruction] = useState("")
-
-  const canAct = session.status === "preview_ready"
-
-  async function run(action: () => Promise<unknown>): Promise<void> {
-    setBusy(true)
-    setError(null)
-    try {
-      await action()
-      onChanged()
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : "Action failed")
-    } finally {
-      setBusy(false)
-    }
-  }
-
-  function onRevise(event: FormEvent): void {
-    event.preventDefault()
-    const trimmed = instruction.trim()
-    if (!trimmed) return
-    void run(async () => {
-      await gateway.edit.revise.mutate({ id: session.id, instruction: trimmed })
-      setInstruction("")
-    })
-  }
-
+export function SessionRow({ session, onOpen }: { session: SessionSummary; onOpen: (id: string) => void }) {
   return (
     <li>
-      <div className="row">
+      <button
+        type="button"
+        className="row session-open"
+        onClick={() => {
+          haptics.impact("light")
+          onOpen(session.id)
+        }}
+      >
         <span className={`status status-${session.status}`}>{session.status}</span>
         <span className="goal">{session.goal ?? session.id}</span>
-      </div>
-
-      {canAct && (
-        <div className="actions">
-          <button type="button" disabled={busy} onClick={() => run(() => gateway.edit.approve.mutate({ id: session.id }))}>
-            Approve
-          </button>
-          <button type="button" disabled={busy} onClick={() => run(() => gateway.edit.cancel.mutate({ id: session.id }))}>
-            Cancel
-          </button>
-          <form className="revise" onSubmit={onRevise}>
-            <input
-              value={instruction}
-              onChange={(event) => setInstruction(event.target.value)}
-              placeholder="Revise…"
-              disabled={busy}
-            />
-            <button type="submit" disabled={busy || instruction.trim().length === 0}>
-              Revise
-            </button>
-          </form>
-        </div>
-      )}
-
-      {error && <p className="error">{error}</p>}
+        <span className="chevron" aria-hidden="true">
+          ›
+        </span>
+      </button>
     </li>
   )
 }

--- a/apps/telegram-mini-app/src/styles.css
+++ b/apps/telegram-mini-app/src/styles.css
@@ -47,6 +47,48 @@ body {
   gap: 8px;
 }
 
+.session-open {
+  width: 100%;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+}
+
+.session-open .chevron {
+  margin-left: auto;
+  opacity: 0.4;
+  font-size: 20px;
+}
+
+.detail h2 {
+  margin: 8px 0 12px;
+}
+
+.detail .meta {
+  margin: 0 0 16px;
+  display: grid;
+  gap: 8px;
+}
+
+.detail .meta > div {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.detail .meta dt {
+  color: var(--tg-theme-hint-color, #888888);
+}
+
+.detail .meta dd {
+  margin: 0;
+  text-align: right;
+}
+
 .actions {
   display: flex;
   flex-wrap: wrap;

--- a/apps/telegram-mini-app/src/telegram.ts
+++ b/apps/telegram-mini-app/src/telegram.ts
@@ -1,9 +1,9 @@
 /**
  * Minimal typed access to the Telegram WebApp runtime (#330).
  *
- * Reads `window.Telegram.WebApp.initData` directly — the same string the gateway
- * verifies. Kept dependency-free for the first slice; the richer `@twa-dev/sdk`
- * (theme/viewport helpers) can be layered on later without changing callers.
+ * Reads `window.Telegram.WebApp` directly (initData, theme, BackButton, haptics)
+ * — kept dependency-free; the richer `@twa-dev/sdk` can replace this later
+ * without changing callers.
  */
 
 export interface TelegramWebAppUser {
@@ -13,12 +13,27 @@ export interface TelegramWebAppUser {
   last_name?: string
 }
 
+export interface TelegramHapticFeedback {
+  impactOccurred: (style: "light" | "medium" | "heavy" | "rigid" | "soft") => void
+  notificationOccurred: (type: "error" | "success" | "warning") => void
+  selectionChanged: () => void
+}
+
+export interface TelegramBackButton {
+  show: () => void
+  hide: () => void
+  onClick: (cb: () => void) => void
+  offClick: (cb: () => void) => void
+}
+
 export interface TelegramWebApp {
   initData: string
   initDataUnsafe?: { user?: TelegramWebAppUser }
   colorScheme?: "light" | "dark"
   ready: () => void
   expand: () => void
+  HapticFeedback?: TelegramHapticFeedback
+  BackButton?: TelegramBackButton
 }
 
 declare global {
@@ -35,4 +50,29 @@ export function getWebApp(): TelegramWebApp | undefined {
 export function getInitData(): string | undefined {
   const data = getWebApp()?.initData
   return data && data.length > 0 ? data : undefined
+}
+
+/** Best-effort haptic feedback (no-op outside Telegram). */
+export const haptics = {
+  impact(style: "light" | "medium" | "heavy" | "rigid" | "soft" = "light"): void {
+    getWebApp()?.HapticFeedback?.impactOccurred(style)
+  },
+  notify(type: "error" | "success" | "warning"): void {
+    getWebApp()?.HapticFeedback?.notificationOccurred(type)
+  },
+}
+
+/**
+ * Wire the Telegram BackButton to a callback while shown; returns a cleanup that
+ * hides it and detaches the handler. No-op outside Telegram.
+ */
+export function showBackButton(onBack: () => void): () => void {
+  const back = getWebApp()?.BackButton
+  if (!back) return () => {}
+  back.onClick(onBack)
+  back.show()
+  return () => {
+    back.offClick(onBack)
+    back.hide()
+  }
 }


### PR DESCRIPTION
Второй экран + нативные Telegram-штрихи, **без новых зависимостей**.

- **telegram.ts**: типизированный доступ к `HapticFeedback` + `BackButton` (`haptics.impact/notify`, `showBackButton` с cleanup).
- **SessionRow**: теперь тапабельная строка (status + goal + chevron) → открывает детали (light haptic).
- **SessionDetail**: полная инфа сессии (ревизии, approved/published/updated, failure) + действия approve/revise/cancel с success/error-haptics.
- **App**: навигация list ↔ detail; нативная **BackButton** возвращает к списку.

## Проверка
- `apps/telegram-mini-app check:type` — **0**; **`vite build` успешен** (~235 kB). Только app-изменения.

🤖 Generated with [Claude Code](https://claude.com/claude-code)