### PR TITLE
feat(bot): concierge approval policy — always/never/auto (#334)

### DIFF
--- a/apps/cli/src/commands/bot-worker.ts
+++ b/apps/cli/src/commands/bot-worker.ts
@@ -31,6 +31,7 @@ import {
 } from "@timeline-studio/adapters/node"
 import type { BotFeedbackTranscriptionProvider } from "@timeline-studio/core/ports"
 import type {
+  BotApprovalPolicy,
   BotRenderJobDestination,
   BotWorkflowRunResult,
   BotWorkflowStatusOptions,
@@ -82,6 +83,7 @@ export interface BotWorkerCommandOptions {
   feedbackTranscriberLanguage?: string
   transcribeVoiceIdeas?: boolean
   conciergeApproval?: boolean
+  approvalPolicy?: BotApprovalPolicy
   firstCutPlanner?: boolean
   firstCutPlannerCommand?: string
   firstCutPlannerKind?: NodeRustFirstCutPlannerKind
@@ -167,6 +169,10 @@ export const botWorkerCommand = new Command("bot-worker")
   .option(
     "--no-concierge-approval",
     "Disable the operator manual-approval gate and auto-deliver results (default: approval required)",
+  )
+  .option(
+    "--approval-policy <policy>",
+    "Concierge approval policy: always (manual), never (self-serve), or auto (auto-approve clean first cuts)",
   )
   .option("--first-cut-planner", "Enable Rust timeline montage-plan/llm-plan first-cut planning")
   .option("--first-cut-planner-command <path>", "Path/name for the Rust timeline first-cut planner command")
@@ -289,6 +295,7 @@ export async function runBotWorker(options: BotWorkerCommandOptions = {}): Promi
     feedbackTranscriber: services.botFeedbackTranscriber,
     transcribeVoiceIdeas: resolvedOptions.transcribeVoiceIdeas ?? false,
     conciergeApproval: resolvedOptions.conciergeApproval ?? true,
+    ...(resolvedOptions.approvalPolicy ? { approvalPolicy: resolvedOptions.approvalPolicy } : {}),
     previewRenderer: createBotReviewPreviewRenderer(services.renderJob, resolvedOptions),
     publishService: services.publish,
     previewResponder: services.botStatus,
@@ -400,6 +407,7 @@ export function resolveBotWorkerCommandOptions(
     // otherwise the env can disable it, falling back to enabled.
     conciergeApproval:
       options.conciergeApproval === false ? false : (parseBooleanEnv(env.TIMELINE_BOT_CONCIERGE_APPROVAL) ?? true),
+    approvalPolicy: normalizeApprovalPolicy(firstConfigured(options.approvalPolicy, env.TIMELINE_BOT_APPROVAL_POLICY)),
     firstCutPlanner: options.firstCutPlanner ?? parseBooleanEnv(env.TIMELINE_BOT_FIRST_CUT_PLANNER),
     firstCutPlannerCommand: firstConfigured(options.firstCutPlannerCommand, env.TIMELINE_BOT_FIRST_CUT_PLANNER_COMMAND),
     firstCutPlannerKind: firstConfigured(
@@ -874,6 +882,17 @@ function normalizeFeedbackTranscriberProvider(value: string | undefined): BotFee
     case "local":
     case "faster-whisper":
       return value.trim() as BotFeedbackTranscriptionProvider
+    default:
+      return undefined
+  }
+}
+
+function normalizeApprovalPolicy(value: string | undefined): BotApprovalPolicy | undefined {
+  switch (value?.trim()) {
+    case "always":
+    case "never":
+    case "auto":
+      return value.trim() as BotApprovalPolicy
     default:
       return undefined
   }

--- a/packages/adapters/src/node/__tests__/telegram-bot-worker.test.ts
+++ b/packages/adapters/src/node/__tests__/telegram-bot-worker.test.ts
@@ -434,6 +434,83 @@ describe("Telegram bot worker", () => {
     expect(workflowOptions?.approvalGate).toBeUndefined()
   })
 
+  // A gated workflow result that flows through upsertReviewEditSessionFromWorkflowResult
+  // to create a preview-ready session (#334 auto-approve fixture).
+  type RunWarning = { code: string; field?: string; message: string; userMessage?: string }
+  const gatedPreviewResult = (warnings: RunWarning[] = []): BotWorkflowRunResult => ({
+    ok: true,
+    workflow: { source: "telegram", chatId: "chat-1", userId: "user-1", messageId: "idea-auto" },
+    renderJob: {
+      source: "bot",
+      output: { format: "mp4", destination: "file" },
+      project: { type: "inline", schema: createProjectSchema() },
+    },
+    result: {
+      job: {
+        id: "job-auto-1",
+        status: "done",
+        progress: 1,
+        request: { source: "bot", output: { format: "mp4" } },
+        artifact: { type: "file", path: "/tmp/auto.mp4", destination: "file", mimeType: "video/mp4" },
+        createdAt: "2026-06-08T08:00:00.000Z",
+        updatedAt: "2026-06-08T08:00:01.000Z",
+        events: [],
+      },
+      events: [],
+    },
+    warnings,
+    approvalGate: { enabled: true, previewDestination: "telegram", publishTarget: "telegram" },
+  })
+
+  it("bypasses the approval gate under the 'never' policy (#334)", async () => {
+    const { store } = createEditSessionStore()
+    const { service, runTelegramLikePayload } = createWorkflowService()
+    const worker = new NodeTelegramBotWorker({ workflow: service, editSessionStore: store, approvalPolicy: "never" })
+
+    await worker.handleUpdate(ideaTextUpdate(34))
+
+    const [, workflowOptions] = runTelegramLikePayload.mock.calls[0] as unknown as [unknown, { approvalGate?: unknown } | undefined]
+    expect(workflowOptions?.approvalGate).toBeUndefined()
+  })
+
+  it("gates under the 'auto' policy (#334)", async () => {
+    const { store } = createEditSessionStore()
+    const { service, runTelegramLikePayload } = createWorkflowService()
+    const worker = new NodeTelegramBotWorker({ workflow: service, editSessionStore: store, approvalPolicy: "auto" })
+
+    await worker.handleUpdate(ideaTextUpdate(35))
+
+    const [, workflowOptions] = runTelegramLikePayload.mock.calls[0] as unknown as [unknown, { approvalGate?: { enabled?: boolean } } | undefined]
+    expect(workflowOptions?.approvalGate).toMatchObject({ enabled: true })
+  })
+
+  it("auto-approves a warning-free first cut under the 'auto' policy (#334)", async () => {
+    const { store, records } = createEditSessionStore()
+    const { service } = createWorkflowService(gatedPreviewResult([]))
+    const worker = new NodeTelegramBotWorker({ workflow: service, editSessionStore: store, approvalPolicy: "auto" })
+
+    await worker.handleUpdate(ideaTextUpdate(36))
+
+    const session = records.get("edit:telegram:chat-1:user-1")
+    expect(session?.status).toBe("approved")
+    expect(session?.approvedBy).toBe("user-1")
+  })
+
+  it("leaves a warning'd first cut for manual approval under the 'auto' policy (#334)", async () => {
+    const { store, records } = createEditSessionStore()
+    const warned = gatedPreviewResult([
+      { code: "quality_warning", field: "render", message: "low confidence", userMessage: "Please review." },
+    ])
+    const { service } = createWorkflowService(warned)
+    const worker = new NodeTelegramBotWorker({ workflow: service, editSessionStore: store, approvalPolicy: "auto" })
+
+    await worker.handleUpdate(ideaTextUpdate(37))
+
+    const session = records.get("edit:telegram:chat-1:user-1")
+    expect(session?.status).toBe("preview_ready")
+    expect(session?.approvedBy).toBeUndefined()
+  })
+
   it("records the approving operator in the edit session (#325)", async () => {
     const session = createReviewSession({ status: "preview_ready" })
     const { store, records } = createEditSessionStore([session])

--- a/packages/adapters/src/node/telegram-bot-worker.ts
+++ b/packages/adapters/src/node/telegram-bot-worker.ts
@@ -12,7 +12,9 @@ import {
   runAIProjectEdit,
   validateBotDestinationCapability,
 } from "@timeline-studio/core/services"
+import { resolveBotApprovalDecision } from "@timeline-studio/core/types"
 import type {
+  BotApprovalPolicy,
   BotEditRevision,
   BotEditSession,
   BotEditSessionStore,
@@ -136,8 +138,18 @@ export interface NodeTelegramBotWorkerOptions {
    * operator `/approve` before delivery/publish — a human in the loop. Set to
    * `false` to bypass the gate and auto-deliver (self-serve mode), while keeping
    * the edit-session store for other features.
+   *
+   * Superseded by {@link approvalPolicy} when set; kept for back-compat
+   * (`true` → `"always"`, `false` → `"never"`).
    */
   conciergeApproval?: boolean
+  /**
+   * Concierge approval policy (#334). Generalizes {@link conciergeApproval}:
+   * `"always"` (manual `/approve`), `"never"` (self-serve auto-deliver), or
+   * `"auto"` (gate + auto-approve when the first cut renders warning-free, else
+   * manual). When unset, falls back to {@link conciergeApproval}.
+   */
+  approvalPolicy?: BotApprovalPolicy
   publishService?: IPublishService
   previewRenderer?: NodeTelegramBotReviewPreviewRenderer
   previewResponder?: NodeTelegramBotReviewPreviewResponder
@@ -783,12 +795,21 @@ export class NodeTelegramBotWorker {
     return this.options.now?.() ?? new Date().toISOString()
   }
 
+  /**
+   * Effective approval policy (#334): `approvalPolicy` wins; otherwise derive
+   * from the legacy {@link conciergeApproval} boolean (`false` → self-serve).
+   */
+  private resolveApprovalPolicy(): BotApprovalPolicy {
+    if (this.options.approvalPolicy) return this.options.approvalPolicy
+    return this.options.conciergeApproval === false ? "never" : "always"
+  }
+
   private withReviewApprovalGate(
     options: NodeBotWorkflowServiceOptions | undefined,
   ): NodeBotWorkflowServiceOptions | undefined {
     if (!this.options.editSessionStore) return options
-    // Concierge toggle (#325): bypass the gate for auto-delivery when disabled.
-    if (this.options.conciergeApproval === false) return options
+    // Policy (#334/#325): bypass the gate for auto-delivery in self-serve mode.
+    if (!resolveBotApprovalDecision(this.resolveApprovalPolicy(), 0).gateEnabled) return options
     const gatedOptions = mergeWorkflowOptions(options, {
       approvalGate: {
         enabled: true,
@@ -2078,6 +2099,32 @@ export class NodeTelegramBotWorker {
     })
 
     await store.writeSession(session)
+
+    // Policy "auto" (#334): when the first cut renders warning-free, approve it
+    // immediately instead of waiting for a manual /approve.
+    if (resolveBotApprovalDecision(this.resolveApprovalPolicy(), workflowResult.warnings.length).autoApprove) {
+      await this.autoApprovePreview(session, workflowResult.workflow)
+    }
+  }
+
+  /**
+   * Auto-approve a just-created preview session by replaying a synthesized
+   * `/approve` through the normal review path — identical semantics to an
+   * operator approval (records the decision, delivers when a publish service is
+   * configured). No-op without a chat to attribute the approval to.
+   */
+  private async autoApprovePreview(session: BotEditSession, workflow: BotWorkflowRequest): Promise<void> {
+    const chatId = session.chatId ?? workflow.chatId
+    if (chatId === undefined) return
+    await this.handleUpdate({
+      update_id: 0,
+      message: {
+        message_id: `auto-approve-${session.id}`,
+        chat: { id: chatId },
+        ...(workflow.userId ? { from: { id: workflow.userId } } : {}),
+        text: "/approve",
+      },
+    })
   }
 
   private async sendDraftResponse(draftId: string, payload: TelegramLikeBotPayload, text: string): Promise<void> {

--- a/packages/core/src/services/__tests__/bot-workflow-runner.test.ts
+++ b/packages/core/src/services/__tests__/bot-workflow-runner.test.ts
@@ -8,6 +8,7 @@ import type {
   BotRenderJobResult,
   BotRenderJobRunOptions,
 } from "../../types"
+import { resolveBotApprovalDecision } from "../../types/bot-workflow"
 import { createBotProjectSchemaFromRenderJob } from "../bot-project-assembler"
 import { runBotWorkflow, runTelegramLikeBotWorkflow } from "../bot-workflow-runner"
 import { InMemoryBotRenderJobEventStream } from "../render-job-events"
@@ -387,5 +388,22 @@ describe("bot workflow runner", () => {
     expect(renderJob.lastOptions?.eventSinks).toHaveLength(2)
     expect(callerSink.publish).toHaveBeenCalledTimes(1)
     expect(eventStream.getSnapshot("job-1")).toMatchObject({ status: "done" })
+  })
+})
+
+describe("resolveBotApprovalDecision (#334)", () => {
+  it("'never' bypasses the gate (self-serve, no auto-approve)", () => {
+    expect(resolveBotApprovalDecision("never", 0)).toEqual({ gateEnabled: false, autoApprove: false })
+    expect(resolveBotApprovalDecision("never", 3)).toEqual({ gateEnabled: false, autoApprove: false })
+  })
+
+  it("'always' gates and never auto-approves", () => {
+    expect(resolveBotApprovalDecision("always", 0)).toEqual({ gateEnabled: true, autoApprove: false })
+    expect(resolveBotApprovalDecision("always", 5)).toEqual({ gateEnabled: true, autoApprove: false })
+  })
+
+  it("'auto' gates and auto-approves only when the run is warning-free", () => {
+    expect(resolveBotApprovalDecision("auto", 0)).toEqual({ gateEnabled: true, autoApprove: true })
+    expect(resolveBotApprovalDecision("auto", 1)).toEqual({ gateEnabled: true, autoApprove: false })
   })
 })

--- a/packages/core/src/types/bot-workflow.ts
+++ b/packages/core/src/types/bot-workflow.ts
@@ -219,6 +219,32 @@ export interface BotWorkflowApprovalGateOptions {
   previewDestination?: BotRenderJobDestination
 }
 
+/**
+ * Concierge approval policy (#334) — how a first cut is gated before delivery:
+ * - `"always"`: gate every result behind a manual `/approve` (human in the loop).
+ * - `"never"`: bypass the gate and auto-deliver (self-serve).
+ * - `"auto"`: gate, render the preview, then auto-approve when the run is clean
+ *   (no validation warnings); otherwise fall back to manual approval.
+ */
+export type BotApprovalPolicy = "always" | "never" | "auto"
+
+export interface BotApprovalDecision {
+  /** Whether to enable the approval gate (render to a preview destination). */
+  gateEnabled: boolean
+  /** Whether to auto-approve the preview once rendered (only in `"auto"`). */
+  autoApprove: boolean
+}
+
+/**
+ * Pure decision for a {@link BotApprovalPolicy} given the run's validation
+ * warning count. `"auto"` auto-approves only when the render is warning-free.
+ */
+export function resolveBotApprovalDecision(policy: BotApprovalPolicy, warningCount: number): BotApprovalDecision {
+  if (policy === "never") return { gateEnabled: false, autoApprove: false }
+  if (policy === "auto") return { gateEnabled: true, autoApprove: warningCount === 0 }
+  return { gateEnabled: true, autoApprove: false }
+}
+
 export interface BotWorkflowApprovalGateResult {
   enabled: boolean
   previewDestination: BotRenderJobDestination


### PR DESCRIPTION
Первый срез Phase 3 **#334** (concierge → self-serve): обобщает булев тумблер #325 в **policy**.

- **`always`** — ручной `/approve` на каждую нарезку (прежний дефолт).
- **`never`** — без гейта, авто-доставка (self-serve; прежний `conciergeApproval:false`).
- **`auto`** — гейт + превью, затем **авто-апрув при чистом рендере** (без validation-warnings — реальный сигнал качества), иначе ручной апрув.

## Что
- **core**: `BotApprovalPolicy` + чистая `resolveBotApprovalDecision(policy, warningCount)` → `{ gateEnabled, autoApprove }`.
- **worker**: опция `approvalPolicy` (fallback на `conciergeApproval` для обратной совместимости); включение гейта policy-driven; `auto` переигрывает синтезированный `/approve` через обычный review-путь (семантика идентична операторскому апруву).
- **cli**: `--approval-policy <always|never|auto>` + `TIMELINE_BOT_APPROVAL_POLICY`.

## Проверка
Тесты: core-решение (always/never/auto × warnings), worker (never bypass, auto gate, auto-апрув чистой нарезки, auto остаётся ручным при warnings). `check:workspaces` 0; worker-сьют **63 pass**; review-smoke 2 pass.

Часть EPIC #323. Back-compat: дефолт = `always` (поведение не меняется).

🤖 Generated with [Claude Code](https://claude.com/claude-code)