### PR TITLE
fix: browser-preview crashes and extensive i18n localization gaps

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "frontend",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev", "--", "-p", "3100"],
+      "port": 3100
+    }
+  ]
+}

--- a/packages/core/src/services/montage-planner-registry.ts
+++ b/packages/core/src/services/montage-planner-registry.ts
@@ -21,8 +21,17 @@ function createMissingBinding(name: keyof MontagePlannerBindings): MontagePlanne
     construct() {
       throw new Error(`Montage planner binding "${name}" is not registered`)
     },
+    // Property reads must stay side-effect-free. The montage-planner barrel is
+    // imported eagerly (top-bar → montage-planner), so this proxy is exported and
+    // evaluated BEFORE MontagePlannerBindingsBootstrapProvider registers the real
+    // bindings. React Fast Refresh (and devtools/console introspection) probe every
+    // export at module-eval time — isLikelyComponentType reads `.prototype` /
+    // `.displayName` / `.$$typeof` — and a throwing getter there crashes the whole
+    // feature module and takes down the app in dev/browser-preview. Returning
+    // undefined keeps introspection harmless; genuine misuse still throws on
+    // apply/construct (calling or `new`-ing an unregistered binding).
     get() {
-      throw new Error(`Montage planner binding "${name}" is not registered`)
+      return undefined
     },
   })
 }

--- a/packages/ui/src/components/resizable.tsx
+++ b/packages/ui/src/components/resizable.tsx
@@ -27,8 +27,29 @@ function ResizablePanelGroup({ className, direction, orientation, autoSaveId, ..
   )
 }
 
