### PR TITLE
feat(idea.submit): start a first-cut workflow from the Mini App, end-to-end (#330)

### DIFF
--- a/src-node/__tests__/api/idea.test.ts
+++ b/src-node/__tests__/api/idea.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Gateway idea-submission router (#330) — submit drives the bot's first-cut
+ * workflow via a synthesized plain-text message, scoped to the authenticated
+ * user, enqueuing so the mutation returns fast.
+ */
+
+import { describe, test, expect } from "bun:test"
+import crypto from "node:crypto"
+import type { BotEditSession, BotEditSessionStore, BotEditSessionQuery } from "@timeline-studio/core"
+import type {
+  NodeBotWorkflowService,
+  NodeTelegramBotWorkflowQueue,
+  NodeTelegramBotWorkflowQueueJob,
+} from "@timeline-studio/adapters/node"
+import { appRouter } from "../../src/api/root"
+import type { Context } from "../../src/api/context"
+import { createLogger } from "../../src/utils/logger"
+
+const BOT_TOKEN = "123456:test-bot-token"
+
+function signInitData(userId: number): string {
+  const fields = { auth_date: "1700000000", user: JSON.stringify({ id: userId }) }
+  const dataCheckString = Object.entries(fields)
+    .map(([k, v]) => `${k}=${v}`)
+    .sort()
+    .join("\n")
+  const secretKey = crypto.createHmac("sha256", "WebAppData").update(BOT_TOKEN).digest()
+  const hash = crypto.createHmac("sha256", secretKey).update(dataCheckString).digest("hex")
+  const params = new URLSearchParams(fields)
+  params.set("hash", hash)
+  return params.toString()
+}
+
+function emptyStore(): BotEditSessionStore {
+  const map = new Map<string, BotEditSession>()
+  const store: BotEditSessionStore = {
+    readSession: async (id) => map.get(id),
+    writeSession: async (s) => {
+      map.set(s.id, s)
+    },
+    deleteSession: async (id) => {
+      map.delete(id)
+    },
+    listSessions: async (q: BotEditSessionQuery = {}) =>
+      [...map.values()].filter((s) => (!q.userId || s.userId === q.userId) && (!q.chatId || s.chatId === q.chatId)),
+    readCurrentSession: async () => undefined,
+  }
+  return store
+}
+
+// A workflow runner whose execution is never reached: with a deferring queue,
+// the worker enqueues without invoking run().
+const stubWorkflow = {
+  runWorkflow: async () => {
+    throw new Error("workflow run should not execute synchronously")
+  },
+  runTelegramLikePayload: async () => {
+    throw new Error("workflow run should not execute synchronously")
+  },
+  cancelRenderJob: async () => false,
+} as unknown as NodeBotWorkflowService
+
+/** A queue that records submissions and defers (never runs them). */
+function recordingQueue(): { queue: NodeTelegramBotWorkflowQueue; jobs: NodeTelegramBotWorkflowQueueJob[] } {
+  const jobs: NodeTelegramBotWorkflowQueueJob[] = []
+  const queue: NodeTelegramBotWorkflowQueue = {
+    enqueue: async (job) => {
+      jobs.push(job)
+      return { id: job.id, status: "queued" }
+    },
+  }
+  return { queue, jobs }
+}
+
+function ctxFor(userId: number, overrides: Partial<Context> = {}): Context {
+  return {
+    logger: createLogger("test"),
+    botToken: BOT_TOKEN,
+    initDataMaxAge: 0,
+    initData: signInitData(userId),
+    editSessionStore: emptyStore(),
+    botWorkflow: stubWorkflow,
+    ...overrides,
+  } as Context
+}
+
+describe("Gateway idea router (#330)", () => {
+  test("idea.submit enqueues the idea and returns a queued job id", async () => {
+    const { queue, jobs } = recordingQueue()
+    const caller = appRouter.createCaller(ctxFor(42, { workflowQueue: queue }))
+
+    const result = await caller.idea.submit({ text: "a punchy promo for our new app" })
+
+    expect(result.queued).toBe(true)
+    expect(result.status).toBe("queued")
+    expect(typeof result.jobId).toBe("string")
+    expect(jobs.length).toBe(1)
+    // The synthesized message carries the idea text, scoped to the caller.
+    expect(jobs[0]?.update.message?.text).toBe("a punchy promo for our new app")
+    expect(jobs[0]?.update.message?.from?.id).toBe("42")
+  })
+
+  test("idea.submit is disabled without a workflow (501)", async () => {
+    const caller = appRouter.createCaller(ctxFor(42, { botWorkflow: undefined }))
+    await expect(caller.idea.submit({ text: "hello" })).rejects.toMatchObject({ code: "NOT_IMPLEMENTED" })
+  })
+
+  test("idea.submit fails without an edit-session store (500)", async () => {
+    const caller = appRouter.createCaller(ctxFor(42, { editSessionStore: undefined }))
+    await expect(caller.idea.submit({ text: "hello" })).rejects.toMatchObject({ code: "INTERNAL_SERVER_ERROR" })
+  })
+
+  test("idea.submit rejects empty text", async () => {
+    const caller = appRouter.createCaller(ctxFor(42, { workflowQueue: recordingQueue().queue }))
+    await expect(caller.idea.submit({ text: "   " })).rejects.toBeDefined()
+  })
+
+  test("idea.submit requires authentication (401)", async () => {
+    const caller = appRouter.createCaller({
+      logger: createLogger("test"),
+      botToken: BOT_TOKEN,
+      editSessionStore: emptyStore(),
+      botWorkflow: stubWorkflow,
+    } as Context)
+    await expect(caller.idea.submit({ text: "hello" })).rejects.toMatchObject({ code: "UNAUTHORIZED" })
+  })
+})

--- a/src-node/src/api/context.ts
+++ b/src-node/src/api/context.ts
@@ -1,10 +1,14 @@
 import type { BotEditSessionStore, IAIProjectEditor, IPublishService } from "@timeline-studio/core"
 import {
+  createNodeServices,
   NodeAIProjectEditor,
   NodeBotEditSessionFileStore,
+  type NodeBotWorkflowService,
   NodePublishService,
   NodeTelegramBotFileWorkflowJobStore,
+  NodeTelegramBotInMemoryWorkflowQueue,
   type NodeTelegramBotWorkflowJobStore,
+  type NodeTelegramBotWorkflowQueue,
 } from "@timeline-studio/adapters/node"
 import type { EnhancedMediaService } from "../services/media-service"
 import type { CacheService } from "../services/cache-service"
@@ -37,6 +41,10 @@ export interface Context {
   publishService?: IPublishService
   /** AI project editor for edit.revise, when configured (#329). */
   aiProjectEditor?: IAIProjectEditor
+  /** Bot workflow runner for idea.submit (first cut), when configured (#330). */
+  botWorkflow?: NodeBotWorkflowService
+  /** In-process queue so idea.submit returns fast and renders async (#330). */
+  workflowQueue?: NodeTelegramBotWorkflowQueue
 }
 
 // Edit-session store is a process singleton over the bot's shared directory.
@@ -86,6 +94,41 @@ function getAIProjectEditor(): IAIProjectEditor | undefined {
     })
   }
   return aiProjectEditor
