### PR TITLE
feat(mini-app): idea composer on the home screen (#330)

### DIFF
--- a/apps/telegram-mini-app/src/App.tsx
+++ b/apps/telegram-mini-app/src/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react"
 import { gateway } from "./gateway"
+import { IdeaComposer } from "./IdeaComposer"
 import { RenderJobs } from "./RenderJobs"
 import { SessionDetail } from "./SessionDetail"
 import { type SessionSummary, SessionRow } from "./SessionRow"
@@ -86,6 +87,11 @@ export function App() {
         <h1>Reels</h1>
         {me && <p className="muted">@{me.username ?? me.userId}</p>}
       </header>
+
+      <section>
+        <h2>New idea</h2>
+        <IdeaComposer onSubmitted={() => void refresh()} />
+      </section>
 
       <section>
         <h2>Your sessions</h2>

--- a/apps/telegram-mini-app/src/IdeaComposer.tsx
+++ b/apps/telegram-mini-app/src/IdeaComposer.tsx
@@ -1,0 +1,57 @@
+import { type FormEvent, useState } from "react"
+import { gateway } from "./gateway"
+import { haptics } from "./telegram"
+
+/**
+ * Idea composer (#330): submit a fresh idea to start a review session. Drives
+ * the gateway's `idea.submit`, which enqueues the bot's first-cut workflow; the
+ * new session surfaces in the list once it reaches preview-ready. Disabled
+ * server-side without a script generator → we surface that as a hint.
+ */
+export function IdeaComposer({ onSubmitted }: { onSubmitted: () => void }) {
+  const [text, setText] = useState("")
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [queued, setQueued] = useState(false)
+
+  async function onSubmit(event: FormEvent): Promise<void> {
+    event.preventDefault()
+    const trimmed = text.trim()
+    if (!trimmed || busy) return
+    setBusy(true)
+    setError(null)
+    setQueued(false)
+    try {
+      await gateway.idea.submit.mutate({ text: trimmed })
+      haptics.notify("success")
+      setText("")
+      setQueued(true)
+      onSubmitted()
+    } catch (cause) {
+      haptics.notify("error")
+      setError(cause instanceof Error ? cause.message : "Could not submit idea")
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <form className="idea" onSubmit={onSubmit}>
+      <textarea
+        value={text}
+        onChange={(event) => {
+          setText(event.target.value)
+          setQueued(false)
+        }}
+        placeholder="Describe your reel idea…"
+        rows={3}
+        disabled={busy}
+      />
+      <button type="submit" disabled={busy || text.trim().length === 0}>
+        {busy ? "Sending…" : "Send idea"}
+      </button>
+      {queued && <p className="muted">Idea queued — your first cut is being prepared.</p>}
+      {error && <p className="error">{error}</p>}
+    </form>
+  )
+}

--- a/apps/telegram-mini-app/src/styles.css
+++ b/apps/telegram-mini-app/src/styles.css
@@ -111,6 +111,40 @@ body {
   cursor: default;
 }
 
+.idea {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.idea textarea {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 10px 12px;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 10px;
+  font: inherit;
+  resize: vertical;
+  background: var(--tg-theme-bg-color, #ffffff);
+  color: var(--tg-theme-text-color, #000000);
+}
+
+.idea button {
+  align-self: flex-start;
+  padding: 8px 16px;
+  border: none;
+  border-radius: 8px;
+  background: var(--tg-theme-button-color, #2481cc);
+  color: var(--tg-theme-button-text-color, #ffffff);
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.idea button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
 .revise {
   display: flex;
   gap: 6px;


### PR DESCRIPTION
Восстанавливает фронтовую половину `idea.submit`: **squash #400 влил только backend**, а композер идеи остался за бортом main.

На home-экране Mini App: textarea + «Send idea» → `gateway.idea.submit` → обновление списка, с подсказкой «queued — first cut being prepared» и обработкой серверного **501** (script generator не настроен), haptic-отклик. Завершает `idea.submit` end-to-end.

## Проверка
`apps/telegram-mini-app check:type` 0; **vite build** ✓. Только app-изменения (biome игнорирует app).