### PR TITLE
feat(mini-app): native MainButton for Approve on detail screen (#330)

### DIFF
--- a/apps/telegram-mini-app/src/SessionDetail.tsx
+++ b/apps/telegram-mini-app/src/SessionDetail.tsx
@@ -1,7 +1,7 @@
-import { type FormEvent, useState } from "react"
+import { type FormEvent, useEffect, useState } from "react"
 import { gateway } from "./gateway"
 import type { SessionSummary } from "./SessionRow"
-import { haptics } from "./telegram"
+import { getWebApp, haptics, setMainButtonBusy, showMainButton } from "./telegram"
 
 /**
  * Session detail screen (#330): the full review session plus concierge actions
@@ -14,6 +14,9 @@ export function SessionDetail({ session, onChanged }: { session: SessionSummary;
   const [instruction, setInstruction] = useState("")
 
   const canAct = session.status === "preview_ready"
+  // In Telegram, "Approve" is the native MainButton; show an in-screen button
+  // only as a fallback where MainButton is unavailable (e.g. browser dev).
+  const hasMainButton = Boolean(getWebApp()?.MainButton)
 
   async function run(action: () => Promise<unknown>): Promise<void> {
     setBusy(true)
@@ -29,6 +32,17 @@ export function SessionDetail({ session, onChanged }: { session: SessionSummary;
       setBusy(false)
     }
   }
+
+  // The native MainButton mirrors the primary "Approve" action while preview-ready.
+  useEffect(() => {
+    if (!canAct) return
+    return showMainButton("Approve ✓", () => run(() => gateway.edit.approve.mutate({ id: session.id })))
+  }, [canAct, session.id])
+
+  // Reflect in-flight state on the MainButton spinner.
+  useEffect(() => {
+    setMainButtonBusy(busy)
+  }, [busy])
 
   function onRevise(event: FormEvent): void {
     event.preventDefault()
@@ -76,9 +90,11 @@ export function SessionDetail({ session, onChanged }: { session: SessionSummary;
 
       {canAct ? (
         <div className="actions">
-          <button type="button" disabled={busy} onClick={() => run(() => gateway.edit.approve.mutate({ id: session.id }))}>
-            Approve
-          </button>
+          {!hasMainButton && (
+            <button type="button" disabled={busy} onClick={() => run(() => gateway.edit.approve.mutate({ id: session.id }))}>
+              Approve
+            </button>
+          )}
           <button type="button" disabled={busy} onClick={() => run(() => gateway.edit.cancel.mutate({ id: session.id }))}>
             Cancel
           </button>

--- a/apps/telegram-mini-app/src/telegram.ts
+++ b/apps/telegram-mini-app/src/telegram.ts
@@ -26,6 +26,18 @@ export interface TelegramBackButton {
   offClick: (cb: () => void) => void
 }
 
+export interface TelegramMainButton {
+  setText: (text: string) => void
+  show: () => void
+  hide: () => void
+  enable: () => void
+  disable: () => void
+  showProgress: (leaveActive?: boolean) => void
+  hideProgress: () => void
+  onClick: (cb: () => void) => void
+  offClick: (cb: () => void) => void
+}
+
 export interface TelegramWebApp {
   initData: string
   initDataUnsafe?: { user?: TelegramWebAppUser }
@@ -34,6 +46,7 @@ export interface TelegramWebApp {
   expand: () => void
   HapticFeedback?: TelegramHapticFeedback
   BackButton?: TelegramBackButton
+  MainButton?: TelegramMainButton
 }
 
 declare global {
@@ -74,5 +87,36 @@ export function showBackButton(onBack: () => void): () => void {
   return () => {
     back.offClick(onBack)
     back.hide()
+  }
+}
+
+/**
+ * Show the Telegram MainButton (the native bottom action) with `text` wired to
+ * `onClick` while mounted; returns a cleanup that hides it and detaches the
+ * handler. No-op outside Telegram.
+ */
+export function showMainButton(text: string, onClick: () => void): () => void {
+  const main = getWebApp()?.MainButton
+  if (!main) return () => {}
+  main.setText(text)
+  main.onClick(onClick)
+  main.show()
+  return () => {
+    main.offClick(onClick)
+    main.hideProgress()
+    main.hide()
+  }
+}
+
+/** Toggle the MainButton's spinner + disabled state (no-op outside Telegram). */
+export function setMainButtonBusy(busy: boolean): void {
+  const main = getWebApp()?.MainButton
+  if (!main) return
+  if (busy) {
+    main.disable()
+    main.showProgress()
+  } else {
+    main.hideProgress()
+    main.enable()
   }
 }


### PR DESCRIPTION
Главное действие **Approve** теперь на нативной **MainButton** Telegram (нижняя панель), пока сессия `preview_ready`, со спиннером во время запроса.

- **telegram.ts**: типизированный `MainButton`; `showMainButton(text, onClick)` с cleanup, `setMainButtonBusy(busy)` — спиннер/disabled.
- **SessionDetail**: MainButton дублирует Approve в `preview_ready`; in-screen кнопка Approve остаётся только как fallback там, где MainButton недоступна (браузер-dev). Cancel/Revise — на экране.

## Проверка
`check:type` 0; **vite build** ✓. Только app-изменения (biome игнорирует app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)