-function ResizablePanel({ ...props }: React.ComponentProps<typeof ResizablePrimitive.Panel>) {
-  return <ResizablePrimitive.Panel data-slot="resizable-panel" {...props} />
+// v4 breaking change: number size props are pixels, not percentages (string "35%" is %).
+// Our layouts pass numbers expecting percentage semantics, so coerce here to keep callsites unchanged.
+function asPercent(v: unknown): unknown {
+  return typeof v === "number" ? `${v}%` : v
+}
+
+function ResizablePanel({
+  defaultSize,
+  minSize,
+  maxSize,
+  collapsedSize,
+  ...props
+}: React.ComponentProps<typeof ResizablePrimitive.Panel>) {
+  return (
+    <ResizablePrimitive.Panel
+      data-slot="resizable-panel"
+      defaultSize={asPercent(defaultSize) as any}
+      minSize={asPercent(minSize) as any}
+      maxSize={asPercent(maxSize) as any}
+      collapsedSize={asPercent(collapsedSize) as any}
+      {...props}
+    />
+  )
 }
 
 function ResizableHandle({

--- a/src/features/ai-director/hooks/use-ai-director-analysis-v2.ts
+++ b/src/features/ai-director/hooks/use-ai-director-analysis-v2.ts
@@ -212,7 +212,11 @@ function simulateAnalyzerProgress(file: FileProgress, stage: string, overallProg
 }
 
 export function useAIDirectorAnalysisV2(): UseAIDirectorAnalysisV2Return {
-  logger.infoSync("[useAIDirectorAnalysisV2] Инициализация хука для пакетного AI Director анализа")
+  // Лог инициализации в useEffect, чтобы не спамить на каждый рендер
+  // (хук используется в нескольких местах, каждый рендер каждой инстанции иначе пишет в консоль).
+  useEffect(() => {
+    logger.infoSync("[useAIDirectorAnalysisV2] Инициализация хука для пакетного AI Director анализа")
+  }, [])
 
   const [isAnalyzing, setIsAnalyzing] = useState(false)
   const [filesProgress, setFilesProgress] = useState<FileProgress[]>([])

--- a/src/features/ai-director/types/analysis-progress.ts
+++ b/src/features/ai-director/types/analysis-progress.ts
@@ -47,7 +47,10 @@ export type VlmModelType =
 export interface VlmModelInfo {
   id: VlmModelType
   displayName: string
+  /** Russian description */
   description: string
+  /** English description */
+  descriptionEn: string
   size: "small" | "medium" | "large" | "xlarge"
   /** Рекомендуемое количество фреймов */
   recommendedFrames: number
@@ -61,6 +64,7 @@ export const VLM_MODELS: Record<VlmModelType, VlmModelInfo> = {
     id: "moondream2",
     displayName: "Moondream 2",
     description: "Быстрая и легкая модель для базового анализа изображений",
+    descriptionEn: "Fast and lightweight model for basic image analysis",
     size: "small",
     recommendedFrames: 5,
     estimatedSpeed: 2.0,
@@ -69,6 +73,7 @@ export const VLM_MODELS: Record<VlmModelType, VlmModelInfo> = {
     id: "llava",
     displayName: "LLaVA 7B",
     description: "Универсальная модель для анализа видео и изображений",
+    descriptionEn: "Versatile model for video and image analysis",
     size: "medium",
     recommendedFrames: 4,
     estimatedSpeed: 1.0,
@@ -77,6 +82,7 @@ export const VLM_MODELS: Record<VlmModelType, VlmModelInfo> = {
     id: "llava:13b",
     displayName: "LLaVA 13B",
     description: "Улучшенная точность для детального анализа",
+    descriptionEn: "Improved accuracy for detailed analysis",
     size: "large",
     recommendedFrames: 3,
     estimatedSpeed: 0.5,
@@ -85,6 +91,7 @@ export const VLM_MODELS: Record<VlmModelType, VlmModelInfo> = {
     id: "llava:34b",
     displayName: "LLaVA 34B",
     description: "Максимальная точность, требует мощный GPU",
+    descriptionEn: "Maximum accuracy, requires a powerful GPU",
     size: "xlarge",
     recommendedFrames: 2,
     estimatedSpeed: 0.2,
@@ -93,6 +100,7 @@ export const VLM_MODELS: Record<VlmModelType, VlmModelInfo> = {
     id: "llama3.2-vision",
     displayName: "Llama 3.2 Vision",
     description: "Новейшая модель от Meta для vision-задач",
+    descriptionEn: "Meta's newest model for vision tasks",
     size: "medium",
     recommendedFrames: 4,
     estimatedSpeed: 1.2,
@@ -101,6 +109,7 @@ export const VLM_MODELS: Record<VlmModelType, VlmModelInfo> = {
     id: "llama3.2-vision:11b",
     displayName: "Llama 3.2 Vision 11B",
     description: "Баланс скорости и качества",
+    descriptionEn: "Balance of speed and quality",
     size: "large",
     recommendedFrames: 3,
     estimatedSpeed: 0.6,
@@ -109,6 +118,7 @@ export const VLM_MODELS: Record<VlmModelType, VlmModelInfo> = {
     id: "llama3.2-vision:90b",
     displayName: "Llama 3.2 Vision 90B",
     description: "Максимальное качество, требует много VRAM",
+    descriptionEn: "Maximum quality, requires a lot of VRAM",
     size: "xlarge",
     recommendedFrames: 2,
     estimatedSpeed: 0.1,
@@ -131,7 +141,10 @@ export interface AnalyzerMetadata {
   type: AnalyzerType
   displayName: string
   category: "video" | "audio" | "content"
+  /** Russian description */
   description: string
+  /** English description */
+  descriptionEn: string
   estimatedDuration: number // в секундах
   icon?: string
 }
@@ -341,6 +354,7 @@ export const ANALYZER_METADATA: Record<AnalyzerType, AnalyzerMetadata> = {
     displayName: "Scene Detection",
     category: "video",
     description: "Определение сцен и переходов",
+    descriptionEn: "Scene and transition detection",
     estimatedDuration: 30,
   },
   object_detection: {
@@ -348,6 +362,7 @@ export const ANALYZER_METADATA: Record<AnalyzerType, AnalyzerMetadata> = {
     displayName: "Object Detection",
     category: "video",
     description: "Распознавание объектов (YOLO)",
+    descriptionEn: "Object recognition (YOLO)",
     estimatedDuration: 60,
   },
   face_detection: {
@@ -355,6 +370,7 @@ export const ANALYZER_METADATA: Record<AnalyzerType, AnalyzerMetadata> = {
     displayName: "Face Detection",
     category: "video",
     description: "Детекция лиц",
+    descriptionEn: "Face detection",
     estimatedDuration: 45,
   },
   motion_analysis: {
@@ -362,6 +378,7 @@ export const ANALYZER_METADATA: Record<AnalyzerType, AnalyzerMetadata> = {
     displayName: "Motion Analysis",
     category: "video",
     description: "Анализ движения",
+    descriptionEn: "Motion analysis",
     estimatedDuration: 40,
   },
   composition_analysis: {
@@ -369,6 +386,7 @@ export const ANALYZER_METADATA: Record<AnalyzerType, AnalyzerMetadata> = {
     displayName: "Composition Analysis",
     category: "video",
     description: "Оценка композиции кадра",
+    descriptionEn: "Frame composition assessment",
     estimatedDuration: 35,
   },
   // Audio
@@ -377,6 +395,7 @@ export const ANALYZER_METADATA: Record<AnalyzerType, AnalyzerMetadata> = {
     displayName: "Audio Quality",
     category: "audio",
     description: "Оценка качества звука",
+    descriptionEn: "Audio quality assessment",
     estimatedDuration: 20,
   },
   speech_recognition: {
@@ -384,6 +403,7 @@ export const ANALYZER_METADATA: Record<AnalyzerType, AnalyzerMetadata> = {
     displayName: "Speech Recognition",
     category: "audio",
     description: "Распознавание речи (Whisper)",
+    descriptionEn: "Speech recognition (Whisper)",
     estimatedDuration: 90,
   },
   music_detection: {
@@ -391,6 +411,7 @@ export const ANALYZER_METADATA: Record<AnalyzerType, AnalyzerMetadata> = {
     displayName: "Music Detection",
     category: "audio",
     description: "Детекция музыки",
+    descriptionEn: "Music detection",
     estimatedDuration: 25,
   },
   sound_events: {
@@ -398,6 +419,7 @@ export const ANALYZER_METADATA: Record<AnalyzerType, AnalyzerMetadata> = {
     displayName: "Sound Events",
     category: "audio",
     description: "Определение звуковых событий",
+    descriptionEn: "Sound event detection",
     estimatedDuration: 30,
   },
   silence_detection: {
@@ -405,6 +427,7 @@ export const ANALYZER_METADATA: Record<AnalyzerType, AnalyzerMetadata> = {
     displayName: "Silence Detection",
     category: "audio",
     description: "Детекция тишины",
+    descriptionEn: "Silence detection",
     estimatedDuration: 15,
   },
   speech_detection: {
@@ -412,6 +435,7 @@ export const ANALYZER_METADATA: Record<AnalyzerType, AnalyzerMetadata> = {
     displayName: "Speech Detection",
     category: "audio",
     description: "Определение речевых сегментов",
+    descriptionEn: "Speech segment detection",
     estimatedDuration: 30,
   },
   // Content
@@ -420,6 +444,7 @@ export const ANALYZER_METADATA: Record<AnalyzerType, AnalyzerMetadata> = {
     displayName: "Person Recognition",
     category: "video",
     description: "Распознавание персон",
+    descriptionEn: "Person recognition",
     estimatedDuration: 55,
   },
   visual_quality: {
@@ -427,6 +452,7 @@ export const ANALYZER_METADATA: Record<AnalyzerType, AnalyzerMetadata> = {
     displayName: "Visual Quality",
     category: "video",
     description: "Оценка визуального качества",
+    descriptionEn: "Visual quality assessment",
     estimatedDuration: 30,
   },
   mood_analysis: {
@@ -434,6 +460,7 @@ export const ANALYZER_METADATA: Record<AnalyzerType, AnalyzerMetadata> = {
     displayName: "Mood Analysis",
     category: "content",
     description: "Определение настроения",
+    descriptionEn: "Mood detection",
     estimatedDuration: 50,
   },
   content_classification: {
@@ -441,6 +468,7 @@ export const ANALYZER_METADATA: Record<AnalyzerType, AnalyzerMetadata> = {
     displayName: "Content Classification",
     category: "content",
     description: "Классификация контента",
+    descriptionEn: "Content classification",
     estimatedDuration: 40,
   },
   quality_assessment: {
@@ -448,6 +476,7 @@ export const ANALYZER_METADATA: Record<AnalyzerType, AnalyzerMetadata> = {
     displayName: "Quality Assessment",
     category: "content",
     description: "Общая оценка качества",
+    descriptionEn: "Overall quality assessment",
     estimatedDuration: 35,
   },
   moment_detection: {
@@ -455,6 +484,7 @@ export const ANALYZER_METADATA: Record<AnalyzerType, AnalyzerMetadata> = {
     displayName: "Moment Detection",
     category: "content",
     description: "Поиск ключевых моментов",
+    descriptionEn: "Key moment detection",
     estimatedDuration: 45,
   },
   vlm_analysis: {
@@ -462,6 +492,7 @@ export const ANALYZER_METADATA: Record<AnalyzerType, AnalyzerMetadata> = {
     displayName: "VLM Analysis",
     category: "content",
     description: "Vision Language Model (LLaVA/GPT-4V)",
+    descriptionEn: "Vision Language Model (LLaVA/GPT-4V)",
     estimatedDuration: 120,
   },
 }

--- a/src/features/ai-director/types/analyzer-presets.ts
+++ b/src/features/ai-director/types/analyzer-presets.ts
@@ -70,7 +70,10 @@ export interface AnalyzerCategory {
   id: string
   name: string
   nameRu: string
+  /** Russian description */
   description: string
+  /** English description */
+  descriptionEn: string
   analyzers: AnalyzerType[]
   availableFor: MediaAnalysisType[]
   icon?: string
@@ -82,6 +85,7 @@ export const ANALYZER_CATEGORIES: AnalyzerCategory[] = [
     name: "Object Detection",
     nameRu: "Детекция объектов",
     description: "Распознавание лиц, объектов, людей",
+    descriptionEn: "Face, object, and person recognition",
     analyzers: ["face_detection", "object_detection", "person_recognition"],
     availableFor: ["video", "image"],
     icon: "scan",
@@ -91,6 +95,7 @@ export const ANALYZER_CATEGORIES: AnalyzerCategory[] = [
     name: "Scene Analysis",
     nameRu: "Анализ сцен",
     description: "Детекция сцен, переходов, движения",
+    descriptionEn: "Scene, transition, and motion detection",
     analyzers: ["scene_detection", "motion_analysis"],
     availableFor: ["video"],
     icon: "film",
@@ -100,6 +105,7 @@ export const ANALYZER_CATEGORIES: AnalyzerCategory[] = [
     name: "Audio Analysis",
     nameRu: "Аудио анализ",
     description: "Речь, музыка, качество звука",
+    descriptionEn: "Speech, music, audio quality",
     analyzers: [
       "audio_quality",
       "speech_recognition",
@@ -116,6 +122,7 @@ export const ANALYZER_CATEGORIES: AnalyzerCategory[] = [
     name: "Quality Assessment",
     nameRu: "Оценка качества",
     description: "Качество изображения, композиция",
+    descriptionEn: "Image quality, composition",
     analyzers: ["quality_assessment", "visual_quality", "composition_analysis"],
     availableFor: ["video", "audio", "image"],
     icon: "sparkles",
@@ -125,6 +132,7 @@ export const ANALYZER_CATEGORIES: AnalyzerCategory[] = [
     name: "AI Content Analysis",
     nameRu: "AI анализ контента",
     description: "Настроение, классификация, VLM",
+    descriptionEn: "Mood, classification, VLM",
     analyzers: ["mood_analysis", "content_classification", "moment_detection", "vlm_analysis"],
     availableFor: ["video", "audio", "image"],
     icon: "brain",

--- a/src/features/browser/components/no-files.tsx
+++ b/src/features/browser/components/no-files.tsx
@@ -12,6 +12,7 @@ import { Card, CardContent } from "@timeline-studio/ui/components/card"
 import { FileText, Filter, FolderOpen, Music, Palette, Sparkles, Upload, Video } from "lucide-react"
 import type React from "react"
 import { useEffect, useState } from "react"
+import { useTranslation } from "react-i18next"
 import { replaceHomeWithTilde } from "@/lib/path-utils"
 import { createLogger } from "@/lib/tauri-logger"
 
@@ -33,95 +34,24 @@ interface NoFilesProps {
   className?: string
 }
 
-interface MediaTypeConfig {
-  title: string
-  description: string
-  icon: React.ComponentType<{ className?: string }>
-  folders: string[]
-  formats: string[]
-  importText: string
-  folderText: string
-}
-
-// Базовая конфигурация без путей (пути будут загружены динамически)
-const BASE_MEDIA_CONFIGS: Record<MediaType, Omit<MediaTypeConfig, "folders">> = {
-  media: {
-    title: "Медиафайлы не найдены",
-    description: "Добавьте видео, аудио или фото файлы для работы с проектом",
-    icon: Video,
-    formats: [
-      "Видео: MP4, MOV, AVI, MKV, WEBM, INSV (360°)",
-      "Аудио: MP3, WAV, AAC, ALAC, OGG, FLAC",
-      "Фото: JPG, PNG, GIF, WEBP, TIFF, BMP",
-    ],
-
-    importText: "Импортировать медиафайлы",
-    folderText: "Или поместите файлы в папку",
-  },
-  music: {
-    title: "Музыкальные файлы не найдены",
-    description: "Добавьте музыку и звуковые эффекты для озвучивания проекта",
-    icon: Music,
-    formats: ["MP3, WAV, AAC, ALAC, OGG, FLAC"],
-    importText: "Импортировать музыку",
-    folderText: "Или поместите музыку в папку",
-  },
-  effects: {
-    title: "Эффекты не найдены",
-    description: "Добавьте видеоэффекты для улучшения ваших клипов",
-    icon: Sparkles,
-    formats: ["JSON файлы с описанием эффектов"],
-    importText: "Импортировать эффекты",
-    folderText: "Или поместите эффекты в папку",
-  },
-  filters: {
-    title: "Фильтры не найдены",
-    description: "Добавьте цветовые фильтры и коррекцию для видео",
-    icon: Filter,
-    formats: ["JSON файлы с настройками фильтров"],
-    importText: "Импортировать фильтры",
-    folderText: "Или поместите фильтры в папку",
-  },
-  transitions: {
-    title: "Переходы не найдены",
-    description: "Добавьте переходы между клипами для плавного монтажа",
-    icon: Palette,
-    formats: ["JSON файлы с анимациями переходов"],
-    importText: "Импортировать переходы",
-    folderText: "Или поместите переходы в папку",
-  },
-  templates: {
-    title: "Шаблоны не найдены",
-    description: "Добавьте готовые шаблоны для быстрого создания проектов",
-    icon: FileText,
-    formats: ["JSON файлы с настройками шаблонов"],
-    importText: "Импортировать шаблоны",
-    folderText: "Или поместите шаблоны в папку",
-  },
-  style_templates: {
-    title: "Стилестические шаблоны не найдены",
-    description: "Добавьте стилизованные шаблоны с готовым дизайном",
-    icon: Palette,
-    formats: ["JSON файлы со стилями и настройками"],
-    importText: "Импортировать стилестические шаблоны",
-    folderText: "Или поместите шаблоны в папку",
-  },
-  subtitles: {
-    title: "Субтитры не найдены",
-    description: "Добавьте файлы субтитров или создайте новые",
-    icon: FileText,
-    formats: ["SRT, VTT, ASS, SSA файлы субтитров"],
-    importText: "Импортировать субтитры",
-    folderText: "Или поместите субтитры в папку",
-  },
+const MEDIA_TYPE_ICONS: Record<MediaType, React.ComponentType<{ className?: string }>> = {
+  media: Video,
+  music: Music,
+  effects: Sparkles,
+  filters: Filter,
+  transitions: Palette,
+  templates: FileText,
+  style_templates: Palette,
+  subtitles: FileText,
 }
 
 export function NoFiles({ type, onImport, className }: NoFilesProps) {
+  const { t } = useTranslation()
   const [folders, setFolders] = useState<string[]>([])
   const [isLoadingFolders, setIsLoadingFolders] = useState(true)
 
-  const baseConfig = BASE_MEDIA_CONFIGS[type]
-  const IconComponent = baseConfig.icon
+  const IconComponent = MEDIA_TYPE_ICONS[type]
+  const formats = t(`browser.emptyState.${type}.formats`, { returnObjects: true }) as string[]
 
   // Загружаем пути из AppDirectories при монтировании
   useEffect(() => {
@@ -175,10 +105,10 @@ export function NoFiles({ type, onImport, className }: NoFilesProps) {
             {/* Заголовок и описание */}
             <div className="space-y-2" data-oid="1hj7xwy">
               <h3 className="font-semibold text-foreground" data-oid="67_6:x5">
-                {baseConfig.title}
+                {t(`browser.emptyState.${type}.title`)}
               </h3>
               <p className="text-sm text-muted-foreground" data-oid="5vfg_fz">
-                {baseConfig.description}
+                {t(`browser.emptyState.${type}.description`)}
               </p>
             </div>
 
@@ -186,7 +116,7 @@ export function NoFiles({ type, onImport, className }: NoFilesProps) {
             {onImport && (
               <Button onClick={onImport} className="w-full" data-oid="qrzx8_z">
                 <Upload className="h-4 w-4 mr-2" data-oid="ope-7u-" />
-                {baseConfig.importText}
+                {t(`browser.emptyState.${type}.importText`)}
               </Button>
             )}
 
@@ -197,7 +127,7 @@ export function NoFiles({ type, onImport, className }: NoFilesProps) {
                   className="flex items-center justify-center gap-2 text-sm text-muted-foreground"
                   data-oid=".aiitzw"
                 >
-                  <span data-oid="xdenvsv">{baseConfig.folderText}</span>
+                  <span data-oid="xdenvsv">{t(`browser.emptyState.${type}.folderText`)}</span>
                 </div>
 
                 {folders.map((folder, index) => (
@@ -214,10 +144,10 @@ export function NoFiles({ type, onImport, className }: NoFilesProps) {
             {/* Поддерживаемые форматы */}
             <div className="space-y-2 pt-2" data-oid="bkse:0v">
               <p className="text-xs text-muted-foreground" data-oid="0:fjlpb">
-                Поддерживаемые форматы:
+                {t("browser.emptyState.formatsLabel")}
               </p>
               <div className="flex flex-wrap gap-1 justify-center" data-oid=".7nl-ym">
-                {baseConfig.formats.map((format, index) => (
+                {formats.map((format, index) => (
                   <Badge key={index} variant="outline" className="text-xs" data-oid="9:9aeu5">
                     {format}
                   </Badge>

--- a/src/features/effects/components/effect-detail-modal.tsx
+++ b/src/features/effects/components/effect-detail-modal.tsx
@@ -167,7 +167,7 @@ export function EffectDetailModal() {
               </TabsTrigger>
               <TabsTrigger value="comparison" data-oid="a99tqcp">
                 <SplitSquareHorizontal size={16} className="mr-2" data-oid="db::p2v" />
-                {t("effects.comparison", "Сравнение")}
+                {t("effects.comparisonTab", "Сравнение")}
               </TabsTrigger>
             </TabsList>
 

--- a/src/features/export/components/section-export-tab.tsx
+++ b/src/features/export/components/section-export-tab.tsx
@@ -304,7 +304,7 @@ export function SectionExportTab({ defaultSettings, onExport, onPreviewSection }
                     {t("export.sections.preview")}
                   </div>
                   <div className="text-xs text-muted-foreground" data-oid="hr-hkhm">
-                    720p, Low bitrate, Fast encoding
+                    {t("export.sections.previewDescription")}
                   </div>
                 </div>
               </SelectItem>
@@ -314,7 +314,7 @@ export function SectionExportTab({ defaultSettings, onExport, onPreviewSection }
                     {t("export.sections.draft")}
                   </div>
                   <div className="text-xs text-muted-foreground" data-oid="xolilsz">
-                    1080p, Medium quality
+                    {t("export.sections.draftDescription")}
                   </div>
                 </div>
               </SelectItem>
@@ -324,7 +324,7 @@ export function SectionExportTab({ defaultSettings, onExport, onPreviewSection }
                     {t("export.sections.final")}
                   </div>
                   <div className="text-xs text-muted-foreground" data-oid="vslg4qy">
-                    Full quality, project settings
+                    {t("export.sections.finalDescription")}
                   </div>
                 </div>
               </SelectItem>

--- a/src/features/export/components/social-export-tab.tsx
+++ b/src/features/export/components/social-export-tab.tsx
@@ -230,7 +230,7 @@ export function SocialExportTab({
               </CardHeader>
               <CardContent className="space-y-3" data-oid="z83pv_t">
                 <CardDescription data-oid="d_u8lps">
-                  Max: {network.maxResolution} • {network.maxFps}fps
+                  {t("dialogs.export.social.max")}: {network.maxResolution} • {network.maxFps}fps
                 </CardDescription>
 
                 {isSelected && (
@@ -283,7 +283,7 @@ export function SocialExportTab({
             <CardTitle className="flex items-center justify-between" data-oid="q6o6jg4">
               <div className="flex items-center gap-3" data-oid="736ujcr">
                 {getSocialIcon(selectedNetwork)}
-                {selectedNetworkData.name} Limits & Validation
+                {selectedNetworkData.name} {t("dialogs.export.social.limitsAndValidation")}
               </div>
               <div className="flex items-center gap-2" data-oid="-7-sycr">
                 {validation.valid ? (
@@ -292,7 +292,7 @@ export function SocialExportTab({
                   <AlertCircle className="h-5 w-5 text-red-500" data-oid="-ld3:we" />
                 )}
                 <Badge variant={validation.valid ? "default" : "destructive"} data-oid="k8c190b">
-                  {validation.valid ? "Valid" : "Invalid"}
+                  {validation.valid ? t("dialogs.export.social.valid") : t("dialogs.export.social.invalid")}
                 </Badge>
               </div>
             </CardTitle>
@@ -303,7 +303,7 @@ export function SocialExportTab({
               <div className="grid grid-cols-2 md:grid-cols-4 gap-4 p-4 bg-muted/50 rounded-lg" data-oid="ni.in41">
                 <div className="text-center" data-oid="j4o1qtn">
                   <div className="text-sm font-medium" data-oid="drujmjy">
-                    Max File Size
+                    {t("dialogs.export.social.maxFileSize")}
                   </div>
                   <div className="text-xs text-muted-foreground" data-oid="3.u5rb3">
                     {(networkLimits.maxFileSize / (1024 * 1024 * 1024)).toFixed(1)}
@@ -312,7 +312,7 @@ export function SocialExportTab({
                 </div>
                 <div className="text-center" data-oid="01n4bmu">
                   <div className="text-sm font-medium" data-oid="9hv_ro6">
-                    Max Duration
+                    {t("dialogs.export.social.maxDuration")}
                   </div>
                   <div className="text-xs text-muted-foreground" data-oid="q3m-1pk">
                     {Math.round(networkLimits.maxDuration / 3600)}h
@@ -320,7 +320,7 @@ export function SocialExportTab({
                 </div>
                 <div className="text-center" data-oid="8g6l0f1">
                   <div className="text-sm font-medium" data-oid="-..yea7">
-                    Max Resolution
+                    {t("dialogs.export.social.maxResolution")}
                   </div>
                   <div className="text-xs text-muted-foreground" data-oid="d11hl3a">
                     {networkLimits.maxResolution}
@@ -328,7 +328,7 @@ export function SocialExportTab({
                 </div>
                 <div className="text-center" data-oid="sfiiieg">
                   <div className="text-sm font-medium" data-oid="79i9agf">
-                    Title Limit
+                    {t("dialogs.export.social.titleLimit")}
                   </div>
                   <div className="text-xs text-muted-foreground" data-oid="kgt.c6u">
                     {networkLimits.titleMaxLength} chars
@@ -376,7 +376,7 @@ export function SocialExportTab({
                 <AlertDescription data-oid="90r3oc4">
                   <div className="space-y-1" data-oid="w700zmc">
                     <div className="font-medium" data-oid="5d2_u2d">
-                      Optimization suggestions:
+                      {t("dialogs.export.social.optimizationSuggestions")}
                     </div>
                     {validation.suggestions.map((suggestion, index) => (
                       <div key={index} className="text-sm" data-oid="vx.r7-_">
@@ -547,22 +547,22 @@ export function SocialExportTab({
                   </SelectTrigger>
                   <SelectContent data-oid="cpm:5at">
                     <SelectItem value="22" data-oid="qc4w0:x">
-                      People & Blogs
+                      {t("dialogs.export.social.categories.peopleAndBlogs")}
                     </SelectItem>
                     <SelectItem value="24" data-oid="r40lhup">
-                      Entertainment
+                      {t("dialogs.export.social.categories.entertainment")}
                     </SelectItem>
                     <SelectItem value="25" data-oid="hoo55q3">
-                      News & Politics
+                      {t("dialogs.export.social.categories.newsAndPolitics")}
                     </SelectItem>
                     <SelectItem value="26" data-oid=".-gy2:n">
-                      Howto & Style
+                      {t("dialogs.export.social.categories.howtoAndStyle")}
                     </SelectItem>
                     <SelectItem value="27" data-oid="jccck5a">
-                      Education
+                      {t("dialogs.export.social.categories.education")}
                     </SelectItem>
                     <SelectItem value="28" data-oid="k58zpws">
-                      Science & Technology
+                      {t("dialogs.export.social.categories.scienceAndTechnology")}
                     </SelectItem>
                   </SelectContent>
                 </Select>

--- a/src/features/timeline/components/analysis-view.tsx
+++ b/src/features/timeline/components/analysis-view.tsx
@@ -131,11 +131,11 @@ export function AnalysisView() {
               <>
                 <div className="border-b px-4 py-3 flex items-center justify-between bg-muted/30" data-oid="yuzja8.">
                   <div className="text-sm font-medium" data-oid="aoexhj7">
-                    Результаты анализа
+                    {t("timeline.analysisPanel.results")}
                   </div>
                   <Button variant="ghost" size="sm" onClick={handleNewAnalysis} data-oid="l:h8qzz">
                     <Plus className="h-4 w-4 mr-2" data-oid="77.s3.n" />
-                    Новый анализ
+                    {t("timeline.analysisPanel.newAnalysis")}
                   </Button>
                 </div>
                 <div className="flex-1 overflow-auto" data-oid="lol12ho">
@@ -147,7 +147,7 @@ export function AnalysisView() {
               <>
                 <div className="border-b px-4 py-3 bg-muted/30" data-oid="hk3v51i">
                   <div className="text-sm font-medium" data-oid="oy-qea_">
-                    Настройка нового анализа
+                    {t("timeline.analysisPanel.newAnalysisSettings")}
                   </div>
                 </div>
                 <div className="flex-1 overflow-auto" data-oid="34pfskl">

--- a/src/features/timeline/components/analysis/analysis-settings-panel.tsx
+++ b/src/features/timeline/components/analysis/analysis-settings-panel.tsx
@@ -11,6 +11,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@timeline-studio/ui/components/tabs"
 import { AudioLines, Film, ImageIcon, Loader2, Play, Sparkles, Zap } from "lucide-react"
 import { useCallback, useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
 import { useAIDirectorAnalysisV2 } from "@/features/ai-director/hooks/use-ai-director-analysis-v2"
 import {
   ANALYZER_METADATA,
@@ -42,6 +43,13 @@ const MEDIA_TYPE_NAMES = {
   image: "Изображения",
 }
 
+/** English names for media types */
+const MEDIA_TYPE_NAMES_EN = {
+  video: "Video",
+  audio: "Audio",
+  image: "Images",
+}
+
 /** Иконки и названия уровней анализа */
 const ANALYSIS_LEVEL_CONFIG = {
   quick: { icon: Zap, name: "Быстрый", nameEn: "Quick" },
@@ -69,6 +77,8 @@ interface FileWithMediaType {
 }
 
 export function AnalysisSettingsPanel() {
+  const { i18n } = useTranslation()
+  const isRu = i18n.language === "ru"
   const { mediaFiles } = useMediaFiles()
   const { startBatchAnalysis, isAnalyzing } = useAIDirectorAnalysisV2()
 
@@ -294,28 +304,28 @@ export function AnalysisSettingsPanel() {
         <div className="flex items-center justify-between" data-oid="ifqc9gh">
           <div data-oid="rdld9ty">
             <CardTitle className="text-base" data-oid="i0kw3ku">
-              Настройки анализа
+              {isRu ? "Настройки анализа" : "Analysis settings"}
             </CardTitle>
             <CardDescription className="text-xs" data-oid="825b0ma">
-              Выберите файлы и настройте параметры анализа
+              {isRu ? "Выберите файлы и настройте параметры анализа" : "Select files and configure analysis parameters"}
             </CardDescription>
           </div>
           <div className="flex items-center gap-3" data-oid="pwk9d8i">
             {estimatedTime && (
               <span className="text-xs text-muted-foreground" data-oid="n8k.pxh">
-                Примерно: {estimatedTime}
+                {isRu ? "Примерно" : "About"}: {estimatedTime}
               </span>
             )}
             <Button onClick={handleStartAnalysis} disabled={!canStartAnalysis} className="gap-2" data-oid="tz-7otl">
               {isAnalyzing ? (
                 <>
                   <Loader2 className="h-4 w-4 animate-spin" data-oid="au1hvn5" />
-                  Анализируем...
+                  {isRu ? "Анализируем..." : "Analyzing..."}
                 </>
               ) : (
                 <>
                   <Play className="h-4 w-4" data-oid="fi:510k" />
-                  Начать анализ
+                  {isRu ? "Начать анализ" : "Start analysis"}
                 </>
               )}
             </Button>
@@ -326,24 +336,24 @@ export function AnalysisSettingsPanel() {
         {selectedFiles.size > 0 && (
           <div className="flex items-center gap-2 mt-2" data-oid="y-pagki">
             <span className="text-xs text-muted-foreground" data-oid="yd8hn-.">
-              Выбрано:
+              {isRu ? "Выбрано:" : "Selected:"}
             </span>
             {selectionStats.video > 0 && (
               <Badge variant="secondary" className="gap-1" data-oid="zmiowi6">
                 <Film className="h-3 w-3" data-oid="ii.zju1" />
-                {selectionStats.video} видео
+                {selectionStats.video} {isRu ? "видео" : "video"}
               </Badge>
             )}
             {selectionStats.audio > 0 && (
               <Badge variant="secondary" className="gap-1" data-oid="qzqqcrk">
                 <AudioLines className="h-3 w-3" data-oid="ijqggp1" />
-                {selectionStats.audio} аудио
+                {selectionStats.audio} {isRu ? "аудио" : "audio"}
               </Badge>
             )}
             {selectionStats.image > 0 && (
               <Badge variant="secondary" className="gap-1" data-oid="erg9:44">
                 <ImageIcon className="h-3 w-3" data-oid="tz95qa:" />
-                {selectionStats.image} изображений
+                {selectionStats.image} {isRu ? "изображений" : "images"}
               </Badge>
             )}
           </div>
@@ -354,13 +364,13 @@ export function AnalysisSettingsPanel() {
         <Tabs defaultValue="files" className="w-full" data-oid="b:5b.nj">
           <TabsList className="grid w-full grid-cols-3" data-oid="5:xq5r.">
             <TabsTrigger value="files" data-oid="exg5mon">
-              Файлы ({selectedFiles.size}/{analyzableFiles.length})
+              {isRu ? "Файлы" : "Files"} ({selectedFiles.size}/{analyzableFiles.length})
             </TabsTrigger>
             <TabsTrigger value="analyzers" data-oid="eu:dp5f">
-              Анализаторы ({selectedAnalyzers.size})
+              {isRu ? "Анализаторы" : "Analyzers"} ({selectedAnalyzers.size})
             </TabsTrigger>
             <TabsTrigger value="settings" data-oid="98zkr.j">
-              Настройки
+              {isRu ? "Настройки" : "Settings"}
             </TabsTrigger>
           </TabsList>
 
@@ -368,15 +378,21 @@ export function AnalysisSettingsPanel() {
           <TabsContent value="files" className="space-y-3" data-oid="ppwo9kj">
             <div className="flex items-center justify-between" data-oid="a0bqmb6">
               <p className="text-sm text-muted-foreground" data-oid="oc_x7s6">
-                {analyzableFiles.length === 0 ? "Нет доступных файлов для анализа" : "Выберите файлы для анализа"}
+                {analyzableFiles.length === 0
+                  ? isRu
+                    ? "Нет доступных файлов для анализа"
+                    : "No files available for analysis"
+                  : isRu
+                    ? "Выберите файлы для анализа"
+                    : "Select files to analyze"}
               </p>
               {analyzableFiles.length > 0 && (
                 <div className="flex gap-2" data-oid="x9w6rqg">
                   <Button variant="outline" size="sm" onClick={handleSelectAll} data-oid="7hembgk">
-                    Выбрать все
+                    {isRu ? "Выбрать все" : "Select all"}
                   </Button>
                   <Button variant="outline" size="sm" onClick={handleClearAll} data-oid="wtmoi:v">
-                    Очистить
+                    {isRu ? "Очистить" : "Clear"}
                   </Button>
                 </div>
               )}
@@ -397,7 +413,7 @@ export function AnalysisSettingsPanel() {
                         <div className="flex items-center gap-2" data-oid="xkj8s_g">
                           <Icon className="h-4 w-4 text-muted-foreground" data-oid="f6zwuwa" />
                           <span className="text-sm font-medium" data-oid="q6j3_8p">
-                            {MEDIA_TYPE_NAMES[mediaType]}
+                            {isRu ? MEDIA_TYPE_NAMES[mediaType] : MEDIA_TYPE_NAMES_EN[mediaType]}
                           </span>
                           <span className="text-xs text-muted-foreground" data-oid="pzej058">
                             ({selectedCount}/{files.length})
@@ -411,7 +427,7 @@ export function AnalysisSettingsPanel() {
                             onClick={() => handleSelectAllOfType(mediaType)}
                             data-oid="x1lcd:5"
                           >
-                            Все
+                            {isRu ? "Все" : "All"}
                           </Button>
                           <Button
                             variant="ghost"
@@ -420,7 +436,7 @@ export function AnalysisSettingsPanel() {
                             onClick={() => handleClearType(mediaType)}
                             data-oid="4itlryk"
                           >
-                            Снять
+                            {isRu ? "Снять" : "None"}
                           </Button>
                         </div>
                       </div>
@@ -451,7 +467,7 @@ export function AnalysisSettingsPanel() {
 
                 {analyzableFiles.length === 0 && (
                   <p className="text-sm text-muted-foreground text-center py-4" data-oid="gm.hzs4">
-                    Добавьте медиафайлы в проект для анализа
+                    {isRu ? "Добавьте медиафайлы в проект для анализа" : "Add media files to the project to analyze"}
                   </p>
                 )}
               </div>
@@ -463,7 +479,7 @@ export function AnalysisSettingsPanel() {
             {/* Уровень анализа */}
             <div className="flex items-center gap-4 pb-2 border-b" data-oid="m3iz8oo">
               <span className="text-sm font-medium" data-oid="v8dd5zd">
-                Уровень:
+                {isRu ? "Уровень:" : "Level:"}
               </span>
               <div className="flex gap-2" data-oid="xo4i_cs">
                 {(["quick", "balanced", "comprehensive"] as AnalysisLevel[]).map((level) => {
@@ -479,13 +495,13 @@ export function AnalysisSettingsPanel() {
                       data-oid="7oav6zs"
                     >
                       {LevelIcon && <LevelIcon className="h-3 w-3" data-oid="yah..r." />}
-                      {config.name}
+                      {isRu ? config.name : config.nameEn}
                     </Button>
                   )
                 })}
                 {analysisLevel === "custom" && (
                   <Badge variant="secondary" data-oid="fq4x31m">
-                    Кастомный
+                    {isRu ? ANALYSIS_LEVEL_CONFIG.custom.name : ANALYSIS_LEVEL_CONFIG.custom.nameEn}
                   </Badge>
                 )}
               </div>
@@ -527,7 +543,7 @@ export function AnalysisSettingsPanel() {
                           className="text-sm font-medium cursor-pointer"
                           data-oid=":q2idz."
                         >
-                          {category.nameRu}
+                          {isRu ? category.nameRu : category.name}
                         </Label>
                         <span className="text-xs text-muted-foreground" data-oid="02knopj">
                           ({categorySelected}/{availableAnalyzers.length})
@@ -557,7 +573,7 @@ export function AnalysisSettingsPanel() {
                                   {metadata.displayName}
                                 </Label>
                                 <p className="text-xs text-muted-foreground" data-oid="t9_fbry">
-                                  {metadata.description}
+                                  {isRu ? metadata.description : metadata.descriptionEn}
                                 </p>
                               </div>
                             </div>
@@ -577,11 +593,11 @@ export function AnalysisSettingsPanel() {
             {selectedAnalyzers.has("vlm_analysis") && (
               <div className="space-y-2" data-oid="e:9cxie">
                 <Label className="text-sm font-medium" data-oid="u7kfbtd">
-                  VLM модель
+                  {isRu ? "VLM модель" : "VLM model"}
                 </Label>
                 <Select value={vlmModel} onValueChange={(v) => setVlmModel(v as VlmModelType)} data-oid="18i-80j">
                   <SelectTrigger className="w-full" data-oid="rec00a:">
-                    <SelectValue placeholder="Выберите модель" data-oid="4z49rff" />
+                    <SelectValue placeholder={isRu ? "Выберите модель" : "Select a model"} data-oid="4z49rff" />
                   </SelectTrigger>
                   <SelectContent data-oid="stnfwgt">
                     {ALL_VLM_MODELS.map((modelId) => {
@@ -591,7 +607,7 @@ export function AnalysisSettingsPanel() {
                           <div className="flex flex-col" data-oid="1pr2a8k">
                             <span data-oid="rj_2-2f">{model.displayName}</span>
                             <span className="text-xs text-muted-foreground" data-oid="uk4wwq9">
-                              {model.description}
+                              {isRu ? model.description : model.descriptionEn}
                             </span>
                           </div>
                         </SelectItem>
@@ -600,7 +616,9 @@ export function AnalysisSettingsPanel() {
                   </SelectContent>
                 </Select>
                 <p className="text-xs text-muted-foreground" data-oid="b:piop.">
-                  Vision Language Model для глубокого анализа контента
+                  {isRu
+                    ? "Vision Language Model для глубокого анализа контента"
+                    : "Vision Language Model for deep content analysis"}
                 </p>
               </div>
             )}
@@ -609,7 +627,7 @@ export function AnalysisSettingsPanel() {
             {selectedMediaTypes.size > 0 && (
               <div className="space-y-2" data-oid="ntboslf">
                 <Label className="text-sm font-medium" data-oid="vft_2ju">
-                  Рекомендуемые пресеты
+                  {isRu ? "Рекомендуемые пресеты" : "Recommended presets"}
                 </Label>
                 <div className="grid gap-2" data-oid="4v00_t_">
                   {[...selectedMediaTypes].slice(0, 1).map((mediaType) => {
@@ -630,10 +648,11 @@ export function AnalysisSettingsPanel() {
                         <div className="flex items-center justify-between" data-oid="24tdtj5">
                           <div data-oid="52v6tv3">
                             <p className="text-sm font-medium" data-oid="c6mib6e">
-                              {ANALYSIS_LEVEL_CONFIG[preset.level].name} ({MEDIA_TYPE_NAMES[mediaType]})
+                              {isRu ? ANALYSIS_LEVEL_CONFIG[preset.level].name : ANALYSIS_LEVEL_CONFIG[preset.level].nameEn}{" "}
+                              ({isRu ? MEDIA_TYPE_NAMES[mediaType] : MEDIA_TYPE_NAMES_EN[mediaType]})
                             </p>
                             <p className="text-xs text-muted-foreground" data-oid="qwrcx4k">
-                              {preset.descriptionRu}
+                              {isRu ? preset.descriptionRu : preset.description}
                             </p>
                           </div>
                           <Badge variant="outline" data-oid="e1ygc.6">
@@ -649,13 +668,17 @@ export function AnalysisSettingsPanel() {
 
             {selectedMediaTypes.size === 0 && (
               <p className="text-sm text-muted-foreground text-center py-4" data-oid="c150a9i">
-                Выберите файлы, чтобы увидеть рекомендуемые пресеты
+                {isRu
+                  ? "Выберите файлы, чтобы увидеть рекомендуемые пресеты"
+                  : "Select files to see recommended presets"}
               </p>
             )}
 
             {!selectedAnalyzers.has("vlm_analysis") && selectedMediaTypes.size === 0 && (
               <p className="text-sm text-muted-foreground text-center py-4" data-oid="lx4prge">
-                Включите VLM Analysis для настройки AI Vision модели
+                {isRu
+                  ? "Включите VLM Analysis для настройки AI Vision модели"
+                  : "Enable VLM Analysis to configure the AI Vision model"}
               </p>
             )}
           </TabsContent>

--- a/src/features/timeline/components/timeline-content.tsx
+++ b/src/features/timeline/components/timeline-content.tsx
@@ -54,6 +54,7 @@ export function TimelineContent() {
 
 function TimelineContentInner() {
   const scrollContainerRef = useRef<HTMLDivElement>(null)
+  const projectCreateRequestedRef = useRef(false)
   const [scrollOffset, setScrollOffset] = useState(0)
   const [containerWidth, setContainerWidth] = useState(0)
 
@@ -123,16 +124,18 @@ function TimelineContentInner() {
   // Инициализируем синхронизацию с плеером
   useTimelinePlayerSync()
 
-  // Создаем проект немедленно при наличии currentProject
+  // Создаем проект при первой загрузке.
+  // `currentProject` приходит из backend project-state; в browser-режиме мок отдаёт null,
+  // и без него Timeline бесконечно висел на лоадере. Не блокируем инициализацию его наличием.
+  // ref-флаг критичен: orchestrator.createProject выставляет SET_LOADING/CLEAR_LOADING, но
+  // НЕ кладёт `project` в context — без guard эффект ушёл бы в бесконечный цикл вызовов.
   useEffect(() => {
-    if (!project && currentProject && projectSettings) {
-      // Создаем проект синхронно
-      createProject(currentProject.metadata.name).then(() => {
-        logger.info("[TimelineContent] Timeline project created", {
-          projectName: currentProject.metadata.name,
-        })
-      })
-    }
+    if (project || projectCreateRequestedRef.current || !projectSettings) return
+    projectCreateRequestedRef.current = true
+    const name = currentProject?.metadata?.name || "Untitled Project"
+    createProject(name).then(() => {
+      logger.info("[TimelineContent] Timeline project created", { projectName: name })
+    })
   }, [project, currentProject, projectSettings, createProject])
 
   // Добавляем демо секцию после создания проекта

--- a/src/features/timeline/components/virtualized-timeline-content.tsx
+++ b/src/features/timeline/components/virtualized-timeline-content.tsx
@@ -46,6 +46,7 @@ const logger = createLogger("VirtualizedTimelineContent")
 
 export function VirtualizedTimelineContent() {
   const scrollContainerRef = useRef<HTMLDivElement>(null)
+  const projectCreateRequestedRef = useRef(false)
   const [scrollOffset, setScrollOffset] = useState(0)
   const [containerWidth, setContainerWidth] = useState(0)
 
@@ -89,11 +90,16 @@ export function VirtualizedTimelineContent() {
     overscan: 5, // Рендерим 5 дополнительных треков сверху и снизу
   })
 
-  // Создаем проект при первой загрузке
+  // Создаем проект при первой загрузке.
+  // `currentProject` приходит из backend project-state; в browser-режиме мок отдаёт null,
+  // и без него Timeline бесконечно висел на лоадере. Не блокируем инициализацию его наличием.
+  // ref-флаг критичен: orchestrator.createProject выставляет SET_LOADING/CLEAR_LOADING, но
+  // НЕ кладёт `project` в context — без guard эффект ушёл бы в бесконечный цикл вызовов.
   useEffect(() => {
-    if (!project && currentProject && projectSettings) {
-      void createProject(currentProject.metadata.name)
-    }
+    if (project || projectCreateRequestedRef.current || !projectSettings) return
+    projectCreateRequestedRef.current = true
+    const name = currentProject?.metadata?.name || "Untitled Project"
+    void createProject(name)
   }, [project, currentProject, projectSettings, createProject])
 
   // Добавляем демо секцию
@@ -155,7 +161,11 @@ export function VirtualizedTimelineContent() {
     )
   }
 
-  if (!project) {
+  // Лоадер показываем ТОЛЬКО до момента, когда мы запросили создание проекта.
+  // В browser-режиме mock-backend возвращает success, но не шлёт PROJECT_UPDATED-эвент,
+  // поэтому context.project остаётся null навсегда. Дальше рендер опирается на project?.
+  // и спокойно отрисовывает пустой таймлайн.
+  if (!project && !projectCreateRequestedRef.current) {
     return (
       <div className="flex h-full items-center justify-center" data-oid="go-p6we">
         <Card className="w-96" data-oid="jg6rgnm">
@@ -188,12 +198,14 @@ export function VirtualizedTimelineContent() {
             <div className="flex items-center gap-6" data-oid="ac_1tn2">
               <div data-oid="0xpt59r">
                 <h3 className="font-semibold text-foreground" data-oid="tnf7ciz">
-                  {currentProject?.metadata?.name || project.name}
+                  {currentProject?.metadata?.name || project?.name || "Untitled Project"}
                 </h3>
                 <p className="text-sm text-muted-foreground" data-oid="q5:6ba3">
                   {projectSettings
                     ? `${projectSettings.aspectRatio.value.width}x${projectSettings.aspectRatio.value.height} @ ${projectSettings.frameRate}fps`
-                    : `${project.settings.resolution.width}x${project.settings.resolution.height} @ ${project.settings.fps}fps`}
+                    : project?.settings
+                      ? `${project.settings.resolution.width}x${project.settings.resolution.height} @ ${project.settings.fps}fps`
+                      : ""}
                 </p>
               </div>
               {/* Edit mode selector */}
@@ -203,7 +215,7 @@ export function VirtualizedTimelineContent() {
             </div>
             <div className="flex gap-2" data-oid="c4b002.">
               <Badge variant="outline" data-oid="2hspsrl">
-                {project.sections?.length || 0} секций
+                {project?.sections?.length || 0} секций
               </Badge>
               <Badge variant="outline" data-oid="1mi0f:9">
                 {tracks.length} треков

--- a/src/features/transcription/components/language-selector.tsx
+++ b/src/features/transcription/components/language-selector.tsx
@@ -38,7 +38,7 @@ export function LanguageSelector({ value, onChange, includeAutoDetect = true }: 
 
   return (
     <div className="space-y-2" data-oid="njnimz2">
-      <Label data-oid="x2_fbz:">{t("transcription.language", "Язык")}</Label>
+      <Label data-oid="x2_fbz:">{t("transcription.language.label")}</Label>
       <Select
         value={value || (includeAutoDetect ? "auto" : undefined)}
         onValueChange={(val) => onChange(val === "auto" ? undefined : val)}

--- a/src/features/transcription/components/transcription-editor.tsx
+++ b/src/features/transcription/components/transcription-editor.tsx
@@ -51,7 +51,7 @@ export function TranscriptionEditor({ result, onAddToTimeline }: TranscriptionEd
     <div className="space-y-4" data-oid="d7yaoj3">
       <div className="flex items-center justify-between" data-oid="i2-sj6z">
         <h3 className="text-sm font-medium" data-oid="wm5_gjf">
-          {t("transcription.results", "Результаты транскрипции")}
+          {t("transcription.transcriptionResultsHeading", "Результаты транскрипции")}
         </h3>
         {onAddToTimeline && (
           <Button size="sm" onClick={handleAddAllToTimeline} data-oid="-mivr7e">

--- a/src/features/transcription/components/transcription-panel.tsx
+++ b/src/features/transcription/components/transcription-panel.tsx
@@ -192,7 +192,7 @@ export function TranscriptionPanel({ onAddToTimeline }: TranscriptionPanelProps 
 
             {/* Задача */}
             <div className="space-y-2" data-oid="9ca:sj4">
-              <Label data-oid="gevbu3b">{t("transcription.task", "Задача")}</Label>
+              <Label data-oid="gevbu3b">{t("transcription.task.label")}</Label>
               <Select
                 value={options.task}
                 onValueChange={(value) =>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -77,7 +77,9 @@
     "averageScore": "Average Score",
     "detectionRate": "Detection Rate",
     "momentsDetected": "moments detected",
-    "momentTypes": "Moment Types"
+    "momentTypes": "Moment Types",
+    "pause": "Pause",
+    "play": "Play"
   },
   "app": {
     "connectingToBackend": "Connecting to application...",
@@ -222,6 +224,44 @@
     },
     "montagePlanner": {
       "title": "Smart Montage Planner"
+    },
+    "about": {
+      "title": "About"
+    },
+    "subtitleEditor": {
+      "titleEdit": "Edit Subtitle",
+      "titleAdd": "Add Subtitle"
+    },
+    "personForm": {
+      "titleEdit": "Edit Person",
+      "titleAdd": "Create Person"
+    },
+    "missingFiles": {
+      "title": "Missing Media Files"
+    },
+    "aiMarkerSettings": {
+      "title": "AI Marker Settings"
+    },
+    "subtitleAITools": {
+      "title": "Automatic Transcription"
+    },
+    "audioEffects": {
+      "title": "Audio Effects"
+    },
+    "midiLearn": {
+      "title": "MIDI Learn"
+    },
+    "midiMapping": {
+      "title": "MIDI Mapping Editor"
+    },
+    "midiConfiguration": {
+      "title": "MIDI Settings"
+    },
+    "effectDetail": {
+      "title": "Effect Details"
+    },
+    "colorGrading": {
+      "title": "Save Color Grading Preset"
     }
   },
   "dialogs": {
@@ -288,7 +328,12 @@
       "errorGettingDevices": "Failed to get device list",
       "browserNotSupported": "Your browser does not support camera recording",
       "mediaDevicesNotSupported": "Media devices are not supported in this browser",
-      "mediaDevicesError": "Error accessing media devices"
+      "mediaDevicesError": "Error accessing media devices",
+      "requestingPermissions": "Requesting permissions...",
+      "recordingSuccess": "Recording saved successfully",
+      "recordingError": "Error saving recording",
+      "notSupported": "Camera recording unavailable",
+      "notSupportedDescription": "Camera recording isn't supported in the desktop app. This feature is only available when using Timeline Studio in a web browser."
     },
     "cameraPreview": {
       "title": "Recording Preview",
@@ -331,7 +376,16 @@
       "hint": "Click the record button to start. The recording will be automatically added to the media library.",
       "browserNotSupported": "Your browser does not support audio recording",
       "mediaDevicesNotSupported": "Media devices are not supported in this browser",
-      "mediaDevicesError": "Error accessing media devices"
+      "mediaDevicesError": "Error accessing media devices",
+      "saveError": "Error saving audio recording",
+      "notSupported": "Audio recording unavailable",
+      "notSupportedDescription": "Audio recording isn't supported in the desktop app. This feature is only available when using Timeline Studio in a web browser.",
+      "unsupportedBrowser": "Your browser doesn't support audio recording. Please use a modern browser.",
+      "permissionsDenied": "Microphone access denied. Check your browser settings.",
+      "permissionCheckError": "Couldn't check permissions. Please try again.",
+      "errorGettingDevices": "Couldn't get the list of devices",
+      "recordingNotSupported": "Recording isn't supported by this browser",
+      "streamError": "Couldn't initialize the microphone"
     },
     "userSettings": {
       "title": "User Settings",
@@ -635,7 +689,46 @@
         "description": "The project will be automatically saved at the specified time interval"
       },
       "cancel": "Cancel",
-      "save": "OK"
+      "save": "OK",
+      "socialNetworksDescription": "Set up OAuth connections to automatically publish videos to social networks.",
+      "comingSoon": "Coming soon",
+      "socialNetworksComingSoon": "OAuth integration with social networks will be available in a future update. For now, API keys are stored encrypted.",
+      "currentImplementation": "Current implementation",
+      "currentImplementationText": "Secure API key storage is ready. OAuth integration and the social networks UI are still in development.",
+      "aiServicesDescription": "Set up API keys to integrate with AI assistants. Keys are stored securely on your device.",
+      "openAiDescription": "Used for ChatGPT integration and content generation. Get a key at platform.openai.com",
+      "getApiKey": "Get API key",
+      "claudeDescription": "Used for the Claude AI assistant and advanced content analysis. Get a key from the Anthropic Console",
+      "grokApiKey": "Grok API key",
+      "grokDescription": "Used for xAI's Grok models. Get a key at console.x.ai",
+      "deepSeekApiKey": "DeepSeek API key",
+      "deepSeekDescription": "Used for DeepSeek models. Get a key at platform.deepseek.com",
+      "mcpClaudeApiKey": "Claude API key for MCP",
+      "mcpDescription": "Model Context Protocol (MCP) — extended Claude integration for accessing video editing tools. Lets you use your Claude Code subscription right inside the editor.",
+      "learnAboutMcp": "Learn more about MCP",
+      "mcpFeatures": "MCP capabilities:",
+      "mcpFeature1": "Video and audio content analysis",
+      "mcpFeature2": "Timeline and clip management",
+      "mcpFeature3": "Applying effects and transitions",
+      "mcpFeature4": "Export and preview generation",
+      "mcpFeature5": "18 specialized tools",
+      "securityNote": "Security note",
+      "securityNoteText": "All API keys are encrypted and stored locally on your device. They are never shared with third parties.",
+      "developmentDescription": "Settings for development tools and analytics. Available only in development mode.",
+      "codecovDescription": "Token for uploading test coverage reports to Codecov. Used in the CI/CD pipeline.",
+      "getToken": "Get token",
+      "tauriAnalyticsDescription": "Key for Tauri app analytics. Used to collect performance metrics.",
+      "tauriDocs": "Tauri documentation",
+      "devModeNote": "Development mode",
+      "devModeNoteText": "This tab is only visible in development mode. Development settings are unavailable in production builds.",
+      "hideKey": "Hide key",
+      "showKey": "Show key",
+      "invalidKey": "Invalid API key or connection issue",
+      "validKey": "API key is working correctly",
+      "lastValidated": "Last validated",
+      "created": "Created",
+      "codecovToken": "Codecov Token",
+      "tauriAnalyticsKey": "Tauri Analytics Key"
     },
     "export": {
       "title": "Export",
@@ -695,6 +788,7 @@
       "video": "Video",
       "audio": "Audio",
       "file": "File",
+      "transitions": "Transitions",
       "exportVideo": "Export video",
       "exportAudio": "Export audio",
       "codecType": "Codec Type",
@@ -763,6 +857,25 @@
       "uploadProgress": "Upload Progress",
       "uploading": "Uploading",
       "uploadTo": "Upload to {{platform}}",
+      "social": {
+        "max": "Max",
+        "limitsAndValidation": "Limits & Validation",
+        "valid": "Valid",
+        "invalid": "Invalid",
+        "maxFileSize": "Max File Size",
+        "maxDuration": "Max Duration",
+        "maxResolution": "Max Resolution",
+        "titleLimit": "Title Limit",
+        "optimizationSuggestions": "Optimization suggestions:",
+        "categories": {
+          "peopleAndBlogs": "People & Blogs",
+          "entertainment": "Entertainment",
+          "newsAndPolitics": "News & Politics",
+          "howtoAndStyle": "Howto & Style",
+          "education": "Education",
+          "scienceAndTechnology": "Science & Technology"
+        }
+      },
       "batchTab": "Batch",
       "sectionsTab": "Sections",
       "batchSettings": "Batch Export Settings",
@@ -833,7 +946,9 @@
         "timeline": "Timeline",
         "markers-multicam": "Markers & Multicam",
         "miscellaneous": "Miscellaneous",
-        "other": "Other"
+        "other": "Other",
+        "marker": "Marker",
+        "multicam": "Multicam Editing"
       },
       "shortcuts": {
         "preferences": "Preferences",
@@ -1029,13 +1144,22 @@
         "volume-up": "Volume Up",
         "volume-down": "Volume Down",
         "help": "Help",
-        "export": "Export"
+        "export": "Export",
+        "adjust-bezier": "Adjust bezier curve"
       },
       "presets": {
         "timeline": "Timeline",
         "filmora": "Wondershare Filmora",
         "premiere": "Adobe Premier Pro"
-      }
+      },
+      "cheatSheet": "Keyboard Shortcuts Cheat Sheet",
+      "cheatSheetDescription": "All available keyboard shortcuts",
+      "print": "Print",
+      "conflictDetected": "Conflict detected",
+      "criticalConflict": "Critical conflict",
+      "potentialConflict": "Potential conflict",
+      "export": "Export",
+      "import": "Import"
     }
   },
   "developerTools": {
@@ -1043,7 +1167,8 @@
     "description": "Advanced tools for developers and content creators",
     "tabs": {
       "effectPreviews": "Effect Previews"
-    }
+    },
+    "openButton": "Open Developer Tools"
   },
   "templates": {
     "verticalSplit": "Vertical Split",
@@ -1273,6 +1398,83 @@
       "supportedVideoFormats": "Supported video formats: MP4, MOV, AVI, MKV, WEBM, INSV (360°)",
       "supportedAudioFormats": "Supported audio formats: MP3, WAV, AAC, ALAC, OGG, FLAC"
     },
+    "emptyState": {
+      "formatsLabel": "Supported formats:",
+      "media": {
+        "title": "No media files found",
+        "description": "Add video, audio, or photo files to work with the project",
+        "importText": "Import media files",
+        "folderText": "Or place files in the folder",
+        "formats": [
+          "Video: MP4, MOV, AVI, MKV, WEBM, INSV (360°)",
+          "Audio: MP3, WAV, AAC, ALAC, OGG, FLAC",
+          "Photo: JPG, PNG, GIF, WEBP, TIFF, BMP"
+        ]
+      },
+      "music": {
+        "title": "No music files found",
+        "description": "Add music and sound effects to score your project",
+        "importText": "Import music",
+        "folderText": "Or place music in the folder",
+        "formats": [
+          "MP3, WAV, AAC, ALAC, OGG, FLAC"
+        ]
+      },
+      "effects": {
+        "title": "No effects found",
+        "description": "Add video effects to enhance your clips",
+        "importText": "Import effects",
+        "folderText": "Or place effects in the folder",
+        "formats": [
+          "JSON files with effect definitions"
+        ]
+      },
+      "filters": {
+        "title": "No filters found",
+        "description": "Add color filters and correction for video",
+        "importText": "Import filters",
+        "folderText": "Or place filters in the folder",
+        "formats": [
+          "JSON files with filter settings"
+        ]
+      },
+      "transitions": {
+        "title": "No transitions found",
+        "description": "Add transitions between clips for smooth editing",
+        "importText": "Import transitions",
+        "folderText": "Or place transitions in the folder",
+        "formats": [
+          "JSON files with transition animations"
+        ]
+      },
+      "templates": {
+        "title": "No templates found",
+        "description": "Add ready-made templates for quick project creation",
+        "importText": "Import templates",
+        "folderText": "Or place templates in the folder",
+        "formats": [
+          "JSON files with template settings"
+        ]
+      },
+      "style_templates": {
+        "title": "No style templates found",
+        "description": "Add styled templates with ready-made designs",
+        "importText": "Import style templates",
+        "folderText": "Or place templates in the folder",
+        "formats": [
+          "JSON files with styles and settings"
+        ]
+      },
+      "subtitles": {
+        "title": "No subtitles found",
+        "description": "Add subtitle files or create new ones",
+        "importText": "Import subtitles",
+        "folderText": "Or place subtitles in the folder",
+        "formats": [
+          "SRT, VTT, ASS, SSA subtitle files"
+        ]
+      }
+    },
     "subtitles": {
       "search": "Search...",
       "dragHint": "Drag subtitle to timeline to add it to your project",
@@ -1465,7 +1667,13 @@
     "workspace": {
       "timeline": "Timeline",
       "audioMixer": "Audio Mixer",
-      "analysis": "Analysis"
+      "analysis": "Analysis",
+      "script": "Script"
+    },
+    "analysisPanel": {
+      "results": "Analysis results",
+      "newAnalysis": "New analysis",
+      "newAnalysisSettings": "New analysis settings"
     },
     "audioMixer": {
       "title": "Audio Mixer",
@@ -1628,7 +1836,8 @@
       "copy": "Copy",
       "loading_models": "Loading models...",
       "no_models": "No available models",
-      "no_tool_models": "No models with tool support"
+      "no_tool_models": "No models with tool support",
+      "error": "An error occurred while sending the message. Please check your API key settings."
     },
     "title": "Timeline",
     "noTracks": "No tracks",
@@ -1638,7 +1847,27 @@
     "fitToScreen": "Fit to screen",
     "zoomIn": "Zoom in",
     "zoomOut": "Zoom out",
-    "scale": "Scale"
+    "scale": "Scale",
+    "clip": {
+      "copy": "Copy",
+      "cut": "Cut",
+      "split": "Split",
+      "properties": "Properties",
+      "effects": "Effects",
+      "transitions": "Transitions",
+      "filters": "Filters",
+      "volume": "Volume",
+      "delete": "Delete"
+    },
+    "effects": {
+      "title": "Clip Effects",
+      "noClipSelected": "Select a clip to manage effects",
+      "add": "Add",
+      "selectEffect": "Select effect",
+      "selectEffectDescription": "Select an effect to add to the clip",
+      "noEffects": "No effects",
+      "selectEffectToEdit": "Select an effect to edit"
+    }
   },
   "titles": {
     "add": "Titles",
@@ -1760,7 +1989,9 @@
       "parameters": "Parameters",
       "tags": "Tags",
       "applyFilter": "Apply Filter"
-    }
+    },
+    "resetParams": "Reset to Default",
+    "previewNote": "Changes are applied in real-time to the preview"
   },
   "transitions": {
     "add": "Add transition",
@@ -1943,8 +2174,56 @@
       "parameters": "Parameters",
       "presets": "Presets",
       "ffmpegCommand": "FFmpeg Command",
-      "applyEffect": "Apply Effect"
-    }
+      "applyEffect": "Apply Effect",
+      "resetToDefault": "Reset to default",
+      "exportEffect": "Export effect",
+      "savePreset": "Save as preset",
+      "currentValues": "Current values"
+    },
+    "loading": "Loading effects...",
+    "error": "Failed to load effects",
+    "search": "Search effects...",
+    "scope": {
+      "all": "All",
+      "clip": "Clip",
+      "track": "Track",
+      "global": "Global"
+    },
+    "import": "Import",
+    "apply": "Apply",
+    "comparisonTab": "Comparison",
+    "comparison": {
+      "original": "Original",
+      "withEffect": "With effect",
+      "position": "Position"
+    },
+    "customPreset": "Custom preset",
+    "deletePreset": "Delete preset",
+    "noParameters": "No parameters",
+    "createdAt": "Created",
+    "enterExportName": "Enter a file name for export:",
+    "preview": {
+      "generator": {
+        "title": "Effect Preview Generator",
+        "description": "Generate preview videos for all effects using the prerender system",
+        "totalEffects": "Total Effects",
+        "completed": "Completed",
+        "failed": "Failed",
+        "progress": "Progress",
+        "current": "Current",
+        "sourceVideo": "Source Video",
+        "sourceVideoHelp": "Path to the video file to apply effects to",
+        "duration": "Duration (seconds)",
+        "quality": "Quality (0-100)",
+        "outputDir": "Output Directory",
+        "generate": "Generate Previews",
+        "cancel": "Cancel Generation",
+        "info1": "This will generate preview videos for all effects using the Rust prerender backend.",
+        "info2": "Generated videos will be saved to the output directory and used for effect previews.",
+        "warning": "Warning: This process may take several minutes depending on the number of effects."
+      }
+    },
+    "enterPresetName": "Enter a preset name:"
   },
   "project": {
     "untitledProject": "Untitled #{{number}}",
@@ -2013,7 +2292,46 @@
   "ai": {
     "suggestions": {
       "whatCanDo": "What can I do",
-      "emptyHint": "Add videos to media browser or use AI to help with import"
+      "emptyHint": "Add videos to media browser or use AI to help with import",
+      "music": "music",
+      "analysisComplete": "Analysis complete",
+      "detected": "Detected"
+    },
+    "actionPreview": {
+      "riskHigh": "High risk",
+      "riskMedium": "Medium risk",
+      "riskLow": "Low risk",
+      "riskUnknown": "Unknown",
+      "title": "AI plans to perform the following actions",
+      "parameters": "Parameters",
+      "cancel": "Cancel",
+      "confirm": "Run"
+    },
+    "cache": {
+      "entries": "Cache",
+      "hits": "Hits",
+      "expired": "Expired",
+      "refresh": "Refresh",
+      "title": "AI Request Cache",
+      "description": "Automatic caching of AI responses",
+      "disabled": "Caching disabled",
+      "totalEntries": "Total entries",
+      "totalHits": "Total hits",
+      "maxEntries": "Max entries",
+      "expiredWarning": "Expired entries: {{count}}",
+      "refreshTooltip": "Refresh cache stats",
+      "cleanup": "Clear expired",
+      "cleanupTooltip": "Remove expired entries from the cache",
+      "clear": "Clear entire cache",
+      "clearTooltip": "Remove all entries from the cache",
+      "info": "The cache is stored locally in a SQLite database. Entries are automatically deleted after 24 hours.",
+      "hitRate": "Hit Rate"
+    },
+    "processing": {
+      "analyzing": "Analyzing project context...",
+      "preparingTools": "Preparing tools...",
+      "generating": "Generating response...",
+      "processing": "Processing..."
     }
   },
   "source": {
@@ -2187,7 +2505,10 @@
       "maintainDuration": "Maintain Duration",
       "frameInterpolation": "Frame Interpolation",
       "interpolationMethod": "Interpolation Method",
-      "smoothnessLevel": "Smoothness Level"
+      "smoothnessLevel": "Smoothness Level",
+      "smoothPlayback": "Smooth Playback",
+      "performance": "Performance",
+      "quality": "Quality"
     },
     "info": {
       "title": "Media File Info",
@@ -2411,7 +2732,8 @@
         "videotoolboxCodec": "Use H.265/HEVC for better compression",
         "lowMemory": "Low video memory, avoid 4K rendering",
         "highMemory": "Sufficient memory for 4K rendering"
-      }
+      },
+      "appleMetalError": "Apple Metal/VideoToolbox initialization error. This is usually temporary."
     },
     "cache": {
       "statistics": "Cache Statistics",
@@ -2579,6 +2901,40 @@
       "selectFile": "Select file",
       "selectFileDesc": "Select audio or video file for transcription",
       "noMedia": "Add video or audio files to project for transcription"
+    },
+    "enhanced": {
+      "success": "Subtitles created",
+      "successDesc": "Processed {{count}} subtitles with {{confidence}}% confidence",
+      "error": "Failed to create subtitles",
+      "cancelled": "Operation cancelled"
+    },
+    "trackName": "Subtitles",
+    "autoSync": {
+      "selectAudio": "Select an audio track",
+      "noSubtitles": "No subtitles to sync",
+      "analyzing": "Analyzing audio...",
+      "detectingSpeech": "Detecting speech...",
+      "noSpeechDetected": "No speech detected",
+      "matching": "Matching subtitles...",
+      "success": "Sync complete",
+      "successDesc": "Synced {{synced}} of {{total}} subtitles ({{confident}} high-confidence)",
+      "error": "Sync error",
+      "errorDesc": "Failed to complete automatic sync",
+      "title": "Auto Sync",
+      "description": "Sync subtitles to audio based on speech analysis",
+      "audioSource": "Audio source",
+      "selectAudioPlaceholder": "Select an audio track or file",
+      "tracksSection": "Timeline tracks",
+      "filesSection": "Media files",
+      "mode": "Sync mode",
+      "voiceDetection": "Voice detection",
+      "silenceDetection": "Silence detection",
+      "beatDetection": "Beat sync",
+      "sensitivity": "Sensitivity",
+      "progress": "Progress",
+      "syncing": "Syncing...",
+      "start": "Start sync",
+      "hint": "The algorithm analyzes the audio waveform to detect where speech begins and automatically aligns subtitles"
     }
   },
   "export": {
@@ -2596,8 +2952,11 @@
       "qualityPreset": "Quality Preset",
       "qualityPresetDescription": "Choose export quality for sections",
       "preview": "Preview Quality",
+      "previewDescription": "720p, Low bitrate, Fast encoding",
       "draft": "Draft Quality",
+      "draftDescription": "1080p, Medium quality",
       "final": "Final Quality",
+      "finalDescription": "Full quality, project settings",
       "sectionsTitle": "Sections",
       "selectedCount": "{{selected}} of {{total}} sections selected",
       "selectAll": "Select All",
@@ -3436,5 +3795,129 @@
       "invalidFile": "File is not a color scheme",
       "importFailed": "Failed to import scheme"
     }
+  },
+  "transcription": {
+    "modelsDescription": "Download models for local transcription",
+    "downloaded": "Downloaded",
+    "download": "Download",
+    "tip": "Tip",
+    "modelTip": "For most tasks, the 'base' model offers a good balance of speed and quality. Use 'large' models for maximum accuracy.",
+    "fileSelect": {
+      "error": "File selection error"
+    },
+    "error": "Error",
+    "noFile": "Select a file",
+    "transcriptionResultsHeading": "Transcription Results",
+    "save": {
+      "success": "Subtitles saved",
+      "error": "Save failed",
+      "srt": "SRT"
+    },
+    "enhanced": {
+      "title": "AI Subtitle Generation",
+      "description": "Automatic subtitle creation powered by AI",
+      "generate": "AI Generation",
+      "quick": "Quick",
+      "confidence": "Confidence",
+      "ocr": "OCR"
+    },
+    "mode": {
+      "basic": "Basic",
+      "enhanced": "Enhanced AI"
+    },
+    "file": {
+      "title": "File selection",
+      "select": "Select file"
+    },
+    "settings": {
+      "title": "Settings",
+      "main": "General",
+      "ai": "AI features",
+      "advanced": "Advanced"
+    },
+    "language": {
+      "label": "Language"
+    },
+    "task": {
+      "label": "Task",
+      "transcribe": "Transcribe",
+      "translate": "Translate"
+    },
+    "ai": {
+      "sources": "Data sources",
+      "speech": "Speech recognition",
+      "ocr": "On-screen text (OCR)",
+      "scenes": "Scene analysis",
+      "speakers": "Speaker identification",
+      "processing": "Text processing",
+      "grammar": "Grammar correction",
+      "capitalization": "Capitalization",
+      "filler": "Remove filler words",
+      "optimize": "Optimize for readability",
+      "style": "Subtitle style",
+      "provider": "AI provider"
+    },
+    "style": {
+      "standard": "Standard",
+      "broadcast": "Broadcast",
+      "social": "Social media",
+      "accessibility": "Accessibility"
+    },
+    "basic": {
+      "start": "Transcribe"
+    },
+    "cancel": "Cancel",
+    "reset": "Reset",
+    "results": {
+      "title": "Results"
+    },
+    "addToTimeline": "Add to timeline",
+    "selectLanguage": "Select language",
+    "wordTimings": "Word timings",
+    "fullText": "Full text",
+    "title": "Transcription",
+    "description": "Automatic subtitle creation with AI",
+    "selectFile": "Select a media file",
+    "chooseFile": "Choose file",
+    "basicSettings": "General",
+    "advancedSettings": "Advanced",
+    "models": "Models",
+    "model": "Model",
+    "transcribe": "Transcription",
+    "translate": "Translate to English",
+    "provider": {
+      "unified": "Unified AI",
+      "whisper": "Whisper",
+      "azure": "Azure",
+      "google": "Google"
+    },
+    "device": "Device",
+    "wordTimestamps": "Word timestamps",
+    "vadFilter": "Voice activity filter",
+    "processing": "Processing...",
+    "start": "Start transcription"
+  },
+  "about": {
+    "version": "Version",
+    "description": "Professional video editor for creating and editing video",
+    "rights": "All rights reserved",
+    "builtWith": "Built with",
+    "documentation": "Documentation",
+    "license": "License"
+  },
+  "cameraCapture": {
+    "saving": "Saving recording...",
+    "cameraMode": "Camera",
+    "screenMode": "Screen",
+    "screenSettings": "Screen Recording Settings",
+    "screenInfo": "Select a window, tab, or entire screen to record",
+    "microphone": "Microphone",
+    "noAudio": "No Audio",
+    "countdown": "Countdown",
+    "noCountdown": "No countdown",
+    "seconds": "seconds"
+  },
+  "camera": {
+    "permissionError": "Couldn't access the camera and microphone. Check your settings."
   }
 }

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -77,7 +77,9 @@
     "averageScore": "Средняя оценка",
     "detectionRate": "Частота обнаружения",
     "momentsDetected": "моментов обнаружено",
-    "momentTypes": "Типы моментов"
+    "momentTypes": "Типы моментов",
+    "pause": "Пауза",
+    "play": "Воспроизвести"
   },
   "app": {
     "connectingToBackend": "Подключение к приложению...",
@@ -460,7 +462,8 @@
     "description": "Расширенные инструменты для разработчиков и создателей контента",
     "tabs": {
       "effectPreviews": "Предпросмотр эффектов"
-    }
+    },
+    "openButton": "Открыть инструменты разработчика"
   },
   "templates": {
     "verticalSplit": "Вертикальное разделение",
@@ -690,6 +693,83 @@
       "supportedVideoFormats": "Поддерживаемые форматы видео: MP4, MOV, AVI, MKV, WEBM, INSV (360°)",
       "supportedAudioFormats": "Поддерживаемые форматы аудио: MP3, WAV, AAC, ALAC, OGG, FLAC"
     },
+    "emptyState": {
+      "formatsLabel": "Поддерживаемые форматы:",
+      "media": {
+        "title": "Медиафайлы не найдены",
+        "description": "Добавьте видео, аудио или фото файлы для работы с проектом",
+        "importText": "Импортировать медиафайлы",
+        "folderText": "Или поместите файлы в папку",
+        "formats": [
+          "Видео: MP4, MOV, AVI, MKV, WEBM, INSV (360°)",
+          "Аудио: MP3, WAV, AAC, ALAC, OGG, FLAC",
+          "Фото: JPG, PNG, GIF, WEBP, TIFF, BMP"
+        ]
+      },
+      "music": {
+        "title": "Музыкальные файлы не найдены",
+        "description": "Добавьте музыку и звуковые эффекты для озвучивания проекта",
+        "importText": "Импортировать музыку",
+        "folderText": "Или поместите музыку в папку",
+        "formats": [
+          "MP3, WAV, AAC, ALAC, OGG, FLAC"
+        ]
+      },
+      "effects": {
+        "title": "Эффекты не найдены",
+        "description": "Добавьте видеоэффекты для улучшения ваших клипов",
+        "importText": "Импортировать эффекты",
+        "folderText": "Или поместите эффекты в папку",
+        "formats": [
+          "JSON файлы с описанием эффектов"
+        ]
+      },
+      "filters": {
+        "title": "Фильтры не найдены",
+        "description": "Добавьте цветовые фильтры и коррекцию для видео",
+        "importText": "Импортировать фильтры",
+        "folderText": "Или поместите фильтры в папку",
+        "formats": [
+          "JSON файлы с настройками фильтров"
+        ]
+      },
+      "transitions": {
+        "title": "Переходы не найдены",
+        "description": "Добавьте переходы между клипами для плавного монтажа",
+        "importText": "Импортировать переходы",
+        "folderText": "Или поместите переходы в папку",
+        "formats": [
+          "JSON файлы с анимациями переходов"
+        ]
+      },
+      "templates": {
+        "title": "Шаблоны не найдены",
+        "description": "Добавьте готовые шаблоны для быстрого создания проектов",
+        "importText": "Импортировать шаблоны",
+        "folderText": "Или поместите шаблоны в папку",
+        "formats": [
+          "JSON файлы с настройками шаблонов"
+        ]
+      },
+      "style_templates": {
+        "title": "Стилистические шаблоны не найдены",
+        "description": "Добавьте стилизованные шаблоны с готовым дизайном",
+        "importText": "Импортировать стилистические шаблоны",
+        "folderText": "Или поместите шаблоны в папку",
+        "formats": [
+          "JSON файлы со стилями и настройками"
+        ]
+      },
+      "subtitles": {
+        "title": "Субтитры не найдены",
+        "description": "Добавьте файлы субтитров или создайте новые",
+        "importText": "Импортировать субтитры",
+        "folderText": "Или поместите субтитры в папку",
+        "formats": [
+          "SRT, VTT, ASS, SSA файлы субтитров"
+        ]
+      }
+    },
     "subtitles": {
       "search": "Поиск...",
       "dragHint": "Перетащите субтитры на таймлайн, чтобы добавить их к проекту",
@@ -877,10 +957,18 @@
     }
   },
   "timeline": {
+    "hide": "Скрыть таймлайн",
+    "show": "Показать таймлайн",
     "workspace": {
       "timeline": "Таймлайн",
       "audioMixer": "Аудио микшер",
-      "analysis": "Анализ"
+      "analysis": "Анализ",
+      "script": "Сценарий"
+    },
+    "analysisPanel": {
+      "results": "Результаты анализа",
+      "newAnalysis": "Новый анализ",
+      "newAnalysisSettings": "Настройка нового анализа"
     },
     "audioMixer": {
       "title": "Аудио микшер",
@@ -953,7 +1041,24 @@
       "next": "Следующий"
     },
     "controls": {
-      "playbackSpeed": "Скорость воспроизведения"
+      "firstFrame": "Первый кадр",
+      "previousFrame": "Предыдущий кадр",
+      "play": "Воспроизвести",
+      "pause": "Пауза",
+      "nextFrame": "Следующий кадр",
+      "lastFrame": "Последний кадр",
+      "record": "Начать запись",
+      "stopRecord": "Остановить запись",
+      "entryPoint": "Точка входа",
+      "exitPoint": "Точка выхода",
+      "settings": "Настройки",
+      "takeSnapshot": "Сделать снимок",
+      "switchCamera": "Переключить камеру",
+      "resetTemplate": "Сбросить шаблон",
+      "muteAudio": "Выключить звук",
+      "unmuteAudio": "Включить звук",
+      "fullscreen": "Полноэкранный режим",
+      "exitFullscreen": "Выйти из полноэкранного режима"
     },
     "speed": {
       "normal": "Нормальная",
@@ -985,26 +1090,6 @@
       "editTrackName": "Нажмите для редактирования",
       "sectorName": "Сектор {{date}}",
       "deleteConfirmation": "Вы уверены, что хотите удалить секцию {{section}}? Это действие нельзя отменить."
-    },
-    "controls": {
-      "firstFrame": "Первый кадр",
-      "previousFrame": "Предыдущий кадр",
-      "play": "Воспроизвести",
-      "pause": "Пауза",
-      "nextFrame": "Следующий кадр",
-      "lastFrame": "Последний кадр",
-      "record": "Начать запись",
-      "stopRecord": "Остановить запись",
-      "entryPoint": "Точка входа",
-      "exitPoint": "Точка выхода",
-      "settings": "Настройки",
-      "takeSnapshot": "Сделать снимок",
-      "switchCamera": "Переключить камеру",
-      "resetTemplate": "Сбросить шаблон",
-      "muteAudio": "Выключить звук",
-      "unmuteAudio": "Включить звук",
-      "fullscreen": "Полноэкранный режим",
-      "exitFullscreen": "Выйти из полноэкранного режима"
     },
     "title": "Таймлайн",
     "noTracks": "Нет дорожек",
@@ -1054,7 +1139,28 @@
       "ask_ai_import": "Спросить AI",
       "copy": "Копировать",
       "no_models": "Нет доступных моделей",
-      "no_tool_models": "Нет моделей с поддержкой инструментов"
+      "no_tool_models": "Нет моделей с поддержкой инструментов",
+      "error": "Произошла ошибка при отправке сообщения. Пожалуйста, проверьте настройки API ключа."
+    },
+    "clip": {
+      "copy": "Копировать",
+      "cut": "Вырезать",
+      "split": "Разделить",
+      "properties": "Свойства",
+      "effects": "Эффекты",
+      "transitions": "Переходы",
+      "filters": "Фильтры",
+      "volume": "Громкость",
+      "delete": "Удалить"
+    },
+    "effects": {
+      "title": "Эффекты клипа",
+      "noClipSelected": "Выберите клип для управления эффектами",
+      "add": "Добавить",
+      "selectEffect": "Выберите эффект",
+      "selectEffectDescription": "Выберите эффект для добавления к клипу",
+      "noEffects": "Нет эффектов",
+      "selectEffectToEdit": "Выберите эффект для редактирования"
     }
   },
   "titles": {
@@ -1177,7 +1283,9 @@
       "parameters": "Параметры",
       "tags": "Теги",
       "applyFilter": "Применить фильтр"
-    }
+    },
+    "resetParams": "Сбросить по умолчанию",
+    "previewNote": "Изменения применяются в реальном времени в превью"
   },
   "transitions": {
     "add": "Добавить переход",
@@ -1360,8 +1468,56 @@
       "parameters": "Параметры",
       "presets": "Пресеты",
       "ffmpegCommand": "FFmpeg команда",
-      "applyEffect": "Применить эффект"
-    }
+      "applyEffect": "Применить эффект",
+      "resetToDefault": "Сбросить к значениям по умолчанию",
+      "exportEffect": "Экспортировать эффект",
+      "savePreset": "Сохранить как пресет",
+      "currentValues": "Текущие значения"
+    },
+    "loading": "Загрузка эффектов...",
+    "error": "Ошибка загрузки эффектов",
+    "search": "Поиск эффектов...",
+    "scope": {
+      "all": "Все",
+      "clip": "Клип",
+      "track": "Трек",
+      "global": "Глобальные"
+    },
+    "import": "Импорт",
+    "apply": "Применить",
+    "comparisonTab": "Сравнение",
+    "comparison": {
+      "original": "Оригинал",
+      "withEffect": "С эффектом",
+      "position": "Позиция"
+    },
+    "customPreset": "Пользовательский",
+    "deletePreset": "Удалить пресет",
+    "noParameters": "Нет параметров",
+    "createdAt": "Создано",
+    "enterExportName": "Введите название файла для экспорта:",
+    "preview": {
+      "generator": {
+        "title": "Генератор превью эффектов",
+        "description": "Создание превью-видео для всех эффектов с помощью системы предрендеринга",
+        "totalEffects": "Всего эффектов",
+        "completed": "Завершено",
+        "failed": "Ошибка",
+        "progress": "Прогресс",
+        "current": "Текущий",
+        "sourceVideo": "Исходное видео",
+        "sourceVideoHelp": "Путь к видеофайлу для применения эффектов",
+        "duration": "Длительность (секунды)",
+        "quality": "Качество (0-100)",
+        "outputDir": "Папка вывода",
+        "generate": "Создать превью",
+        "cancel": "Отменить генерацию",
+        "info1": "Это создаст превью-видео для всех эффектов с помощью Rust-бэкенда предрендеринга.",
+        "info2": "Созданные видео будут сохранены в папку вывода и использованы для превью эффектов.",
+        "warning": "Внимание: этот процесс может занять несколько минут в зависимости от количества эффектов."
+      }
+    },
+    "enterPresetName": "Введите название пресета:"
   },
   "project": {
     "untitledProject": "Без названия #{{number}}",
@@ -1508,6 +1664,40 @@
       "selectFile": "Выберите файл",
       "selectFileDesc": "Выберите аудио или видео файл для транскрипции",
       "noMedia": "Добавьте видео или аудио файлы в проект для транскрипции"
+    },
+    "enhanced": {
+      "success": "Субтитры созданы",
+      "successDesc": "Обработано {{count}} субтитров с уверенностью {{confidence}}%",
+      "error": "Ошибка создания субтитров",
+      "cancelled": "Операция отменена"
+    },
+    "trackName": "Субтитры",
+    "autoSync": {
+      "selectAudio": "Выберите аудио трек",
+      "noSubtitles": "Нет субтитров для синхронизации",
+      "analyzing": "Анализ аудио...",
+      "detectingSpeech": "Определение моментов речи...",
+      "noSpeechDetected": "Речь не обнаружена",
+      "matching": "Сопоставление субтитров...",
+      "success": "Синхронизация завершена",
+      "successDesc": "Синхронизировано {{synced}} из {{total}} субтитров ({{confident}} с высокой точностью)",
+      "error": "Ошибка синхронизации",
+      "errorDesc": "Не удалось выполнить автоматическую синхронизацию",
+      "title": "Автоматическая синхронизация",
+      "description": "Синхронизация субтитров с аудио на основе анализа речи",
+      "audioSource": "Источник аудио",
+      "selectAudioPlaceholder": "Выберите аудио трек или файл",
+      "tracksSection": "Треки на таймлайне",
+      "filesSection": "Медиафайлы",
+      "mode": "Режим синхронизации",
+      "voiceDetection": "Определение голоса",
+      "silenceDetection": "Определение пауз",
+      "beatDetection": "Синхронизация с ритмом",
+      "sensitivity": "Чувствительность",
+      "progress": "Прогресс",
+      "syncing": "Синхронизация...",
+      "start": "Начать синхронизацию",
+      "hint": "Алгоритм анализирует аудио волну для определения моментов начала речи и автоматически выравнивает субтитры"
     }
   },
   "styleTemplates": {
@@ -1677,7 +1867,10 @@
       "maintainDuration": "Сохранить длительность",
       "frameInterpolation": "Интерполяция кадров",
       "interpolationMethod": "Метод интерполяции",
-      "smoothnessLevel": "Уровень плавности"
+      "smoothnessLevel": "Уровень плавности",
+      "smoothPlayback": "Плавное воспроизведение",
+      "performance": "Производительность",
+      "quality": "Качество"
     },
     "info": {
       "title": "Информация о медиафайле",
@@ -1864,7 +2057,46 @@
   "ai": {
     "suggestions": {
       "whatCanDo": "Что можно сделать",
-      "emptyHint": "Добавьте видео в браузер медиа или используйте AI для помощи с импортом"
+      "emptyHint": "Добавьте видео в браузер медиа или используйте AI для помощи с импортом",
+      "music": "музыка",
+      "analysisComplete": "Анализ завершён",
+      "detected": "Обнаружено"
+    },
+    "actionPreview": {
+      "riskHigh": "Высокий риск",
+      "riskMedium": "Средний риск",
+      "riskLow": "Низкий риск",
+      "riskUnknown": "Неизвестно",
+      "title": "AI планирует выполнить следующие действия",
+      "parameters": "Параметры",
+      "cancel": "Отменить",
+      "confirm": "Выполнить"
+    },
+    "cache": {
+      "entries": "Кэш",
+      "hits": "Попадания",
+      "expired": "Устарело",
+      "refresh": "Обновить статистику",
+      "title": "Кэш AI запросов",
+      "description": "Автоматическое кэширование ответов от AI",
+      "disabled": "Кэширование отключено",
+      "totalEntries": "Всего записей",
+      "totalHits": "Попадания",
+      "maxEntries": "Макс. записей",
+      "expiredWarning": "Устаревших записей: {{count}}",
+      "refreshTooltip": "Обновить статистику кэша",
+      "cleanup": "Очистить устаревшие",
+      "cleanupTooltip": "Удалить устаревшие записи из кэша",
+      "clear": "Очистить весь кэш",
+      "clearTooltip": "Удалить все записи из кэша",
+      "info": "Кэш хранится локально в SQLite базе данных. Записи автоматически удаляются через 24 часа.",
+      "hitRate": "Процент попаданий"
+    },
+    "processing": {
+      "analyzing": "Анализирую контекст проекта...",
+      "preparingTools": "Подготавливаю инструменты...",
+      "generating": "Генерирую ответ...",
+      "processing": "Обработка..."
     }
   },
   "source": {
@@ -1937,7 +2169,8 @@
         "videotoolboxCodec": "Используйте H.265/HEVC для лучшего сжатия",
         "lowMemory": "Мало видеопамяти, избегайте рендеринга в 4K",
         "highMemory": "Достаточно памяти для рендеринга в 4K"
-      }
+      },
+      "appleMetalError": "Ошибка инициализации Apple Metal/VideoToolbox. Обычно это временная проблема."
     },
     "cache": {
       "statistics": "Статистика кэша",
@@ -1994,7 +2227,191 @@
     }
   },
   "dialogs": {
-    "export": {},
+    "export": {
+      "title": "Экспорт",
+      "local": "Локально",
+      "device": "Устройство",
+      "socialNetworks": "Социальные сети",
+      "dvd": "DVD",
+      "youtube": "YouTube",
+      "tiktok": "TikTok",
+      "telegram": "Telegram",
+      "notLoggedIn": "Не выполнен вход",
+      "loginPrompt": {
+        "youtube": "Войдите в свой аккаунт YouTube для получения дополнительной информации.",
+        "tiktok": "Войдите в свой аккаунт TikTok, чтобы публиковать видео.",
+        "telegram": "Войдите в свой аккаунт Telegram, чтобы отправлять видео в каналы и группы."
+      },
+      "login": "Войти",
+      "cover": "Обложка",
+      "edit": "Редактировать",
+      "outputSettings": "Настройки вывода",
+      "name": "Название",
+      "saveTo": "Сохранить в",
+      "preset": "Пресет",
+      "defaultPreset": "По умолчанию",
+      "custom": "Особый",
+      "format": "Формат",
+      "quality": "Качество",
+      "normal": "Обычное",
+      "good": "Хорошее",
+      "best": "Лучшее",
+      "resolution": "Разрешение",
+      "frameRate": "Частота кадров",
+      "advancedCompression": "Расширенное сжатие",
+      "cloudBackup": "Облачное резервное копирование",
+      "enableGPUEncoding": "Включить аппаратное ускорение кодирования видео",
+      "useLastSettings": "Использовать последние настройки экспорта для локального файла",
+      "length": "Длительность",
+      "size": "Размер",
+      "approximate": "Приблизительно",
+      "titles": "Титры",
+      "device_types": {
+        "iphone": "iPhone",
+        "ipad": "iPad",
+        "android": "Android"
+      },
+      "codec": "Кодек",
+      "additional": "Дополнительно",
+      "fps": "к/с",
+      "kbps": "кбит/с",
+      "sdr": "SDR - Rec.709",
+      "otherNetworks": "Другие социальные сети",
+      "fileName": "Имя файла",
+      "selectPath": "Выбрать папку...",
+      "renderMode": "Режим рендеринга",
+      "singleClip": "Один клип",
+      "individualClips": "Отдельные клипы",
+      "video": "Видео",
+      "audio": "Аудио",
+      "file": "Файл",
+      "transitions": "Переходы",
+      "exportVideo": "Экспортировать видео",
+      "exportAudio": "Экспортировать аудио",
+      "codecType": "Тип кодека",
+      "interlacedRendering": "Чересстрочный рендеринг",
+      "optimizeForNetwork": "Оптимизировать для сетевого стриминга",
+      "useVerticalResolution": "Использовать вертикальное разрешение",
+      "chaptersByMarkers": "Главы по маркерам",
+      "constantBitrate": "Использовать постоянный битрейт",
+      "auto": "Авто",
+      "limitTo": "Ограничить до",
+      "limitSpeed": "Ограничить скорость до",
+      "seconds": "секунд",
+      "optimizeForSpeed": "Оптимизировать для скорости",
+      "encodingProfile": "Профиль кодирования",
+      "entropyMode": "Режим энтропии",
+      "multipassEncoding": "Многопроходное кодирование",
+      "keyframes": "Ключевые кадры",
+      "every": "Каждые",
+      "frames": "кадров",
+      "frameReordering": "Переупорядочивание кадров",
+      "audioCodec": "Аудиокодек",
+      "audioChannels": "Аудиоканалы",
+      "normalizeAudio": "Нормализовать аудио",
+      "normalizeToStandard": "Нормализовать по стандарту",
+      "optimizeToStandard": "Оптимизировать по стандарту",
+      "standard": "Стандарт",
+      "targetLevel": "Целевой уровень",
+      "targetLoudness": "Целевая громкость",
+      "embedInfo": "Встроить информацию",
+      "none": "Нет",
+      "asProject": "Как в проекте",
+      "useProxyMedia": "Использовать прокси-медиа",
+      "renderWithoutTimecode": "Рендерить без таймкода",
+      "advancedSettings": "Расширенные настройки",
+      "advancedDescription": "Дополнительные параметры кодирования для опытных пользователей",
+      "subtitlesSettings": "Настройки субтитров",
+      "subtitlesDescription": "Настройте параметры экспорта дорожки субтитров",
+      "progress": "Прогресс",
+      "rendering": "Рендеринг",
+      "cancel": "Отмена",
+      "close": "Закрыть",
+      "export": "Экспорт",
+      "errors": {
+        "noProject": "Проект не загружен",
+        "noPath": "Пожалуйста, выберите место сохранения",
+        "exportFailed": "Экспорт не удался. Попробуйте снова.",
+        "socialExportFailed": "Не удалось загрузить в соцсеть. Попробуйте снова."
+      },
+      "uploadSuccess": "Успешно загружено в {{platform}}",
+      "loggedIn": "Вход выполнен",
+      "logout": "Выйти",
+      "uploadSettings": "Настройки загрузки для {{platform}}",
+      "videoTitle": "Название видео",
+      "enterTitle": "Введите название видео...",
+      "enterDescription": "Введите описание видео...",
+      "description": "Описание",
+      "privacy": "Конфиденциальность",
+      "public": "Публичное",
+      "unlisted": "Доступно по ссылке",
+      "private": "Приватное",
+      "tags": "Теги",
+      "enterTags": "Введите теги через запятую",
+      "category": "Категория",
+      "channel": "Канал",
+      "enterChannelId": "Введите ID канала или имя пользователя",
+      "uploadProgress": "Прогресс загрузки",
+      "uploading": "Загрузка",
+      "uploadTo": "Загрузить в {{platform}}",
+      "social": {
+        "max": "Макс.",
+        "limitsAndValidation": "Лимиты и проверка",
+        "valid": "Корректно",
+        "invalid": "Некорректно",
+        "maxFileSize": "Макс. размер файла",
+        "maxDuration": "Макс. длительность",
+        "maxResolution": "Макс. разрешение",
+        "titleLimit": "Лимит названия",
+        "optimizationSuggestions": "Рекомендации по оптимизации:",
+        "categories": {
+          "peopleAndBlogs": "Люди и блоги",
+          "entertainment": "Развлечения",
+          "newsAndPolitics": "Новости и политика",
+          "howtoAndStyle": "Полезные советы и стиль",
+          "education": "Образование",
+          "scienceAndTechnology": "Наука и техника"
+        }
+      },
+      "batchTab": "Пакет",
+      "sectionsTab": "Секции",
+      "batchSettings": "Настройки пакетного экспорта",
+      "batchSettingsDescription": "Настройте параметры экспорта для нескольких проектов",
+      "outputFolder": "Папка вывода",
+      "noFolderSelected": "Папка не выбрана",
+      "selectOutputFolder": "Выбрать папку вывода",
+      "pendingProjects": "Ожидающие проекты",
+      "pendingProjectsCount": "Готово к экспорту проектов: {{count}}",
+      "noOutputPath": "Нет пути вывода",
+      "renderQueue": "Очередь рендеринга",
+      "activeJobs": "Активных задач: {{count}}",
+      "noActiveJobs": "Нет активных задач",
+      "addProjects": "Добавить проекты",
+      "clearCompleted": "Очистить завершённые",
+      "emptyQueue": "Очередь рендеринга пуста",
+      "queueStats": "Всего: {{total}} | Завершено: {{completed}} | Ошибок: {{failed}}",
+      "cancelAll": "Отменить всё",
+      "processing": "Обработка задач: {{count}}",
+      "startBatchExport": "Начать экспорт ({{count}} проектов)",
+      "batch": {
+        "selectProjects": "Выбор проектов",
+        "selectProjectsDescription": "Выберите проекты для включения в пакетный экспорт",
+        "selectAll": "Выбрать все",
+        "deselectAll": "Снять выделение",
+        "selectedCount": "Выбрано: {{count}}",
+        "tracks": "дорожек",
+        "exportQueue": "Очередь экспорта",
+        "exportProgress": "Завершено {{completed}} из {{total}}",
+        "waiting": "Ожидание",
+        "completed": "Завершено",
+        "error": "Ошибка",
+        "resume": "Продолжить",
+        "pause": "Пауза",
+        "cancel": "Отмена",
+        "startExport": "Начать экспорт"
+      },
+      "sectionsExportSuccess": "Секции успешно экспортированы"
+    },
     "userSettings": {
       "title": "Настройки пользователя",
       "interfaceLanguage": "Язык интерфейса:",
@@ -2270,7 +2687,81 @@
         "exportLogs": "Экспортировать логи",
         "debugPanel": "Панель отладки",
         "showDebugInfo": "Показывать отладочную информацию"
+      },
+      "socialNetworksDescription": "Настройте OAuth подключения для автоматической публикации видео в социальных сетях.",
+      "comingSoon": "Скоро",
+      "socialNetworksComingSoon": "OAuth интеграция с социальными сетями будет доступна в следующих обновлениях. Пока API ключи сохраняются в зашифрованном виде.",
+      "currentImplementation": "Текущая реализация",
+      "currentImplementationText": "Система безопасного хранения API ключей готова. OAuth интеграция и UI для социальных сетей находятся в разработке.",
+      "aiServicesDescription": "Настройте API ключи для интеграции с AI ассистентами. Ключи безопасно хранятся локально.",
+      "openAiDescription": "Используется для ChatGPT интеграции и генерации контента. Получите ключ на platform.openai.com",
+      "getApiKey": "Получить API ключ",
+      "claudeDescription": "Используется для Claude AI ассистента и продвинутого анализа контента. Получите ключ в консоли Anthropic",
+      "grokApiKey": "Grok API ключ",
+      "grokDescription": "Используется для моделей Grok от xAI. Получите ключ на console.x.ai",
+      "deepSeekApiKey": "DeepSeek API ключ",
+      "deepSeekDescription": "Используется для моделей DeepSeek. Получите ключ на platform.deepseek.com",
+      "mcpClaudeApiKey": "Claude API ключ для MCP",
+      "mcpDescription": "Model Context Protocol (MCP) - расширенная интеграция с Claude для доступа к инструментам видеомонтажа. Позволяет использовать Claude Code подписку прямо в редакторе.",
+      "learnAboutMcp": "Узнать больше о MCP",
+      "mcpFeatures": "Возможности MCP:",
+      "mcpFeature1": "Анализ видео и аудио контента",
+      "mcpFeature2": "Управление таймлайном и клипами",
+      "mcpFeature3": "Применение эффектов и переходов",
+      "mcpFeature4": "Экспорт и создание превью",
+      "mcpFeature5": "18 специализированных инструментов",
+      "securityNote": "Примечание о безопасности",
+      "securityNoteText": "Все API ключи шифруются и хранятся локально на вашем устройстве. Они никогда не передаются третьим лицам.",
+      "developmentDescription": "Настройки для инструментов разработки и аналитики. Доступно только в режиме разработки.",
+      "codecovDescription": "Токен для отправки отчетов покрытия тестами в Codecov. Используется в CI/CD pipeline.",
+      "getToken": "Получить токен",
+      "tauriAnalyticsDescription": "Ключ для аналитики Tauri приложения. Используется для сбора метрик производительности.",
+      "tauriDocs": "Документация Tauri",
+      "devModeNote": "Режим разработки",
+      "devModeNoteText": "Эта вкладка видна только в режиме разработки. В production сборке настройки разработки недоступны.",
+      "hideKey": "Скрыть ключ",
+      "showKey": "Показать ключ",
+      "invalidKey": "Неверный API ключ или проблемы с подключением",
+      "validKey": "API ключ работает корректно",
+      "lastValidated": "Проверено",
+      "created": "Создано",
+      "codecovToken": "Токен Codecov",
+      "tauriAnalyticsKey": "Ключ аналитики Tauri"
+    },
+    "keyboardShortcuts": {
+      "cheatSheet": "Шпаргалка по горячим клавишам",
+      "cheatSheetDescription": "Все доступные клавиатурные сочетания",
+      "print": "Печать",
+      "conflictDetected": "Обнаружен конфликт",
+      "criticalConflict": "Критический конфликт",
+      "potentialConflict": "Потенциальный конфликт",
+      "export": "Экспортировать",
+      "import": "Импортировать",
+      "shortcuts": {
+        "adjust-bezier": "Настройте кривую Безье"
+      },
+      "categories": {
+        "marker": "Маркер",
+        "multicam": "Мультикамерный монтаж"
       }
+    },
+    "cameraCapture": {
+      "requestingPermissions": "Запрашиваем разрешения...",
+      "recordingSuccess": "Запись успешно сохранена",
+      "recordingError": "Ошибка при сохранении записи",
+      "notSupported": "Запись с камеры недоступна",
+      "notSupportedDescription": "Запись с камеры не поддерживается в десктопном приложении. Эта функция доступна только при использовании Timeline Studio в веб-браузере."
+    },
+    "voiceRecord": {
+      "saveError": "Ошибка при сохранении аудиозаписи",
+      "notSupported": "Запись звука недоступна",
+      "notSupportedDescription": "Запись звука не поддерживается в десктопном приложении. Эта функция доступна только при использовании Timeline Studio в веб-браузере.",
+      "unsupportedBrowser": "Ваш браузер не поддерживает запись аудио. Используйте современный браузер.",
+      "permissionsDenied": "Доступ к микрофону запрещен. Проверьте настройки браузера.",
+      "permissionCheckError": "Не удалось проверить разрешения. Попробуйте еще раз.",
+      "errorGettingDevices": "Не удалось получить список устройств",
+      "recordingNotSupported": "Запись не поддерживается браузером",
+      "streamError": "Не удалось инициализировать микрофон"
     }
   },
   "export": {
@@ -2288,8 +2779,11 @@
       "qualityPreset": "Предустановка качества",
       "qualityPresetDescription": "Выберите качество экспорта для секций",
       "preview": "Качество предпросмотра",
+      "previewDescription": "720p, низкий битрейт, быстрое кодирование",
       "draft": "Черновое качество",
+      "draftDescription": "1080p, среднее качество",
       "final": "Финальное качество",
+      "finalDescription": "Полное качество, настройки проекта",
       "sectionsTitle": "Секции",
       "selectedCount": "Выбрано {{selected}} из {{total}} секций",
       "selectAll": "Выбрать все",
@@ -3128,5 +3622,169 @@
       "invalidFile": "Файл не является цветовой схемой",
       "importFailed": "Не удалось импортировать схему"
     }
+  },
+  "transcription": {
+    "modelsDescription": "Скачайте модели для локальной транскрипции",
+    "downloaded": "Скачано",
+    "download": "Скачать",
+    "tip": "Совет",
+    "modelTip": "Для большинства задач модель 'base' обеспечивает хороший баланс между скоростью и качеством. Используйте 'large' модели для максимальной точности.",
+    "fileSelect": {
+      "error": "Ошибка выбора файла"
+    },
+    "error": "Ошибка",
+    "noFile": "Выберите файл",
+    "transcriptionResultsHeading": "Результаты транскрипции",
+    "save": {
+      "success": "Субтитры сохранены",
+      "error": "Ошибка сохранения",
+      "srt": "SRT"
+    },
+    "enhanced": {
+      "title": "AI Генерация субтитров",
+      "description": "Автоматическое создание субтитров с использованием AI",
+      "generate": "AI Генерация",
+      "quick": "Быстрая",
+      "confidence": "Уверенность",
+      "ocr": "OCR"
+    },
+    "mode": {
+      "basic": "Базовая",
+      "enhanced": "Расширенный ИИ"
+    },
+    "file": {
+      "title": "Выбор файла",
+      "select": "Выбрать файл"
+    },
+    "settings": {
+      "title": "Настройки",
+      "main": "Основные",
+      "ai": "AI функции",
+      "advanced": "Дополнительно"
+    },
+    "language": {
+      "label": "Язык"
+    },
+    "task": {
+      "label": "Задача",
+      "transcribe": "Транскрибировать",
+      "translate": "Переводить"
+    },
+    "ai": {
+      "sources": "Источники данных",
+      "speech": "Распознавание речи",
+      "ocr": "Текст на экране (OCR)",
+      "scenes": "Анализ сцен",
+      "speakers": "Идентификация говорящих",
+      "processing": "Обработка текста",
+      "grammar": "Исправление грамматики",
+      "capitalization": "Заглавные буквы",
+      "filler": "Убрать слова-паразиты",
+      "optimize": "Оптимизация для чтения",
+      "style": "Стиль субтитров",
+      "provider": "AI провайдер"
+    },
+    "style": {
+      "standard": "Стандартный",
+      "broadcast": "Телевизионный",
+      "social": "Соцсети",
+      "accessibility": "Доступность"
+    },
+    "basic": {
+      "start": "Транскрибировать"
+    },
+    "cancel": "Отменить",
+    "reset": "Сбросить",
+    "results": {
+      "title": "Результаты"
+    },
+    "addToTimeline": "Добавить в таймлайн",
+    "selectLanguage": "Выберите язык",
+    "wordTimings": "Временные метки слов",
+    "fullText": "Полный текст",
+    "title": "Транскрипция",
+    "description": "Автоматическое создание субтитров с помощью AI",
+    "selectFile": "Выберите медиафайл",
+    "chooseFile": "Выбрать файл",
+    "basicSettings": "Основные",
+    "advancedSettings": "Расширенные",
+    "models": "Модели",
+    "model": "Модель",
+    "transcribe": "Транскрипция",
+    "translate": "Перевод на английский",
+    "provider": {
+      "unified": "Единый ИИ",
+      "whisper": "Whisper",
+      "azure": "Azure",
+      "google": "Google"
+    },
+    "device": "Устройство",
+    "wordTimestamps": "Временные метки слов",
+    "vadFilter": "Фильтр активности голоса",
+    "processing": "Обработка...",
+    "start": "Начать транскрипцию"
+  },
+  "about": {
+    "version": "Версия",
+    "description": "Профессиональный видеоредактор для создания и монтажа видео",
+    "rights": "Все права защищены",
+    "builtWith": "Создано с использованием",
+    "documentation": "Документация",
+    "license": "Лицензия"
+  },
+  "modals": {
+    "about": {
+      "title": "О программе"
+    },
+    "subtitleEditor": {
+      "titleEdit": "Редактировать субтитр",
+      "titleAdd": "Добавить субтитр"
+    },
+    "personForm": {
+      "titleEdit": "Редактировать персону",
+      "titleAdd": "Создать персону"
+    },
+    "missingFiles": {
+      "title": "Отсутствующие медиафайлы"
+    },
+    "aiMarkerSettings": {
+      "title": "Настройки AI маркеров"
+    },
+    "subtitleAITools": {
+      "title": "Автоматическая транскрипция"
+    },
+    "audioEffects": {
+      "title": "Аудио эффекты"
+    },
+    "midiLearn": {
+      "title": "Обучение MIDI"
+    },
+    "midiMapping": {
+      "title": "Редактор MIDI маппинга"
+    },
+    "midiConfiguration": {
+      "title": "Настройки MIDI"
+    },
+    "effectDetail": {
+      "title": "Детали эффекта"
+    },
+    "colorGrading": {
+      "title": "Сохранить пресет цветокоррекции"
+    }
+  },
+  "cameraCapture": {
+    "saving": "Сохранение записи...",
+    "cameraMode": "Камера",
+    "screenMode": "Экран",
+    "screenSettings": "Настройки записи экрана",
+    "screenInfo": "Выберите окно, вкладку или весь экран для записи",
+    "microphone": "Микрофон",
+    "noAudio": "Без звука",
+    "countdown": "Обратный отсчёт",
+    "noCountdown": "Без отсчёта",
+    "seconds": "секунд"
+  },
+  "camera": {
+    "permissionError": "Не удалось получить доступ к камере и микрофону. Проверьте настройки."
   }
 }

--- a/src/test/providers/tauri-mock-provider.tsx
+++ b/src/test/providers/tauri-mock-provider.tsx
@@ -139,8 +139,22 @@ export function TauriMockProvider({ children }: { children: React.ReactNode }) {
 
           // Mock responses for common commands
           switch (cmd) {
-            case "get_app_language_tauri":
-              return { language: "ru", system_language: "ru" }
+            case "get_app_language_tauri": {
+              // Persist via localStorage so reloads + use-language fetch loop stay in sync.
+              // Falls back to "ru" on first run for parity with backend default.
+              const stored = (() => {
+                try { return window.localStorage.getItem("app-language") } catch { return null }
+              })()
+              const language = stored || "ru"
+              return { language, system_language: "ru" }
+            }
+            case "set_app_language_tauri": {
+              const lang = (args as any)?.lang
+              if (typeof lang === "string") {
+                try { window.localStorage.setItem("app-language", lang) } catch {}
+              }
+              return { language: lang, system_language: "ru" }
+            }
             case "get_media_files":
               return []
             case "file_exists":


### PR DESCRIPTION
## Summary

Found and fixed via an extended live browser-preview testing sweep of the Tauri app running in mock mode.

**Crashes / functional bugs:**
- `packages/core/montage-planner-registry.ts` — missing-binding proxy's `get` trap threw during introspection, crashing the entire app on dev-mode Fast Refresh (React reads `.prototype`/`.displayName` before bindings are registered). Now only throws on `apply`/`construct`.
- `packages/ui/resizable.tsx` — `react-resizable-panels` v4 interprets numeric `defaultSize`/`minSize`/`maxSize` as pixels (v2 treated them as percent), so all panels collapsed to their minimum and resize handles reported as inactive. Added an `asPercent()` helper so existing numeric callsites keep percent semantics.
- `use-ai-director-analysis-v2.ts` — a logger call sat in the hook body instead of inside `useEffect`, spamming logs on every render across 3 call sites.
- `tauri-mock-provider.tsx` — `get_app_language_tauri` always returned a fixed `ru` payload and `set_app_language_tauri` was unhandled, so switching language in User Settings silently reverted back to Russian.

**i18n — full-app audit (~1100+ keys backfilled):**
Wrote a static-analysis script that diffs every `t()` call site in `src` against `en.json`/`ru.json`, instead of relying on manually clicking through every UI state. Found and fixed four distinct classes of gap:
- Key present only in `en.json` (~300): normal EN-fallback shown when RU is active.
- Key present only in `ru.json` (~160): worse — with `fallbackLng: "en"` and no further fallback, English users saw the **raw dotted key string** literally (e.g. `dialogs.userSettings.foo`).
- Key missing from **both** files with a hardcoded `t(key, "default")` fallback in source (~410, mostly Russian defaults): the hardcoded text rendered in every language, including English. Spans keyboard-shortcuts presets (214 shortcut names across Filmora/Premiere/Timeline), transcription, subtitles, user-settings (AI services/performance/development/social-networks), ai-chat, effects, timeline clip panels, camera-capture, voice-recording, project-settings, fairlight-audio MIDI dialogs, templates customizer, and export.
- Literal Russian text passed directly as the i18next key itself (~27, in `recognition/components/yolo-*-overlay.tsx`) — renamed to proper `recognition.yolo.*` dotted keys.
- Plus a handful of flat-key-vs-nested-object collisions uncovered along the way (a JSON tree can't hold both a string at `foo.bar` and an object at `foo.bar.baz`), fixed by renaming the newer/narrower usage.
- Two more fully-hardcoded components found afterward: the curve-editor canvas overlay hint, and the entire Timeline Speed Ramping panel (no `useTranslation` import at all).
- **Bonus find:** `browser.tabs.subtitles` said **"Титры"** (Titles/Credits) instead of "Субтитры" (Subtitles) — the tab, content adapter, and routing were all correct; only the label was wrong, which made the Subtitles tab genuinely hard to find during testing.

Rescan after all fixes: 2 remaining "missing" keys, both inside commented-out dead code.

**Verified environment-limited (not app bugs, documented for future reference):**
- `KeyboardShortcutsModal` and the `style_templates` browser tab are both intentionally commented out by the original devs ("needs review" / "need completion") — left untouched.
- Media import (`process_media_files`/`get_media_files`) and project persistence (`get_project_state`) are structural no-ops in browser-mock mode — real-clip and save/load round-trip testing isn't meaningfully possible in this harness.

Also added `.claude/launch.json` so the `frontend` dev server (`npm run dev -- -p 3100`) can be started via the preview tooling used during this session.

## Test plan
- [x] `npm run check:type` — clean
- [x] `npm run lint` (biome) — clean
- [x] JSON validity checked for `en.json`/`ru.json` after every edit; static key-audit script rerun to confirm convergence
- [x] Verified live in browser preview: Export modal (all 4 tabs, RU), User Settings (all 6 tabs), Timeline workspace tabs, Audio Mixer faders, Color grading wheels + Curves/HSL/LUT/Scopes sections, Filters/Transitions/Titles/Multicam/Subtitles browser tabs, keyboard shortcut edge cases, drag-and-drop edge cases
- [x] Confirmed no console errors introduced
- [ ] `npm run test` not run in this session — recommend running before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)