+}
+
+// Bot workflow runner is built only when a script-generator API key is present
+// (#330). It pulls in the full node service stack (video/render/first-cut) via
+// createNodeServices; lazy + gated so the gateway stays thin unless opted in.
+let botWorkflow: NodeBotWorkflowService | undefined
+let botWorkflowResolved = false
+function getBotWorkflow(): NodeBotWorkflowService | undefined {
+  if (botWorkflowResolved) return botWorkflow
+  botWorkflowResolved = true
+  if (!config.GATEWAY_SCRIPT_GENERATOR_API_KEY) return undefined
+  botWorkflow = createNodeServices({
+    botScriptGenerator: {
+      apiKey: config.GATEWAY_SCRIPT_GENERATOR_API_KEY,
+      ...(config.GATEWAY_SCRIPT_GENERATOR_API_URL ? { apiUrl: config.GATEWAY_SCRIPT_GENERATOR_API_URL } : {}),
+      ...(config.GATEWAY_SCRIPT_GENERATOR_PROVIDER ? { provider: config.GATEWAY_SCRIPT_GENERATOR_PROVIDER } : {}),
+      ...(config.GATEWAY_SCRIPT_GENERATOR_MODEL ? { model: config.GATEWAY_SCRIPT_GENERATOR_MODEL } : {}),
+    },
+    rustRender: config.GATEWAY_RUST_RENDER,
+    video: { ffmpegPath: config.FFMPEG_PATH, ffprobePath: config.FFPROBE_PATH },
+  }).botWorkflow
+  return botWorkflow
+}
+
+// In-process workflow queue so idea.submit enqueues and returns immediately,
+// rendering the first cut in the background. Only built alongside the workflow.
+let workflowQueue: NodeTelegramBotWorkflowQueue | undefined
+function getWorkflowQueue(): NodeTelegramBotWorkflowQueue | undefined {
+  if (!getBotWorkflow()) return undefined
+  if (!workflowQueue) {
+    workflowQueue = new NodeTelegramBotInMemoryWorkflowQueue({
+      concurrency: config.GATEWAY_WORKFLOW_CONCURRENCY,
+    })
+  }
+  return workflowQueue
 }
 
 type ContextServices = Pick<Context, "mediaService" | "cacheService" | "queueService">
@@ -149,5 +192,7 @@ export async function createContext(opts: CreateContextOptions = {}): Promise<Co
     renderStreamIntervalMs: config.TELEGRAM_RENDER_STREAM_INTERVAL_MS,
     publishService: getPublishService(),
     aiProjectEditor: getAIProjectEditor(),
+    botWorkflow: getBotWorkflow(),
+    workflowQueue: getWorkflowQueue(),
   }
 }

--- a/src-node/src/api/root.ts
+++ b/src-node/src/api/root.ts
@@ -9,6 +9,7 @@ import { authRouter } from "./routers/auth"
 import { sessionRouter } from "./routers/session"
 import { renderRouter } from "./routers/render"
 import { editRouter } from "./routers/edit"
+import { ideaRouter } from "./routers/idea"
 
 /**
  * Main tRPC app router
@@ -24,6 +25,7 @@ export const appRouter = router({
   session: sessionRouter,
   render: renderRouter,
   edit: editRouter,
+  idea: ideaRouter,
 })
 
 /**

--- a/src-node/src/api/routers/idea.ts
+++ b/src-node/src/api/routers/idea.ts
@@ -1,0 +1,73 @@
+import crypto from "node:crypto"
+import { z } from "zod"
+import { TRPCError } from "@trpc/server"
+import { NodeTelegramBotWorker } from "@timeline-studio/adapters/node"
+import { protectedProcedure, router } from "../trpc"
+
+/**
+ * Gateway idea-submission router (#330).
+ *
+ * `submit` lets the Mini App start a fresh review session from a plain idea,
+ * reusing the bot's own first-cut workflow: the gateway drives a
+ * NodeTelegramBotWorker (bound to the real workflow runner + an in-process
+ * queue) with a synthesized plain-text message, scoped to the authenticated
+ * user. With the queue wired, the worker enqueues and returns immediately; the
+ * first cut renders in the background and the session surfaces in `session.list`
+ * (and render-status SSE) once it reaches preview-ready.
+ *
+ * Disabled unless a script generator is configured (GATEWAY_SCRIPT_GENERATOR_API_KEY),
+ * mirroring how edit.revise is gated on an AI editor.
+ */
+export const ideaRouter = router({
+  submit: protectedProcedure
+    .input(z.object({ text: z.string().trim().min(1).max(4000) }))
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.botWorkflow) {
+        throw new TRPCError({
+          code: "NOT_IMPLEMENTED",
+          message: "Idea submission is not enabled (GATEWAY_SCRIPT_GENERATOR_API_KEY missing)",
+        })
+      }
+      if (!ctx.editSessionStore) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Edit-session store is not configured (TELEGRAM_BOT_EDIT_SESSION_DIR missing)",
+        })
+      }
+
+      const worker = new NodeTelegramBotWorker({
+        workflow: ctx.botWorkflow,
+        editSessionStore: ctx.editSessionStore,
+        ...(ctx.workflowQueue ? { workflowQueue: ctx.workflowQueue } : {}),
+        ...(ctx.workflowJobStore ? { workflowJobStore: ctx.workflowJobStore } : {}),
+        ...(ctx.aiProjectEditor ? { aiProjectEditor: ctx.aiProjectEditor } : {}),
+        ...(ctx.publishService ? { publishService: ctx.publishService } : {}),
+      })
+
+      const result = await worker.handleUpdate({
+        update_id: 0,
+        message: {
+          // Unique id so the worker doesn't treat this as a duplicate of a prior job.
+          message_id: `gateway-idea-${crypto.randomUUID()}`,
+          chat: { id: ctx.auth.userId },
+          from: { id: ctx.auth.userId },
+          text: input.text,
+        },
+      })
+
+      if (result.skipped) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: `Idea was not accepted (${result.reason ?? "skipped"})`,
+        })
+      }
+
+      const queued = "queued" in result && result.queued === true
+      const jobId = "queueId" in result && result.queueId ? result.queueId : null
+      return {
+        queued,
+        jobId,
+        status: queued ? ("queued" as const) : ("running" as const),
+      }
+    }),
+})

--- a/src-node/src/config/index.ts
+++ b/src-node/src/config/index.ts
@@ -53,6 +53,21 @@ const ConfigSchema = z.object({
   GATEWAY_AI_EDITOR_PROVIDER: z.string().optional(),
   GATEWAY_AI_EDITOR_MODEL: z.string().optional(),
 
+  // Opt-in LLM script/storyboard generator for idea.submit (#330): turns a fresh
+  // idea into a first-cut workflow. Built only when an API key is present;
+  // otherwise idea.submit is disabled (the gateway runs no workflows).
+  GATEWAY_SCRIPT_GENERATOR_API_KEY: z.string().optional(),
+  GATEWAY_SCRIPT_GENERATOR_API_URL: z.string().optional(),
+  GATEWAY_SCRIPT_GENERATOR_PROVIDER: z.string().optional(),
+  GATEWAY_SCRIPT_GENERATOR_MODEL: z.string().optional(),
+  // Use the Rust headless renderer for gateway-run first cuts (else ffmpeg CLI).
+  GATEWAY_RUST_RENDER: z
+    .string()
+    .optional()
+    .transform((v) => v === "true" || v === "1"),
+  // Concurrency for the gateway's in-process workflow queue (idea.submit).
+  GATEWAY_WORKFLOW_CONCURRENCY: z.coerce.number().int().min(1).default(1),
+
   // Logging
   LOG_LEVEL: z
     .enum(["trace", "debug", "info", "warn", "error"])


### PR DESCRIPTION
Новый owner-scoped `idea.submit` — Mini App может запустить свежую review-сессию из идеи, **переиспользуя first-cut workflow бота** (не дублируя): gateway гонит `NodeTelegramBotWorker` (реальный workflow-runner + in-process очередь) синтезированным plain-text сообщением. С очередью worker ставит в очередь и сразу отвечает; первая нарезка рендерится в фоне и появляется в `session.list` / render-SSE, когда дойдёт до `preview_ready`.

## Что
- **config**: `GATEWAY_SCRIPT_GENERATOR_API_KEY` (+ `_API_URL/_PROVIDER/_MODEL`), `GATEWAY_RUST_RENDER`, `GATEWAY_WORKFLOW_CONCURRENCY`.
- **context**: ленивый, gated-на-конфиг `botWorkflow` (через `createNodeServices`) + in-process `NodeTelegramBotInMemoryWorkflowQueue`. **По умолчанию выключено** — gateway остаётся тонким и не гоняет workflow без script-generator ключа.
- **routers/idea.ts**: `idea.submit` гонит worker от лица вызывающего; возвращает `{ queued, jobId, status }`. Без workflow — **501**; без edit-session store — **500**; без auth — **401**.

## Проверка
5 новых тестов (enqueue+scope, 501/500/401, пустой текст). Полный gateway-сьют **131 pass**; src-node `check:type` 0; mini-app `check:type` 0 (AppRouter получает `idea.*`).

Фронт-экран ввода идеи — следующим PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)